### PR TITLE
Add Washer&Dryer (CV74J7S2QA) support

### DIFF
--- a/rethink/cloud/devices/F_VB_F___W.B_2QEUK.ts
+++ b/rethink/cloud/devices/F_VB_F___W.B_2QEUK.ts
@@ -1,0 +1,284 @@
+import HADevice from './base'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import AABBDevice from './aabb_device'
+import { ERRORS, STATES, COURSES, TEMPERATURES, SPINS, DRYING_MODES, DOSES } from './washer_common'
+
+export default class Device extends AABBDevice {
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: 'LG Washer' }),
+                components: {
+                    power: {
+                        platform: 'switch',
+                        unique_id: '$deviceid-power',
+                        state_topic: '$this/power',
+                        command_topic: '$this/power/set',
+                        name: '',
+                        icon: 'mdi:washing-machine',
+                    },
+                    start: {
+                        platform: 'button',
+                        unique_id: '$deviceid-start',
+                        command_topic: '$this/start/set',
+                        payload_press: '',
+                        name: 'Start',
+                        icon: 'mdi:play-circle-outline',
+                    },
+                    pause: {
+                        platform: 'button',
+                        unique_id: '$deviceid-pause',
+                        command_topic: '$this/pause/set',
+                        payload_press: '',
+                        name: 'Pause',
+                        icon: 'mdi:pause-circle-outline',
+                    },
+                    status: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-status',
+                        state_topic: '$this/status',
+                        name: 'Status',
+                        icon: 'mdi:state-machine',
+                        device_class: 'enum',
+                        options: STATES.filter((a) => a !== undefined),
+                    },
+                    error: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-error',
+                        state_topic: '$this/error',
+                        name: 'Error',
+                        icon: 'mdi:check-circle',
+                        device_class: 'problem',
+                        entity_category: 'diagnostic',
+                    },
+                    error_message: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-error-message',
+                        state_topic: '$this/error_message',
+                        name: 'Error message',
+                        icon: 'mdi:alert-circle-outline',
+                        device_class: 'enum',
+                        entity_category: 'diagnostic',
+                        options: ERRORS.filter((a) => a !== undefined),
+                    },
+                    course: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-course',
+                        state_topic: '$this/course',
+                        name: 'Course',
+                        icon: 'mdi:pin-outline',
+                    },
+                    temp: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-temp',
+                        state_topic: '$this/temp',
+                        name: 'Temperature',
+                        device_class: 'temperature',
+                        unit_of_measurement: '°C',
+                        suggested_display_precision: 0,
+                        value_template: "{{ value if value | is_number else 'None' }}",
+                    },
+                    spin: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-spin',
+                        state_topic: '$this/spin',
+                        name: 'Spin',
+                        icon: 'mdi:autorenew',
+                        unit_of_measurement: 'RPM',
+                        value_template: "{{ value if value | is_number else 'None' }}",
+                    },
+                    drying_mode: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-drying-mode',
+                        state_topic: '$this/drying_mode',
+                        name: 'Drying mode',
+                        icon: 'mdi:tumble-dryer',
+                    },
+                    cycles: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-cycles',
+                        state_topic: '$this/cycles',
+                        name: 'Cycle count',
+                        icon: 'mdi:counter',
+                    },
+                    remote_start: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-remote_start',
+                        state_topic: '$this/remote_start',
+                        name: 'Remote start',
+                        icon: 'mdi:play-circle-outline',
+                    },
+                    door_lock: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-door_lock',
+                        state_topic: '$this/door_lock',
+                        name: 'Door lock',
+                        device_class: 'lock',
+                    },
+                    child_lock: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-child_lock',
+                        state_topic: '$this/child_lock',
+                        name: 'Child lock',
+                        device_class: 'lock',
+                    },
+                    energy: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-energy',
+                        state_topic: '$this/energy',
+                        name: 'Energy',
+                        icon: 'mdi:lightning-bolt',
+                        device_class: 'energy',
+                        state_class: 'total_increasing',
+                        unit_of_measurement: 'Wh',
+                    },
+                    initial_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-initial_time',
+                        state_topic: '$this/initial_time',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        name: 'Initial time',
+                    },
+                    remaining_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-remaining_time',
+                        state_topic: '$this/remaining_time',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        name: 'Remaining time',
+                    },
+                    delay_end: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-delay_end',
+                        state_topic: '$this/delay_end',
+                        name: 'Delay end',
+                        icon: 'mdi:timer-sand',
+                        device_class: 'duration',
+                        unit_of_measurement: 'h',
+                        suggested_display_precision: 0,
+                    },
+                    detergent: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-detergent',
+                        state_topic: '$this/detergent',
+                        name: 'Detergent dose',
+                        icon: 'mdi:cup',
+                        device_class: 'enum',
+                        options: DOSES,
+                    },
+                    softener: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-softener',
+                        state_topic: '$this/softener',
+                        name: 'Softener dose',
+                        icon: 'mdi:cup-outline',
+                        device_class: 'enum',
+                        options: DOSES,
+                    },
+                    extra_rinse: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-extra_rinse',
+                        state_topic: '$this/extra_rinse',
+                        name: 'Extra rinse',
+                        icon: 'mdi:water-plus',
+                    },
+                    turbowash: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-turbowash',
+                        state_topic: '$this/turbowash',
+                        name: 'TurboWash',
+                        icon: 'mdi:rocket-launch',
+                    },
+                    eco_hybrid: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-eco_hybrid',
+                        state_topic: '$this/eco_hybrid',
+                        name: 'EcoHybrid',
+                        icon: 'mdi:leaf',
+                    },
+                    prewash: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-prewash',
+                        state_topic: '$this/prewash',
+                        name: 'Pre-wash',
+                        icon: 'mdi:water-sync',
+                    },
+                    steam: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-steam',
+                        state_topic: '$this/steam',
+                        name: 'Steam',
+                        icon: 'mdi:kettle-steam',
+                    },
+                },
+            }),
+        )
+    }
+
+    start() {
+        this.send(Buffer.from('F0ED1121010000001800', 'hex'))
+    }
+
+    processAABB(buf: Buffer) {
+        if (buf.length === 80 && buf[0] == 0x20) {
+            const status = buf[43]
+            const time_remain = buf[44] * 60 + buf[45]
+            const time_initial = buf[46] * 60 + buf[47]
+            const course = buf[48]
+            const error = buf[49]
+            const spin = buf[51]
+            const temp = buf[52]
+            const extra_rinse = buf[53]
+            const drying_mode = buf[54]
+            const delay_end = buf[55]
+            const options = buf[57]
+            const lock_status = buf[58]
+            const cycles = buf[64]
+            const energy = buf[71] * 256 + buf[72]
+            const detergent = buf[73]
+            const softener = buf[74]
+
+            this.publishProperty('power', status > 0 ? 'ON' : 'OFF')
+            this.publishProperty('error_message', ERRORS[error] ?? 'unknown') // publish message before set error state
+            this.publishProperty('error', error ? 'ON' : 'OFF')
+            this.publishProperty('status', STATES[status] ?? 'unknown')
+            this.publishProperty('course', COURSES[course] ?? 'unknown')
+            this.publishProperty('spin', SPINS[spin] ?? 'unknown')
+            this.publishProperty('temp', TEMPERATURES[temp] ?? 'unknown')
+            this.publishProperty('drying_mode', DRYING_MODES[drying_mode] ?? 'unknown')
+            this.publishProperty('cycles', cycles)
+            this.publishProperty('remote_start', lock_status & 2 ? 'ON' : 'OFF')
+            this.publishProperty('door_lock', !(lock_status & 0x40) ? 'ON' : 'OFF') // inverted logic, off=locked
+            this.publishProperty('child_lock', lock_status & 0x80 ? 'ON' : 'OFF')
+            this.publishProperty('initial_time', time_initial)
+            this.publishProperty('remaining_time', time_remain)
+            this.publishProperty('energy', energy)
+            this.publishProperty('delay_end', delay_end)
+            this.publishProperty('detergent', DOSES[detergent] ?? 'unknown')
+            this.publishProperty('softener', DOSES[softener] ?? 'unknown')
+            this.publishProperty('extra_rinse', extra_rinse >= 2 ? 'ON' : 'OFF') // 0/1=off, 2+=one or more extra rinses
+            this.publishProperty('turbowash', options & 0x01 ? 'ON' : 'OFF')
+            this.publishProperty('eco_hybrid', options & 0x08 ? 'ON' : 'OFF')
+            this.publishProperty('prewash', options & 0x40 ? 'ON' : 'OFF')
+            this.publishProperty('steam', options & 0x80 ? 'ON' : 'OFF')
+        }
+    }
+
+    setProperty(prop: string, mqttValue: string) {
+        if (prop === 'power') {
+            if (mqttValue === 'ON') {
+                this.send(Buffer.from('F02A0100', 'hex'))
+            } else if (mqttValue === 'OFF') {
+                this.send(Buffer.from('F024010100', 'hex'))
+            }
+        }
+
+        if (prop === 'pause') this.send(Buffer.from('F024040100', 'hex'))
+        if (prop === 'start') this.send(Buffer.from(mqttValue || 'F024050100', 'hex'))
+    }
+}

--- a/rethink/cloud/devices/washer_common.ts
+++ b/rethink/cloud/devices/washer_common.ts
@@ -138,3 +138,5 @@ export const DRYING_MODES: Record<number, string> = {
     0xb: 'Delicate',
     0xc: 'Eco',
 }
+
+export const DOSES = ['Off', 'Low', 'Medium', 'High']

--- a/rethink/cloud/ha_bridge.ts
+++ b/rethink/cloud/ha_bridge.ts
@@ -8,6 +8,7 @@ import Dev_2RES1VE600FWC from './devices/2RES1VE600FWC'
 import Y_V8_Y___W_B32QEUK from './devices/Y_V8_Y___W.B32QEUK'
 import F_V8_Y___W_B_2QEUK from './devices/F_V8_Y___W.B_2QEUK'
 import F_V__F___W_B_1QEUK from './devices/F_V__F___W.B_1QEUK'
+import F_VB_F___W_B_2QEUK from './devices/F_VB_F___W.B_2QEUK'
 import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
 import { type Connection } from './homeassistant'
@@ -33,6 +34,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['F_V8_Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK,
     ['F_V__Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK, // NOTE: we reuse F_V8_Y___W_B_2QEUK as the models appear to be compatible
     ['F_V__F___W.B_1QEUK']: F_V__F___W_B_1QEUK,
+    ['F_VB_F___W.B_2QEUK']: F_VB_F___W_B_2QEUK, // LG CV74J7S2QA washer/dryer combo
 }
 
 class Bridge {

--- a/rethink/tests/cloud/devices/F_VB_F___W.B_2QEUK.test.ts
+++ b/rethink/tests/cloud/devices/F_VB_F___W.B_2QEUK.test.ts
@@ -1,0 +1,257 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/F_VB_F___W.B_2QEUK'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf, hex } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'F_VB_F___W.B_2QEUK'
+const META: Metadata = { modelId: MODEL_ID, modelName: 'F_VB_F___W.B_2QEUK', swVersion: '0.0.0' }
+
+// Powered on, idle (Ready), no course selected, no locks engaged.
+const SAMPLE_INITIAL = buf(
+    'AA5420EC002500050F050F130000000000000000000000000401000A0064000004000CBD02022A1E00030100250100000000000000000000000000000000000000000A006400000000000002022A1E0040014EBB',
+)
+
+// Idle with child lock engaged — used to pin down the 0x80 bit polarity
+// (it is set when locked on this model; see PR #52 conversation with xBelladonna).
+const SAMPLE_CHILD_LOCK = buf(
+    'AA5420EC00250100000000000000000000000000000000000000000A006400000000000002022A1E00030100250100000000000000000000000000008000000000000A006400000000000002022A1E00030107BB',
+)
+
+// Cotton, 1000 RPM (TurboWash auto-adjusted), 40°C, extra rinse + TurboWash + Pre-wash on,
+// detergent dose Off, softener dose High. Steam is unavailable on this combo so it stays OFF.
+const SAMPLE_COMBO_OPTIONS = buf(
+    'AA5420EC00250104010401010003070402000000410001000200000A006400000500000000022A1E00020100250104010401010003070402000000410001000200000A006400000500000000032A1E000201C0BB',
+)
+
+// Same combo as above with delay_end dialled to 3 hours.
+const SAMPLE_DELAY_END = buf(
+    'AA5420EC00250104010401010003070402000000410001000200000A006400000500000000032A1E00020100250104010401010003070402000300410001000200000A006400000500000000032A1E000201CCBB',
+)
+
+// Powered off (status=0). Time/course bytes still hold the last cycle's values.
+const SAMPLE_POWER_OFF = buf(
+    'AA5420EC00250004010401010000000000000000000001000201000A006400000500000000032A1E00020100250004010401010000000000000000000001000201000A006400000500000000032A1E00420161BB',
+)
+
+// Mid-Washing on the Wash + Dry course (0x13), 1400 RPM, 40°C, drying = Auto.
+// Door locked, remote_start active, 2h25m remaining.
+const SAMPLE_RUNNING = buf(
+    'AA5420EC002504050F050F1300030A0401020000004220000101000A006400000400000002022A1E000301002506021902191300030A0401020000004220000104000A006400000400000002022A1E0003010CBB',
+)
+
+// Drying-only course (0x18) just started — status=Drying, drying_mode=Auto, 55 min remaining.
+const SAMPLE_DRYING = buf(
+    'AA5420EC00250100370037180000000000020000000000000600000B006400000000002D00002A1E00000100250900370037180000000000020000000220000101000B006400000000002D00002A1E004001F7BB',
+)
+
+// Outgoing packets emitted by setProperty / start.
+const WRITE_INIT = 'AA0EF0ED1121010000001800B5BB'
+const WRITE_POWER_ON = 'AA08F02A010098BB'
+const WRITE_POWER_OFF = 'AA09F0240101009CBB'
+const WRITE_PAUSE = 'AA09F02404010099BB'
+const WRITE_START = 'AA09F02405010098BB'
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('config exposes expected components on construction', () => {
+        const { ha } = makeDevice()
+        const cfg = ha.devices[DEVICE_ID].config
+        assert.ok(cfg, 'config published')
+        const components = cfg!.components as Record<string, Record<string, unknown>>
+        for (const c of [
+            'power',
+            'start',
+            'pause',
+            'status',
+            'error',
+            'error_message',
+            'course',
+            'temp',
+            'spin',
+            'drying_mode',
+            'cycles',
+            'remote_start',
+            'door_lock',
+            'child_lock',
+            'energy',
+            'initial_time',
+            'remaining_time',
+            'delay_end',
+            'detergent',
+            'softener',
+            'extra_rinse',
+            'turbowash',
+            'eco_hybrid',
+            'prewash',
+            'steam',
+        ]) {
+            assert.ok(components[c], `component ${c} present`)
+        }
+        assert.ok((components.status.options as string[]).includes('Washing'))
+        assert.ok((components.detergent.options as string[]).includes('Medium'))
+        assert.equal(components.door_lock.device_class, 'lock')
+        assert.equal(components.child_lock.device_class, 'lock')
+        assert.equal(components.delay_end.device_class, 'duration')
+    })
+
+    test('initial state push decodes power, status, lock and error state', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_INITIAL)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.power, 'ON')
+        assert.equal(props.status, 'Ready')
+        assert.equal(props.error, 'OFF')
+        assert.equal(props.error_message, 'OK')
+        assert.equal(props.drying_mode, 'Off')
+        assert.equal(props.delay_end, 0)
+        assert.equal(props.extra_rinse, 'OFF')
+        assert.equal(props.turbowash, 'OFF')
+        assert.equal(props.eco_hybrid, 'OFF')
+        assert.equal(props.prewash, 'OFF')
+        assert.equal(props.steam, 'OFF')
+        assert.equal(props.cycles, 10)
+        assert.equal(props.energy, 0)
+        assert.equal(props.initial_time, 0)
+        assert.equal(props.remaining_time, 0)
+        // flags1=0x00: remote_start=OFF, door_lock=ON (unlocked), child_lock=OFF
+        assert.equal(props.remote_start, 'OFF')
+        assert.equal(props.door_lock, 'ON')
+        assert.equal(props.child_lock, 'OFF')
+    })
+
+    test('child lock engaged frame decodes child_lock=ON, polarity is non-inverted', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_CHILD_LOCK)
+        const props = ha.devices[DEVICE_ID].properties
+        // buf[58]=0x80: 0x80 bit is set when child lock engaged on this model.
+        assert.equal(props.child_lock, 'ON')
+        assert.equal(props.door_lock, 'ON') // 0x40 bit still clear → door unlocked
+        assert.equal(props.remote_start, 'OFF')
+    })
+
+    test('combo-options frame decodes extra_rinse, turbowash, prewash, detergent, softener', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_COMBO_OPTIONS)
+        const props = ha.devices[DEVICE_ID].properties
+        // buf[57]=0x41: bit 0x01 (TurboWash) + bit 0x40 (Pre-wash) set; eco_hybrid + steam clear.
+        assert.equal(props.extra_rinse, 'ON')
+        assert.equal(props.turbowash, 'ON')
+        assert.equal(props.prewash, 'ON')
+        assert.equal(props.eco_hybrid, 'OFF')
+        assert.equal(props.steam, 'OFF')
+        assert.equal(props.detergent, 'Off')
+        assert.equal(props.softener, 'High')
+        assert.equal(props.spin, 1000) // TurboWash forces 1000 RPM
+        assert.equal(props.temp, 40)
+        assert.equal(props.initial_time, 241)
+        assert.equal(props.remaining_time, 241)
+    })
+
+    test('delay end frame decodes delay_end in hours', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_DELAY_END)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.delay_end, 3)
+    })
+
+    test('running state on Wash + Dry course decodes status, spin, temp, lock', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_RUNNING)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.status, 'Washing')
+        assert.equal(props.spin, 1400)
+        assert.equal(props.temp, 40)
+        assert.equal(props.drying_mode, 'Auto')
+        // flags1=0x42 = 0x40 (door locked, inverted) + 0x02 (remote_start)
+        assert.equal(props.door_lock, 'OFF') // locked while running
+        assert.equal(props.remote_start, 'ON')
+        assert.equal(props.child_lock, 'OFF')
+    })
+
+    test('drying state on Drying-only course decodes status=Drying, drying_mode=Auto', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_DRYING)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.status, 'Drying')
+        assert.equal(props.drying_mode, 'Auto')
+        assert.equal(props.initial_time, 55)
+        assert.equal(props.remaining_time, 55)
+        assert.equal(props.cycles, 11)
+        // The Drying-only course does not set spin/temp on this model.
+        assert.equal(props.spin, 'unknown')
+        assert.equal(props.temp, 'unknown')
+    })
+
+    test('power-off transition (status=0)', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_POWER_OFF)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.power, 'OFF')
+        assert.equal(props.status, 'Off')
+    })
+
+    test('frames not matching the AA..BB envelope are ignored', () => {
+        const { ha, thinq } = makeDevice()
+        const before = ha.devices[DEVICE_ID].properties.power
+        thinq.emit('data', buf('001122'))
+        assert.equal(ha.devices[DEVICE_ID].properties.power, before)
+    })
+
+    test('frames with wrong inner length are ignored', () => {
+        const { ha, thinq } = makeDevice()
+        const before = ha.devices[DEVICE_ID].properties.power
+        thinq.emit('data', buf('AA08200A01020304BB'))
+        assert.equal(ha.devices[DEVICE_ID].properties.power, before)
+    })
+
+    test('start() sends the F0ED initialisation packet', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.start()
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(hex(thinq.outbox[0]), WRITE_INIT)
+    })
+
+    test('HA write power=ON', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('power', 'ON')
+        assert.equal(hex(thinq.outbox[0]), WRITE_POWER_ON)
+    })
+
+    test('HA write power=OFF', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('power', 'OFF')
+        assert.equal(hex(thinq.outbox[0]), WRITE_POWER_OFF)
+    })
+
+    test('HA write pause button', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('pause', '')
+        assert.equal(hex(thinq.outbox[0]), WRITE_PAUSE)
+    })
+
+    test('HA write start button', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('start', '')
+        assert.equal(hex(thinq.outbox[0]), WRITE_START)
+    })
+
+    test('HA write to unknown property emits no packet', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('does-not-exist', 'whatever')
+        assert.equal(thinq.outbox.length, 0)
+    })
+})


### PR DESCRIPTION
I have a LG ThinQ Washer&Dryer (10,5kg/7kg) (model no. CV74J7S2QA) that wasn't fully supported before. I saw that it worked well enough by monkey-patching the supported device list to also allow `F_VB_F___W.B_2QEUK`, so I got inspired to make it work better. The model existing in current codebase lacked drying capabilities which I wanted to see through HA myself.

Disclaimer; the code is slopped together with Claude, but I reviewed it and this PR's text (and any communication in general) is hand-written. I couldn't find a CONTRIBUTING.md or similar that would've forbidden it :)

