### PR TITLE
Basic Dockerfile and Compose Setup as a Starting Point

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,22 @@
-# Use a small, recent Ubuntu LTS
-FROM ubuntu:24.04
+FROM node:trixie
 
-# Avoid interactive prompts during package installs
-ENV DEBIAN_FRONTEND=noninteractive
-ENV NODE_ENV=production
-
-# Install nodejs and npm via apt (silent)
-# Note: Ubuntu repo versions may be older; if you want newer Node, consider NodeSource or nvm.
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-      ca-certificates \
-      curl \
-      gnupg \
-      nodejs \
-      npm \
- && rm -rf /var/lib/apt/lists/*
-
-# Create app directory and set as working dir
+# Create app directory
 WORKDIR /rethink
 
-# Copy application files into the image
-# Make sure your build context contains the ./rethink folder
+# Copy project
 COPY ./rethink /rethink
 
-# Install dependencies at build time.
-# Prefer npm ci when package-lock.json is present for deterministic installs,
-# otherwise fall back to npm install.
-RUN if [ -f package-lock.json ]; then \
-      npm ci --only=production; \
-    else \
-      npm install --production; \
-    fi
+# Install dependencies
+RUN npm install
 
-# Expose port(s) if your app uses any (adjust as needed)
+# Copy entrypoint script
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Expose ports
+EXPOSE 443
 EXPOSE 4433
+EXPOSE 8884
+EXPOSE 1884
 
-# Entrypoint / command: run your app
-CMD ["node", "rethink-cloud.js"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,11 @@ COPY ./rethink /rethink
 RUN npm install
 RUN npm run build
 
-# Copy entrypoint script
+# Copy Bridge Service Script
+COPY start-bridge-services.sh /start-bridge-services.sh
+RUN chmod +x /start-bridge-services.sh
+
+# Copy Entrypoint Script
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# Use a small, recent Ubuntu LTS
+FROM ubuntu:24.04
+
+# Avoid interactive prompts during package installs
+ENV DEBIAN_FRONTEND=noninteractive
+ENV NODE_ENV=production
+
+# Install nodejs and npm via apt (silent)
+# Note: Ubuntu repo versions may be older; if you want newer Node, consider NodeSource or nvm.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      gnupg \
+      nodejs \
+      npm \
+ && rm -rf /var/lib/apt/lists/*
+
+# Create app directory and set as working dir
+WORKDIR /rethink
+
+# Copy application files into the image
+# Make sure your build context contains the ./rethink folder
+COPY ./rethink /rethink
+
+# Install dependencies at build time.
+# Prefer npm ci when package-lock.json is present for deterministic installs,
+# otherwise fall back to npm install.
+RUN if [ -f package-lock.json ]; then \
+      npm ci --only=production; \
+    else \
+      npm install --production; \
+    fi
+
+# Expose port(s) if your app uses any (adjust as needed)
+EXPOSE 4433
+
+# Entrypoint / command: run your app
+CMD ["node", "rethink-cloud.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY ./rethink /rethink
 
 # Install dependencies
 RUN npm install
+RUN npm run build
 
 # Copy entrypoint script
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY ./rethink /rethink
 # Install dependencies
 RUN npm install
 RUN npm run build
-
+# perhaps removing all unneeded files after building to clean up?
 # Copy Bridge Service Script
 COPY start-bridge-services.sh /start-bridge-services.sh
 RUN chmod +x /start-bridge-services.sh

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     container_name: rethink
     restart: unless-stopped
     ports:
-      - "4433:4433"
+      - "443:443"
       - "8884:8884"
       - "1884:1884"
     environment:
@@ -23,16 +23,17 @@ services:
       RETHINK_MQTT_PASS: "pass"
 
       # Certificate files
-      RETHINK_CA_KEY_FILE: "/cert/ca.key"
-      RETHINK_CA_CERT_FILE: "/cert/ca.cert"
+      RETHINK_CA_KEY_FILE: "ca.key" # Mounting key and cert files to another folder (for example /cert/ca.key) caused connectivity issues 
+      RETHINK_CA_CERT_FILE: "ca.cert"
 
       # Ports inside container
-      RETHINK_HTTPS_PORT: "4433"
+      RETHINK_HTTPS_PORT: "443"
       RETHINK_MQTTS_PORT: "8884"
       RETHINK_MQTT_PORT: "1884"
 
     volumes:
-      - ./cert:/cert
+      - ./ca.key:/rethink/ca.key:ro
+      - ./ca.cert:/rethink/ca.cert:ro
 
     healthcheck:
       test: ps aux | grep "node /rethink/rethink-cloud.js" | grep -v grep >/dev/null || exit 1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,3 +33,10 @@ services:
 
     volumes:
       - ./cert:/cert
+
+    healthcheck:
+      test: ps aux | grep "node /rethink/rethink-cloud.js" | grep -v grep >/dev/null || exit 1
+      interval: 900s
+      timeout: 30s
+      retries: 3
+      start_period: 60s

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       # Hostname (cannot be an IP)
       RETHINK_HOSTNAME: "common.lgthinq.com" # Create a DNS record to redirect this domain to your Rethink server's IP
 
-      # MQTT settings
+      # Local MQTT server settings
       RETHINK_MQTT_URL: "mqtt://mqtt5:1883"
       RETHINK_DISCOVERY_PREFIX: "homeassistant"
       RETHINK_PREFIX: "rethink"
@@ -26,16 +26,20 @@ services:
       RETHINK_CA_KEY_FILE: "ca.key" # Mounting key and cert files to another folder (for example /cert/ca.key) caused connectivity issues 
       RETHINK_CA_CERT_FILE: "ca.cert"
 
-      # Ports inside container
+      # Internal Server Ports
       RETHINK_HTTPS_PORT: "443"
       RETHINK_MQTTS_PORT: "8884"
       RETHINK_MQTT_PORT: "1884"
+      
       # Server Mode
-      RETHINK_SERVER_MODE: both # Accepted values: "bridge", "cloud", "both"
+      RETHINK_SERVER_MODE: "both" # Accepted values: "cloud" or "both". running "bridge" Service only is not implimented
     volumes:
       - ./config:/config
+    # Keep logs in RAM to avoid disk writes 
     tmpfs:
       - /var/log/rethink:rw,mode=1777
+    # Healthcheck is not yet implimented. at the moment it simply checks if CLOUD Service is running
+    # mayby looking for errors in LOGS for Container Health? 
     healthcheck:
       test: ps aux | grep "dist/rethink-cloud.js" | grep -v grep >/dev/null || exit 1
       interval: 900s

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,14 +1,32 @@
+
 services:
   rethink:
     build:
       context: .
       dockerfile: Dockerfile
-    image: rethink:latest
+    image: rethink:local
     container_name: rethink
     restart: unless-stopped
-    environment:
-      NODE_ENV: production
     ports:
       - "4433:4433"
-    volumes:
-      - ./rethink/config.json:/rethink/config.json
+      - "8884:8884"
+      - "1884:1884"
+    environment:
+      # Hostname (cannot be an IP)
+      RETHINK_HOSTNAME: "common.lgthinq.com" # Create a DNS record to redirect this domain to your Rethink server's IP
+
+      # MQTT settings
+      RETHINK_MQTT_URL: "mqtt://mqtt5:1883"
+      RETHINK_DISCOVERY_PREFIX: "homeassistant"
+      RETHINK_PREFIX: "rethink"
+      RETHINK_MQTT_USER: "user"
+      RETHINK_MQTT_PASS: "pass"
+
+      # Certificate files
+      RETHINK_CA_KEY_FILE: "ca.key"
+      RETHINK_CA_CERT_FILE: "ca.cert"
+
+      # Ports inside container
+      RETHINK_HTTPS_PORT: "4433"
+      RETHINK_MQTTS_PORT: "8884"
+      RETHINK_MQTT_PORT: "1884"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,13 +30,21 @@ services:
       RETHINK_HTTPS_PORT: "443"
       RETHINK_MQTTS_PORT: "8884"
       RETHINK_MQTT_PORT: "1884"
-
+      # Server Mode
+      RETHINK_SERVER_MODE: both # Accepted values: "bridge", "cloud", "both"
+      # Bridge values: only required if RETHINK_SERVER_MODE is "bridge" or "both"
+      # These values are the fallback values. Values will be overridden by values captured from CLOUD.JS server.
+      RETHINK_COUNTRY_CODE: PL
+      RETHINK_DEVICE_TYPE: 401
+      RETHINK_MODEL_NAME: RAC_056905_WW
+      RETHINK_DEVICE_ID: 68b5784e-3ae6-40ce-86d6-111fec8838e8
     volumes:
-      - ./ca.key:/rethink/ca.key:ro
-      - ./ca.cert:/rethink/ca.cert:ro
-
+      - ./ca.key:/rethink/ca.key
+      - ./ca.cert:/rethink/ca.cert
+      # Bridge configuration file - only usable if RETHINK_SERVER_MODE is "bridge" or "both"
+      - ./bridge.json:/rethink/.bridge_68b5784e-3ae6-40ce-86d6-111fec8838e8.json
     healthcheck:
-      test: ps aux | grep "node /rethink/rethink-cloud.js" | grep -v grep >/dev/null || exit 1
+      test: ps aux | grep "dist/rethink-cloud.js" | grep -v grep >/dev/null || exit 1
       interval: 900s
       timeout: 30s
       retries: 3

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,10 +23,13 @@ services:
       RETHINK_MQTT_PASS: "pass"
 
       # Certificate files
-      RETHINK_CA_KEY_FILE: "ca.key"
-      RETHINK_CA_CERT_FILE: "ca.cert"
+      RETHINK_CA_KEY_FILE: "/cert/ca.key"
+      RETHINK_CA_CERT_FILE: "/cert/ca.cert"
 
       # Ports inside container
       RETHINK_HTTPS_PORT: "4433"
       RETHINK_MQTTS_PORT: "8884"
       RETHINK_MQTT_PORT: "1884"
+
+    volumes:
+      - ./cert:/cert

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,14 @@
+services:
+  rethink:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: rethink:latest
+    container_name: rethink
+    restart: unless-stopped
+    environment:
+      NODE_ENV: production
+    ports:
+      - "4433:4433"
+    volumes:
+      - ./rethink/config.json:/rethink/config.json

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,17 +32,10 @@ services:
       RETHINK_MQTT_PORT: "1884"
       # Server Mode
       RETHINK_SERVER_MODE: both # Accepted values: "bridge", "cloud", "both"
-      # Bridge values: only required if RETHINK_SERVER_MODE is "bridge" or "both"
-      # These values are the fallback values. Values will be overridden by values captured from CLOUD.JS server.
-      RETHINK_COUNTRY_CODE: PL
-      RETHINK_DEVICE_TYPE: 401
-      RETHINK_MODEL_NAME: RAC_056905_WW
-      RETHINK_DEVICE_ID: 68b5784e-3ae6-40ce-86d6-111fec8838e8
     volumes:
-      - ./ca.key:/rethink/ca.key
-      - ./ca.cert:/rethink/ca.cert
-      # Bridge configuration file - only usable if RETHINK_SERVER_MODE is "bridge" or "both"
-      - ./bridge.json:/rethink/.bridge_68b5784e-3ae6-40ce-86d6-111fec8838e8.json
+      - ./config:/config
+    tmpfs:
+      - /var/log/rethink:rw,mode=1777
     healthcheck:
       test: ps aux | grep "dist/rethink-cloud.js" | grep -v grep >/dev/null || exit 1
       interval: 900s

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,12 +32,22 @@ services:
       RETHINK_MQTT_PORT: "1884"
       
       # Server Mode
-      RETHINK_SERVER_MODE: "both" # Accepted values: "cloud" or "both". running "bridge" Service only is not implimented
+      RETHINK_SERVER_MODE: "both" # Accepted values: "cloud", "bridge" or "both".
+
+      # Use if you are running CLOUD Service in a diffrent container and you want to spin up a Bridge for one Device only
+      RETHINK_COUNTRY_CODE: "PL"
+      RETHINK_DEVICE_TYPE: "401"
+      RETHINK_MODEL_NAME: "RAC_056905_WW"
+      RETHINK_DEVICE_ID: "68b5784e-3ae6-40ce-86d6-111fec8838e8"
+
+    # Persist of certificates and BRIDGE configuration for devices
     volumes:
       - ./config:/config
-    # Keep logs in RAM to avoid disk writes 
+
+    # Keep logs in RAM to avoid disk writes
     tmpfs:
       - /var/log/rethink:rw,mode=1777
+
     # Healthcheck is not yet implimented. at the moment it simply checks if CLOUD Service is running
     # mayby looking for errors in LOGS for Container Health? 
     healthcheck:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,11 @@ RETHINK_CA_CERT_FILE="${RETHINK_CA_CERT_FILE:-ca.cert}"
 RETHINK_HTTPS_PORT="${RETHINK_HTTPS_PORT:-4433}"
 RETHINK_MQTTS_PORT="${RETHINK_MQTTS_PORT:-8884}"
 RETHINK_MQTT_PORT="${RETHINK_MQTT_PORT:-1884}"
-RETHINK_SERVER_MODE="${RETHINK_SERVER_MODE:-cloud}"
+RETHINK_SERVER_MODE="${RETHINK_SERVER_MODE:-both}"
+RETHINK_DEVICE_ID="${RETHINK_DEVICE_ID:-68b5784e-3ae6-40ce-86d6-111fec8838e8}"
+RETHINK_COUNTRY_CODE="${RETHINK_COUNTRY_CODE:-PL}"
+RETHINK_MODEL_NAME="${RETHINK_MODEL_NAME:-RAC_056905_WW}"
+RETHINK_DEVICE_TYPE="${RETHINK_DEVICE_TYPE:-401}"
 
 # Rewrite config.json
 cat <<EOF >/rethink/config.json
@@ -112,9 +116,20 @@ done
 
 # Start BRIDGE mode
 
-if [ "$RETHINK_SERVER_MODE" = "bridge" ] || [ "$RETHINK_SERVER_MODE" = "both" ]; then
-  echo "[INFO] Starting BRIDGE service..."
+if [ "$RETHINK_SERVER_MODE" = "both" ]; then
+  echo "[INFO] Starting BRIDGE services..."
   /start-bridge-services.sh > /var/log/rethink/bridge.log 2>&1 &
+fi
+
+if [ "$RETHINK_SERVER_MODE" = "bridge" ]; then
+  echo "[INFO] Starting BRIDGE service for Device ID ${RETHINK_DEVICE_ID}..."
+  node dist/experimental/bridge/bridge.js \
+    mqtt://${RETHINK_HOSTNAME}:${RETHINK_MQTT_PORT}/ \
+    "$RETHINK_COUNTRY_CODE" \
+    "$RETHINK_DEVICE_TYPE" \
+    "$RETHINK_MODEL_NAME" \
+    "$RETHINK_DEVICE_ID" \
+    > /var/log/rethink/bridge.${RETHINK_DEVICE_ID}.log 2>&1 &
 fi
 
 # -------------------------

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,7 @@ cat <<EOF >/rethink/config.json
 EOF
 
 echo "Generated /rethink/config.json:"
-cat /rethink/config.json
+#cat /rethink/config.json
 
 # Start service
 exec node /rethink/rethink-cloud.js

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,7 +42,7 @@ echo "Generated /rethink/config.json:"
 #cat /rethink/config.json
 
 echo "[INFO] Syncing /config into /rethink as symbolic links..."
-
+mkdir -p /config
 # Iterate over all items including hidden files (but excluding . and ..)
 shopt -s dotglob
 
@@ -87,7 +87,6 @@ if [ "$RETHINK_SERVER_MODE" = "cloud" ] || [ "$RETHINK_SERVER_MODE" = "both" ]; 
 fi
 sleep 5
 echo "[INFO] Ensuring /config contains CA certificate and key"
-mkdir -p /config
 
 for f in ca.cert ca.key; do
     src="/rethink/$f"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,6 +20,7 @@ RETHINK_DEVICE_ID="${RETHINK_DEVICE_ID:-68b5784e-3ae6-40ce-86d6-111fec8838e8}"
 RETHINK_COUNTRY_CODE="${RETHINK_COUNTRY_CODE:-PL}"
 RETHINK_MODEL_NAME="${RETHINK_MODEL_NAME:-RAC_056905_WW}"
 RETHINK_DEVICE_TYPE="${RETHINK_DEVICE_TYPE:-401}"
+RETHINK_LOG="${RETHINK_LOG:-[\"status\",\"incoming\"]}"
 
 # Rewrite config.json
 cat <<EOF >/rethink/config.json
@@ -38,7 +39,9 @@ cat <<EOF >/rethink/config.json
     "ca_cert_file": "$RETHINK_CA_CERT_FILE",
     "https_port": $RETHINK_HTTPS_PORT,
     "mqtts_port": $RETHINK_MQTTS_PORT,
-    "mqtt_port": $RETHINK_MQTT_PORT
+    "mqtt_port": $RETHINK_MQTT_PORT,
+
+	"log": $RETHINK_LOG
 }
 EOF
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,21 @@
 #!/bin/bash
 set -e
 
-# Environment variables with defaults
+# -------------------------
+# Configurable parameters
+# -------------------------
+MAX_RETRIES=60
+SLEEP_SECONDS=5  # seconds between log checks
+
+# Default fallback values
+DEFAULT_DEVICE_ID="${RETHINK_DEVICE_ID:-68b5784e-3ae6-40ce-86d6-111fec8838e8}"
+DEFAULT_COUNTRY_CODE="${RETHINK_COUNTRY_CODE:-PL}"
+DEFAULT_MODEL_NAME="${RETHINK_MODEL_NAME:-RAC_056905_WW}"
+DEFAULT_DEVICE_TYPE="${RETHINK_DEVICE_TYPE:-401}"
+
+# -------------------------
+# Load environment variables
+# -------------------------
 RETHINK_HOSTNAME="${RETHINK_HOSTNAME:-rethink.lan}"
 RETHINK_MQTT_URL="${RETHINK_MQTT_URL:-mqtt://localhost:1883}"
 RETHINK_DISCOVERY_PREFIX="${RETHINK_DISCOVERY_PREFIX:-homeassistant}"
@@ -13,6 +27,13 @@ RETHINK_CA_CERT_FILE="${RETHINK_CA_CERT_FILE:-ca.cert}"
 RETHINK_HTTPS_PORT="${RETHINK_HTTPS_PORT:-4433}"
 RETHINK_MQTTS_PORT="${RETHINK_MQTTS_PORT:-8884}"
 RETHINK_MQTT_PORT="${RETHINK_MQTT_PORT:-1884}"
+RETHINK_SERVER_MODE="${RETHINK_SERVER_MODE:-cloud}"
+
+# Function to extract a value from log for a given key
+extract_value() {
+  local key="$1"
+  grep -a -m1 "\"$key\":" "/var/log/rethink/cloud.log" | sed -n "s/.*\"$key\":\"\([^\"]*\)\".*/\1/p"
+}
 
 # Rewrite config.json
 cat <<EOF >/rethink/config.json
@@ -38,5 +59,72 @@ EOF
 echo "Generated /rethink/config.json:"
 #cat /rethink/config.json
 
-# Start service
-exec node /rethink/rethink-cloud.js
+# -------------------------
+# Start services depending on mode
+# -------------------------
+
+echo "Running in mode: $RETHINK_SERVER_MODE"
+
+mkdir -p /var/log/rethink
+
+
+# Start CLOUD mode
+
+if [ "$RETHINK_SERVER_MODE" = "cloud" ] || [ "$RETHINK_SERVER_MODE" = "both" ]; then
+  echo "Starting CLOUD service..."
+  npm run start > /var/log/rethink/cloud.log 2>&1 &
+fi
+
+
+# Retry to extract values from cloud log
+
+if [ "$RETHINK_SERVER_MODE" = "bridge" ] || [ "$RETHINK_SERVER_MODE" = "both" ]; then
+  RETRY_COUNT=0
+  while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+    DEVICE_ID=$(extract_value "did")
+    COUNTRY_CODE=$(extract_value "subCountryCode")
+    MODEL_NAME=$(extract_value "modelName")
+    DEVICE_TYPE=$(extract_value "DeviceType")
+
+    if [ -n "$DEVICE_ID" ] && [ -n "$COUNTRY_CODE" ] && \
+       [ -n "$MODEL_NAME" ] && [ -n "$DEVICE_TYPE" ]; then
+      echo "Successfully captured values on attempt $((RETRY_COUNT+1))"
+      break
+    fi
+
+    RETRY_COUNT=$((RETRY_COUNT+1))
+    sleep $SLEEP_SECONDS
+  done
+
+  # Fallback to defaults if extraction failed
+  : "${DEVICE_ID:=$DEFAULT_DEVICE_ID}"
+  : "${COUNTRY_CODE:=$DEFAULT_COUNTRY_CODE}"
+  : "${MODEL_NAME:=$DEFAULT_MODEL_NAME}"
+  : "${DEVICE_TYPE:=$DEFAULT_DEVICE_TYPE}"
+
+  # Log the final values
+  echo "Final values for BRIDGE service:"
+  echo "DEVICE_ID=$DEVICE_ID"
+  echo "COUNTRY_CODE=$COUNTRY_CODE"
+  echo "MODEL_NAME=$MODEL_NAME"
+  echo "DEVICE_TYPE=$DEVICE_TYPE"
+
+fi
+
+# Start BRIDGE mode
+
+if [ "$RETHINK_SERVER_MODE" = "bridge" ] || [ "$RETHINK_SERVER_MODE" = "both" ]; then
+  echo "Starting BRIDGE service..."
+  node dist/experimental/bridge/bridge.js \
+    mqtt://${RETHINK_HOSTNAME}:${RETHINK_MQTT_PORT}/ \
+    "$COUNTRY_CODE" \
+    "$DEVICE_TYPE" \
+    "$MODEL_NAME" \
+    "$DEVICE_ID" \
+    > /var/log/rethink/bridge.log 2>&1 &
+fi
+
+# -------------------------
+# Keep container alive
+# -------------------------
+exec tail -F /var/log/rethink/*.log

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+
+# Environment variables with defaults
+RETHINK_HOSTNAME="${RETHINK_HOSTNAME:-rethink.lan}"
+RETHINK_MQTT_URL="${RETHINK_MQTT_URL:-mqtt://localhost:1883}"
+RETHINK_DISCOVERY_PREFIX="${RETHINK_DISCOVERY_PREFIX:-homeassistant}"
+RETHINK_PREFIX="${RETHINK_PREFIX:-rethink}"
+RETHINK_MQTT_USER="${RETHINK_MQTT_USER:-user}"
+RETHINK_MQTT_PASS="${RETHINK_MQTT_PASS:-pass}"
+RETHINK_CA_KEY_FILE="${RETHINK_CA_KEY_FILE:-ca.key}"
+RETHINK_CA_CERT_FILE="${RETHINK_CA_CERT_FILE:-ca.cert}"
+RETHINK_HTTPS_PORT="${RETHINK_HTTPS_PORT:-4433}"
+RETHINK_MQTTS_PORT="${RETHINK_MQTTS_PORT:-8884}"
+RETHINK_MQTT_PORT="${RETHINK_MQTT_PORT:-1884}"
+
+# Rewrite config.json
+cat <<EOF >/rethink/config.json
+{
+    "hostname": "$RETHINK_HOSTNAME",
+
+    "homeassistant": {
+        "mqtt_url": "$RETHINK_MQTT_URL",
+        "discovery_prefix": "$RETHINK_DISCOVERY_PREFIX",
+        "rethink_prefix": "$RETHINK_PREFIX",
+        "mqtt_user": "$RETHINK_MQTT_USER",
+        "mqtt_pass": "$RETHINK_MQTT_PASS"
+    },
+
+    "ca_key_file": "$RETHINK_CA_KEY_FILE",
+    "ca_cert_file": "$RETHINK_CA_CERT_FILE",
+    "https_port": $RETHINK_HTTPS_PORT,
+    "mqtts_port": $RETHINK_MQTTS_PORT,
+    "mqtt_port": $RETHINK_MQTT_PORT
+}
+EOF
+
+echo "Generated /rethink/config.json:"
+cat /rethink/config.json
+
+# Start service
+exec node /rethink/rethink-cloud.js

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,7 +38,7 @@ cat <<EOF >/rethink/config.json
 }
 EOF
 
-echo "Generated /rethink/config.json:"
+echo "[INFO] Generated /rethink/config.json:"
 #cat /rethink/config.json
 
 echo "[INFO] Syncing /config into /rethink as symbolic links..."
@@ -76,13 +76,13 @@ echo "[INFO] Finished syncing /config → /rethink"
 # Start services depending on mode
 # -------------------------
 
-echo "Running in mode: $RETHINK_SERVER_MODE"
+echo "[INFO] Running in mode: $RETHINK_SERVER_MODE"
 mkdir -p /var/log/rethink
 
 # Start CLOUD mode
 
 if [ "$RETHINK_SERVER_MODE" = "cloud" ] || [ "$RETHINK_SERVER_MODE" = "both" ]; then
-  echo "Starting CLOUD service..."
+  echo "[INFO] Starting CLOUD service..."
   npm run start > /var/log/rethink/cloud.log 2>&1 &
 fi
 sleep 5
@@ -113,7 +113,7 @@ done
 # Start BRIDGE mode
 
 if [ "$RETHINK_SERVER_MODE" = "bridge" ] || [ "$RETHINK_SERVER_MODE" = "both" ]; then
-  echo "Starting BRIDGE service..."
+  echo "[INFO] Starting BRIDGE service..."
   /start-bridge-services.sh > /var/log/rethink/bridge.log 2>&1 &
 fi
 

--- a/start-bridge-services.sh
+++ b/start-bridge-services.sh
@@ -8,7 +8,6 @@ echo "[INFO] Monitoring: $CLOUD_LOG"
 # Ensure log file exists before tailing
 if [ ! -f "$CLOUD_LOG" ]; then
     echo "[WARN] Cloud log does not exist yet. Waiting..."
-    echo "[INFO] BRIDGE Service cannot yet run without CLOUD Service"
     touch "$CLOUD_LOG"
 fi
 

--- a/start-bridge-services.sh
+++ b/start-bridge-services.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+CLOUD_LOG="/var/log/rethink/cloud.log"
+
+echo "[INFO] Bridge watcher started"
+echo "[INFO] Monitoring: $CLOUD_LOG"
+
+# Ensure log file exists before tailing
+if [ ! -f "$CLOUD_LOG" ]; then
+    echo "[WARN] Cloud log does not exist yet. Waiting..."
+    touch "$CLOUD_LOG"
+fi
+
+# Tail the log and process each line once
+tail -Fn0 "$CLOUD_LOG" | while read -r line; do
+    # Skip empty or invalid lines
+    if [ -z "$line" ]; then
+        continue
+    fi
+
+    echo "[INFO] Processing line: $line"
+
+    # Only process lines containing `"type":0`
+    if ! echo "$line" | grep -q "\"type\":0"; then
+        echo "[DEBUG] Line does not contain type 0. Skipping."
+        continue
+    fi
+
+    echo "[INFO] Found type 0 message."
+
+    # ------------------------------
+    # Extract values using sed
+    # ------------------------------
+
+    did=$(echo "$line" | sed -n 's/.*"did":"\([^"]*\)".*/\1/p')
+    country=$(echo "$line" | sed -n 's/.*"subCountryCode":"\([^"]*\)".*/\1/p')
+    model=$(echo "$line" | sed -n 's/.*"modelName":"\([^"]*\)".*/\1/p')
+    dtype=$(echo "$line" | sed -n 's/.*"DeviceType":"\([^"]*\)".*/\1/p')
+
+    # Check if values extracted
+    if [ -z "$did" ] || [ -z "$country" ] || [ -z "$model" ] || [ -z "$dtype" ]; then
+        echo "[ERROR] Failed to extract one or more required fields: did=$did country=$country model=$model dtype=$dtype"
+        continue
+    fi
+
+    echo "[INFO] Extracted DID: $did"
+    echo "[INFO] Extracted Country: $country"
+    echo "[INFO] Extracted Model: $model"
+    echo "[INFO] Extracted DeviceType: $dtype"
+
+    # ------------------------------
+    # Check if this bridge is already running
+    # ------------------------------
+
+    if ps aux | grep -v grep | grep -q "$did"; then
+        echo "[INFO] Bridge for DID $did already running. Skipping."
+        continue
+    fi
+
+    echo "[INFO] No running process for DID $did. Starting new bridge instance..."
+
+    # ------------------------------
+    # Start the bridge service
+    # ------------------------------
+
+    LOGFILE="/var/log/rethink/bridge.${did}.log"
+    echo "[INFO] Starting bridge → logging to: $LOGFILE"
+
+    (
+        echo "[INFO] Bridge process started for DID $did"
+        node dist/experimental/bridge/bridge.js \
+            "mqtt://${RETHINK_HOSTNAME}:${RETHINK_MQTT_PORT}/" \
+            "$country" \
+            "$dtype" \
+            "$model" \
+            "$did"
+        echo "[ERROR] Bridge process for DID $did exited unexpectedly!"
+    ) >"$LOGFILE" 2>&1 &
+
+    echo "[INFO] Bridge instance for DID $did started successfully."
+done


### PR DESCRIPTION
After some experimentation, I finally managed to build an image that stays running instead of crashing on startup. I used `ubuntu:24.04` as the base image — definitely heavier than ideal, but it worked reliably — and set `rethink-cloud.js` as the image entry point. I'm still not entirely sure which files need to persist, but for now I’ve mounted only the configuration file `/rethink/config.json` into the container. With that in place, the output behaves exactly as described in the [wiki](https://github.com/anszom/rethink/wiki/Installing-rethink%E2%80%90cloud#step-4-start-the-server):

> root@homeserver:/services/rethink# docker compose logs -f rethink rethink  | Rethink cloud ready
> rethink  | During setup, please ensure that connections to common.lgthinq.com:443 are redirected to lgthinq.mydomain.tld:443
> rethink  | HA mqtt connection established

In my case i created a DNS Record for both `common.lgthinq.com` and `lgthinq.mydomain.tld` pointing to my server with NginX. There I redirected one domain to the other. Is it posible in this case to simply use port 443 and let NginX handle the certificates ?

I have not yet tried it with my ThinQ machine because I do not have a wifi enabled device where i can run `rethink-setup.js` So the image is not yet tested.
This byfar not a production ready solution but it is just a start to get things working