### PR TITLE
add mqtt credentials

### DIFF
--- a/rethink/cloud/ha_connection.js
+++ b/rethink/cloud/ha_connection.js
@@ -32,7 +32,9 @@ class HA extends EventEmitter {
 			will: {
 				topic: config.rethink_prefix + '/availability',
 				payload: 'offline',
-			}
+			},
+			username: this.config.mqtt_user,
+			password: this.config.mqtt_pass
 		})
 		this.client.on('connect', this.connected.bind(this))
 		this.client.on('close', this.disconnected.bind(this))

--- a/rethink/config.json
+++ b/rethink/config.json
@@ -4,7 +4,9 @@
 	"homeassistant": {
 		"mqtt_url": "mqtt://localhost:1883",
 		"discovery_prefix": "homeassistant", 	"//": "corresponds to discovery_prefix in homeassistant config",
-		"rethink_prefix": "rethink",		"//": "rethink topics will be prefixed with this"
+		"rethink_prefix": "rethink",		"//": "rethink topics will be prefixed with this",
+		"mqtt_user": "",
+		"mqtt_pass": ""
 	},
 
 	"ca_key_file": "ca.key",    "//": "will be created on first run if necessary",


### PR DESCRIPTION
My MQTT broker requires credentials, so I've added them to the config. This hopefully does also works if no credentials are required, but I'm unable to test