### PR TITLE
Add LG RH90V9_WW heat pump dryer device class

### DIFF
--- a/rethink/cloud/devices/RH90V9_WW.ts
+++ b/rethink/cloud/devices/RH90V9_WW.ts
@@ -515,11 +515,15 @@ export default class Device extends AABBDevice {
     // ── State packet processing ───────────────────────────────────────────────
 
     processAABB(buf: Buffer) {
-        // Packet: AA + len + inner(56) + chk + BB
-        // inner: header(4: 30 EC 00 19) + A block(26) + B block(26)
-        // B block: B[0]=0x19 marker, Bd=B[1..25] = current state (authoritative)
+        // Two packet types share the same Bd field layout:
         //
-        // Confirmed Bd field map (modelJson indices unless noted):
+        // 30 EC (inner=56): header(4) + A block(26) + B block(26)
+        //   Bd = inner[31..55]  (B[0]=0x19 marker, then 25 state bytes)
+        //
+        // 30 EB (inner=29): header(4) + Bd(25)  — compact state reply to F0 ED poll
+        //   Bd = inner[4..28]
+        //
+        // Confirmed Bd field map:
         //   [0]  run state
         //   [1]  remain hours
         //   [2]  remain minutes
@@ -535,12 +539,18 @@ export default class Device extends AABBDevice {
         //   [14] flags: bit 0x02=anti-crease
         //   [15] flags: bit 0x01=remote-start
         //   [16-22] unknown/counter
-        //   [23] downloaded/smart cycle ID (0=none, see DOWNLOADED_CYCLES) ✓ confirmed inner[54]
+        //   [23] downloaded/smart cycle ID (0=none, see DOWNLOADED_CYCLES) ✓
         //   [24] unknown
 
-        if (buf.length !== 56 || buf[0] !== 0x30 || buf[1] !== 0xec) return
-
-        const Bd = buf.subarray(31)
+        if (buf[0] !== 0x30) return
+        let Bd: Buffer
+        if (buf.length === 56 && buf[1] === 0xec) {
+            Bd = buf.subarray(31)
+        } else if (buf.length === 29 && buf[1] === 0xeb) {
+            Bd = buf.subarray(4)
+        } else {
+            return
+        }
 
         const state = Bd[0]
         const remainHr = Bd[1]

--- a/rethink/cloud/devices/RH90V9_WW.ts
+++ b/rethink/cloud/devices/RH90V9_WW.ts
@@ -10,13 +10,13 @@ import AABBDevice from './aabb_device'
 
 // Bd[0] — run state
 const STATES: Record<number, string> = {
-    0:   'Off',
-    1:   'Initial',
-    2:   'Running',
-    3:   'Paused',
-    4:   'End',
-    5:   'Error',
-    8:   'Smart Diagnosis',
+    0: 'Off',
+    1: 'Initial',
+    2: 'Running',
+    3: 'Paused',
+    4: 'End',
+    5: 'Error',
+    8: 'Smart Diagnosis',
     100: 'Reserved',
 }
 
@@ -24,56 +24,54 @@ const STATES: Record<number, string> = {
 // Indices from packet captures; names from modelJson Cycle.cycleValue
 const CYCLES: Record<number, string> = {
     0x02: 'Towels',
-    0x04: 'Duvet',           // BULKYITEM
-    0x05: 'Easy Care',       // EASYCARE
-    0x06: 'Mixed Fabric',    // MIXFABRIC ✓ confirmed via API snapshot
-    0x07: 'Cotton',          // COTTONNORMAL
-    0x08: 'Sports Wear',     // SPORTWEAR
-    0x09: 'Speed 30',        // QUICKDRY
-    0x0a: 'Delicates',       // DELICATES
-    0x0b: 'Wool',            // WOOL
-    0x0c: 'Rack Dry',        // RACKDRY
-    0x0e: 'Warm Air',        // WARMAIR
-    0x10: 'Allergy Care',    // ALLERGYCARE
-    0x12: 'Condenser Care',  // CONDENSER_CARE
-    0x13: 'Drum Care',       // TUB_CLEAN
-    0x19: 'Eco (Cotton+)',   // COTTONPLUS
+    0x04: 'Duvet', // BULKYITEM
+    0x05: 'Easy Care', // EASYCARE
+    0x06: 'Mixed Fabric', // MIXFABRIC ✓ confirmed via API snapshot
+    0x07: 'Cotton', // COTTONNORMAL
+    0x08: 'Sports Wear', // SPORTWEAR
+    0x09: 'Speed 30', // QUICKDRY
+    0x0a: 'Delicates', // DELICATES
+    0x0b: 'Wool', // WOOL
+    0x0c: 'Rack Dry', // RACKDRY
+    0x0e: 'Warm Air', // WARMAIR
+    0x10: 'Allergy Care', // ALLERGYCARE
+    0x12: 'Condenser Care', // CONDENSER_CARE
+    0x13: 'Drum Care', // TUB_CLEAN
+    0x19: 'Eco (Cotton+)', // COTTONPLUS
 }
 
 // Inverse cycle lookup for commands
-const CYCLE_IDS: Record<string, number> = Object.fromEntries(
-    Object.entries(CYCLES).map(([k, v]) => [v, Number(k)])
-)
+const CYCLE_IDS: Record<string, number> = Object.fromEntries(Object.entries(CYCLES).map(([k, v]) => [v, Number(k)]))
 
 // Bd[7] — dry level (modelJson dryLevel.valueMapping indices)
 const DRY_LEVELS: Record<number, string> = {
     0: 'None',
-    1: 'Iron Dry',      // DRYLEVEL_IRON ✓
-    3: 'Cupboard Dry',  // DRYLEVEL_CUPBOARD ✓ confirmed via API snapshot
-    4: 'Extra Dry',     // DRYLEVEL_EXTRA ✓
+    1: 'Iron Dry', // DRYLEVEL_IRON ✓
+    3: 'Cupboard Dry', // DRYLEVEL_CUPBOARD ✓ confirmed via API snapshot
+    4: 'Extra Dry', // DRYLEVEL_EXTRA ✓
 }
 const DRY_LEVEL_IDS: Record<string, number> = Object.fromEntries(
-    Object.entries(DRY_LEVELS).map(([k, v]) => [v, Number(k)])
+    Object.entries(DRY_LEVELS).map(([k, v]) => [v, Number(k)]),
 )
 
 // Bd[8] — eco hybrid (modelJson ecoHybrid.valueMapping indices)
 const ECO_HYBRID: Record<number, string> = {
     0: 'None',
-    1: 'Energy',   // ECOHYBRID_ECO ✓
-    2: 'Normal',   // ECOHYBRID_NORMAL
-    3: 'Time',     // ECOHYBRID_TURBO ✓ confirmed via API snapshot
+    1: 'Energy', // ECOHYBRID_ECO ✓
+    2: 'Normal', // ECOHYBRID_NORMAL
+    3: 'Time', // ECOHYBRID_TURBO ✓ confirmed via API snapshot
 }
 const ECO_HYBRID_IDS: Record<string, number> = Object.fromEntries(
-    Object.entries(ECO_HYBRID).map(([k, v]) => [v, Number(k)])
+    Object.entries(ECO_HYBRID).map(([k, v]) => [v, Number(k)]),
 )
 
 // Bd[9] — process state (modelJson processState.valueMapping indices)
 const PROCESS_STATES: Record<number, string> = {
     0: 'Detecting',
     1: 'Steam',
-    2: 'Dry',          // DRY_LV1 ✓ confirmed via API snapshot
-    3: 'Dry',          // DRY_LV2
-    4: 'Dry',          // DRY_LV3
+    2: 'Dry', // DRY_LV1 ✓ confirmed via API snapshot
+    3: 'Dry', // DRY_LV2
+    4: 'Dry', // DRY_LV3
     5: 'Cooling',
     6: 'Anti-crease',
     7: 'End',
@@ -81,14 +79,14 @@ const PROCESS_STATES: Record<number, string> = {
 
 // Bd[6] — error code (modelJson error.valueMapping indices)
 const ERRORS: Record<number, string> = {
-    0:  '-',
-    1:  'TE1 (temperature)',
-    2:  'TE2 (temperature)',
-    4:  'TE4 (temperature)',
-    7:  'CE1 (communication)',
+    0: '-',
+    1: 'TE1 (temperature)',
+    2: 'TE2 (temperature)',
+    4: 'TE4 (temperature)',
+    7: 'CE1 (communication)',
     13: 'OE (drain motor)',
     14: 'Empty water tank',
-    15: 'dE (door open)',    // ✓ confirmed 0x0f=15
+    15: 'dE (door open)', // ✓ confirmed 0x0f=15
     17: 'No filter',
     19: 'F1',
     20: 'LE2 (motor)',
@@ -102,24 +100,38 @@ const ERRORS: Record<number, string> = {
 // modelJson: reserveTimeHour min=3, max=19 (0=off, 1 and 2 are invalid)
 const RESERVATION: Record<number, string> = {
     0: 'Off',
-    3: '3h', 4: '4h', 5: '5h', 6: '6h', 7: '7h',
-    8: '8h', 9: '9h', 10: '10h', 11: '11h', 12: '12h',
-    13: '13h', 14: '14h', 15: '15h', 16: '16h', 17: '17h',
-    18: '18h', 19: '19h',
+    3: '3h',
+    4: '4h',
+    5: '5h',
+    6: '6h',
+    7: '7h',
+    8: '8h',
+    9: '9h',
+    10: '10h',
+    11: '11h',
+    12: '12h',
+    13: '13h',
+    14: '14h',
+    15: '15h',
+    16: '16h',
+    17: '17h',
+    18: '18h',
+    19: '19h',
 }
 const RESERVATION_IDS: Record<string, number> = Object.fromEntries(
-    Object.entries(RESERVATION).map(([k, v]) => [v, Number(k)])
+    Object.entries(RESERVATION).map(([k, v]) => [v, Number(k)]),
 )
 
 // Flag bits
-const FLAG14_ANTI_CREASE  = 0x02  // Bd[14] ✓
-const FLAG15_REMOTE_START = 0x01  // Bd[15] ✓
+const FLAG14_ANTI_CREASE = 0x02 // Bd[14] ✓
+const FLAG15_REMOTE_START = 0x01 // Bd[15] ✓
 
 // Safety Lock — gates both Power On and Remote Start commands.
 // Both are potentially dangerous without someone present at the machine.
 // Must be re-acknowledged each session.
-const SAFETY_LOCK_ENABLED  = 'Enabled'
-const SAFETY_LOCK_DISABLED = 'Disabled (I accept the safety/fire risk, not recommended, use with caution, see docs for details)'
+const SAFETY_LOCK_ENABLED = 'Enabled'
+const SAFETY_LOCK_DISABLED =
+    'Disabled (I accept the safety/fire risk, not recommended, use with caution, see docs for details)'
 
 // Bd[20] — downloaded/smart cycle ID
 // Each entry carries the schema from modelJson SmartCourse so defaults are correct.
@@ -127,18 +139,32 @@ const SAFETY_LOCK_DISABLED = 'Disabled (I accept the safety/fire risk, not recom
 // To find an ID: start the cycle, check the `downloaded_cycle_id` diagnostic sensor.
 
 type DownloadedCycle = {
-    name:             string   // modelJson courseValue
-    label:            string   // human-friendly display name
-    baseId:           number | null  // base course wire ID (Bd[5])
-    defaultDryLevel:  number
+    name: string // modelJson courseValue
+    label: string // human-friendly display name
+    baseId: number | null // base course wire ID (Bd[5])
+    defaultDryLevel: number
     defaultEcoHybrid: number
-    defaultTime:      number   // minutes
+    defaultTime: number // minutes
 }
 
 const DOWNLOADED_CYCLES: Record<number, DownloadedCycle> = {
     // ── Confirmed wire IDs ────────────────────────────────────────────────────
-    0x66: { name: 'GYMCLOTHES',    label: 'Gym Clothes',       baseId: 0x08, defaultDryLevel: 0, defaultEcoHybrid: 1, defaultTime: 60  },
-    0x6b: { name: 'DEODORIZATION', label: 'Deodorization',     baseId: null, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 39  },
+    0x66: {
+        name: 'GYMCLOTHES',
+        label: 'Gym Clothes',
+        baseId: 0x08,
+        defaultDryLevel: 0,
+        defaultEcoHybrid: 1,
+        defaultTime: 60,
+    },
+    0x6b: {
+        name: 'DEODORIZATION',
+        label: 'Deodorization',
+        baseId: null,
+        defaultDryLevel: 0,
+        defaultEcoHybrid: 3,
+        defaultTime: 39,
+    },
 
     // ── Wire ID unknown — uncomment and fill in 0x?? when captured ────────────
     // 0x??: { name: 'SHOESFABRICDOLL',  label: 'Shoes / Fabric Doll',  baseId: 0x0c, defaultDryLevel: 0, defaultEcoHybrid: 1, defaultTime: 180 },
@@ -162,39 +188,39 @@ const DOWNLOADED_CYCLES: Record<number, DownloadedCycle> = {
 // modes are valid per cycle, plus the defaults to apply when a cycle is selected.
 
 type CycleSchema = {
-    dryLevels:        number[]  // valid dry level indices (empty = only None supported)
-    ecoHybrids:       number[]  // valid eco hybrid indices
-    defaultDryLevel:  number
+    dryLevels: number[] // valid dry level indices (empty = only None supported)
+    ecoHybrids: number[] // valid eco hybrid indices
+    defaultDryLevel: number
     defaultEcoHybrid: number
 }
 
 const CYCLE_SCHEMA: Record<number, CycleSchema> = {
-    0x02: { dryLevels: [],      ecoHybrids: [3],   defaultDryLevel: 0, defaultEcoHybrid: 3 }, // Towels
-    0x04: { dryLevels: [],      ecoHybrids: [3],   defaultDryLevel: 0, defaultEcoHybrid: 3 }, // Duvet
-    0x05: { dryLevels: [1,3],   ecoHybrids: [1,3], defaultDryLevel: 3, defaultEcoHybrid: 3 }, // Easy Care
-    0x06: { dryLevels: [1,3,4], ecoHybrids: [1,3], defaultDryLevel: 3, defaultEcoHybrid: 3 }, // Mixed Fabric
-    0x07: { dryLevels: [1,3,4], ecoHybrids: [3],   defaultDryLevel: 3, defaultEcoHybrid: 3 }, // Cotton
-    0x08: { dryLevels: [],      ecoHybrids: [1],   defaultDryLevel: 0, defaultEcoHybrid: 1 }, // Sports Wear
-    0x09: { dryLevels: [],      ecoHybrids: [3],   defaultDryLevel: 0, defaultEcoHybrid: 3 }, // Speed 30
-    0x0a: { dryLevels: [],      ecoHybrids: [1],   defaultDryLevel: 0, defaultEcoHybrid: 1 }, // Delicates
-    0x0b: { dryLevels: [],      ecoHybrids: [1],   defaultDryLevel: 0, defaultEcoHybrid: 1 }, // Wool
-    0x0c: { dryLevels: [],      ecoHybrids: [1],   defaultDryLevel: 0, defaultEcoHybrid: 1 }, // Rack Dry
-    0x0e: { dryLevels: [],      ecoHybrids: [1,3], defaultDryLevel: 0, defaultEcoHybrid: 1 }, // Warm Air
-    0x10: { dryLevels: [],      ecoHybrids: [3],   defaultDryLevel: 0, defaultEcoHybrid: 3 }, // Allergy Care
-    0x12: { dryLevels: [],      ecoHybrids: [3],   defaultDryLevel: 0, defaultEcoHybrid: 3 }, // Condenser Care
-    0x13: { dryLevels: [],      ecoHybrids: [3],   defaultDryLevel: 0, defaultEcoHybrid: 3 }, // Drum Care
-    0x19: { dryLevels: [1,3,4], ecoHybrids: [1,3], defaultDryLevel: 3, defaultEcoHybrid: 1 }, // Eco (Cotton+)
+    0x02: { dryLevels: [], ecoHybrids: [3], defaultDryLevel: 0, defaultEcoHybrid: 3 }, // Towels
+    0x04: { dryLevels: [], ecoHybrids: [3], defaultDryLevel: 0, defaultEcoHybrid: 3 }, // Duvet
+    0x05: { dryLevels: [1, 3], ecoHybrids: [1, 3], defaultDryLevel: 3, defaultEcoHybrid: 3 }, // Easy Care
+    0x06: { dryLevels: [1, 3, 4], ecoHybrids: [1, 3], defaultDryLevel: 3, defaultEcoHybrid: 3 }, // Mixed Fabric
+    0x07: { dryLevels: [1, 3, 4], ecoHybrids: [3], defaultDryLevel: 3, defaultEcoHybrid: 3 }, // Cotton
+    0x08: { dryLevels: [], ecoHybrids: [1], defaultDryLevel: 0, defaultEcoHybrid: 1 }, // Sports Wear
+    0x09: { dryLevels: [], ecoHybrids: [3], defaultDryLevel: 0, defaultEcoHybrid: 3 }, // Speed 30
+    0x0a: { dryLevels: [], ecoHybrids: [1], defaultDryLevel: 0, defaultEcoHybrid: 1 }, // Delicates
+    0x0b: { dryLevels: [], ecoHybrids: [1], defaultDryLevel: 0, defaultEcoHybrid: 1 }, // Wool
+    0x0c: { dryLevels: [], ecoHybrids: [1], defaultDryLevel: 0, defaultEcoHybrid: 1 }, // Rack Dry
+    0x0e: { dryLevels: [], ecoHybrids: [1, 3], defaultDryLevel: 0, defaultEcoHybrid: 1 }, // Warm Air
+    0x10: { dryLevels: [], ecoHybrids: [3], defaultDryLevel: 0, defaultEcoHybrid: 3 }, // Allergy Care
+    0x12: { dryLevels: [], ecoHybrids: [3], defaultDryLevel: 0, defaultEcoHybrid: 3 }, // Condenser Care
+    0x13: { dryLevels: [], ecoHybrids: [3], defaultDryLevel: 0, defaultEcoHybrid: 3 }, // Drum Care
+    0x19: { dryLevels: [1, 3, 4], ecoHybrids: [1, 3], defaultDryLevel: 3, defaultEcoHybrid: 1 }, // Eco (Cotton+)
 }
 
 // ─── Device class ──────────────────────────────────────────────────────────────
 
 export default class Device extends AABBDevice {
     // Pending command state — populated by selector changes, sent on start
-    private selectedCycle:      number | null = null
-    private selectedDryLevel:   number        = 0    // NO_DRYLEVEL
-    private selectedEcoHybrid:  number        = 0    // NO_ECOHYBRID
-    private selectedAntiCrease: boolean       = false
-    private selectedReservation: number       = 0    // Off
+    private selectedCycle: number | null = null
+    private selectedDryLevel: number = 0 // NO_DRYLEVEL
+    private selectedEcoHybrid: number = 0 // NO_ECOHYBRID
+    private selectedAntiCrease: boolean = false
+    private selectedReservation: number = 0 // Off
 
     // Safety lock — gates Power On and Remote Start, resets each session
     private safetyLockDisabled: boolean = false
@@ -220,10 +246,7 @@ export default class Device extends AABBDevice {
                         command_topic: '$this/safety_lock/set',
                         name: '🔒 Safety Lock',
                         icon: 'mdi:lock-alert-outline',
-                        options: [
-                            SAFETY_LOCK_ENABLED,
-                            SAFETY_LOCK_DISABLED,
-                        ],
+                        options: [SAFETY_LOCK_ENABLED, SAFETY_LOCK_DISABLED],
                         entity_category: 'config',
                     },
                     // Power ON — works at wire level but rejected by LG cloud.
@@ -413,25 +436,23 @@ export default class Device extends AABBDevice {
         const schema = CYCLE_SCHEMA[cycleId]
         if (!schema || !this.config) return
 
-        const dryOptions = schema.dryLevels.length > 0
-            ? schema.dryLevels.map(id => DRY_LEVELS[id])
-            : [DRY_LEVELS[0]]  // None only — selector will be hidden via availability
+        const dryOptions = schema.dryLevels.length > 0 ? schema.dryLevels.map((id) => DRY_LEVELS[id]) : [DRY_LEVELS[0]] // None only — selector will be hidden via availability
 
-        const ecoOptions = schema.ecoHybrids.map(id => ECO_HYBRID[id])
+        const ecoOptions = schema.ecoHybrids.map((id) => ECO_HYBRID[id])
 
         // Mutate config in place and republish
-        ;(this.config.components.dry_level  as any).options = dryOptions
+        ;(this.config.components.dry_level as any).options = dryOptions
         ;(this.config.components.eco_hybrid as any).options = ecoOptions
 
         // Apply defaults for this cycle
-        this.selectedDryLevel  = schema.defaultDryLevel
+        this.selectedDryLevel = schema.defaultDryLevel
         this.selectedEcoHybrid = schema.defaultEcoHybrid
 
         // Republish full device config with updated options
         this.publishConfig()
 
         // Re-publish current values immediately to prevent "unknown" flash
-        this.publishProperty('dry_level',  DRY_LEVELS[this.selectedDryLevel]  ?? 'None')
+        this.publishProperty('dry_level', DRY_LEVELS[this.selectedDryLevel] ?? 'None')
         this.publishProperty('eco_hybrid', ECO_HYBRID[this.selectedEcoHybrid] ?? 'None')
     }
 
@@ -465,29 +486,29 @@ export default class Device extends AABBDevice {
 
         const Bd = buf.subarray(31) // 25 bytes after 0x19 marker
 
-        const state        = Bd[0]
-        const remainHr     = Bd[1]
-        const remainMin    = Bd[2]
-        const initialHr    = Bd[3]
-        const initialMin   = Bd[4]
-        const cycle        = Bd[5]
-        const errorCode    = Bd[6]
-        const dryLevel     = Bd[7]
-        const ecoHybrid    = Bd[8]
+        const state = Bd[0]
+        const remainHr = Bd[1]
+        const remainMin = Bd[2]
+        const initialHr = Bd[3]
+        const initialMin = Bd[4]
+        const cycle = Bd[5]
+        const errorCode = Bd[6]
+        const dryLevel = Bd[7]
+        const ecoHybrid = Bd[8]
         const processState = Bd[9]
-        const reservation      = Bd[10]  // reservation hours (0=off, 3-19=delayed end)
-        const flags14          = Bd[14]
-        const flags15          = Bd[15]
+        const reservation = Bd[10] // reservation hours (0=off, 3-19=delayed end)
+        const flags14 = Bd[14]
+        const flags15 = Bd[15]
         const downloadedCycleId = Bd[20] // SmartCourse/downloaded cycle ID (0=none)
 
         const remainingTime = remainHr * 60 + remainMin
-        const initialTime   = initialHr * 60 + initialMin
+        const initialTime = initialHr * 60 + initialMin
 
-        const isOff       = state === 0
-        const isEnd       = state === 4
-        const hasError    = errorCode !== 0
+        const isOff = state === 0
+        const isEnd = state === 4
+        const hasError = errorCode !== 0
         const remoteStart = !!(flags15 & FLAG15_REMOTE_START)
-        const antiCrease  = !!(flags14 & FLAG14_ANTI_CREASE)
+        const antiCrease = !!(flags14 & FLAG14_ANTI_CREASE)
 
         // Sync pending command state from machine — respects selector lock
         // so in-progress HA edits aren't clobbered by incoming state packets.
@@ -507,55 +528,57 @@ export default class Device extends AABBDevice {
         if (!this.isSelectorLocked('dry_level')) {
             let effectiveDryLevel: number
             if (!schema || schema.dryLevels.length === 0) {
-                effectiveDryLevel = 0  // cycle has no dry level support — always None
+                effectiveDryLevel = 0 // cycle has no dry level support — always None
             } else if (schema.dryLevels.includes(dryLevel)) {
-                effectiveDryLevel = dryLevel  // valid for this cycle
+                effectiveDryLevel = dryLevel // valid for this cycle
             } else {
-                effectiveDryLevel = schema.defaultDryLevel  // stale/invalid — use default
+                effectiveDryLevel = schema.defaultDryLevel // stale/invalid — use default
             }
             this.selectedDryLevel = effectiveDryLevel
         }
         if (!this.isSelectorLocked('eco_hybrid')) {
             let effectiveEcoHybrid: number
             if (!schema || schema.ecoHybrids.length === 0) {
-                effectiveEcoHybrid = 0  // no eco hybrid support
+                effectiveEcoHybrid = 0 // no eco hybrid support
             } else if (schema.ecoHybrids.includes(ecoHybrid)) {
-                effectiveEcoHybrid = ecoHybrid  // valid for this cycle
+                effectiveEcoHybrid = ecoHybrid // valid for this cycle
             } else {
-                effectiveEcoHybrid = schema.defaultEcoHybrid  // stale/invalid — use default
+                effectiveEcoHybrid = schema.defaultEcoHybrid // stale/invalid — use default
             }
             this.selectedEcoHybrid = effectiveEcoHybrid
         }
-        if (!this.isSelectorLocked('anti_crease'))  this.selectedAntiCrease  = antiCrease
-        if (!this.isSelectorLocked('reservation'))  this.selectedReservation = reservation
+        if (!this.isSelectorLocked('anti_crease')) this.selectedAntiCrease = antiCrease
+        if (!this.isSelectorLocked('reservation')) this.selectedReservation = reservation
 
         // Publish status sensors
-        this.publishProperty('power',          isOff ? 'OFF' : 'ON')
-        this.publishProperty('run_state',      STATES[state]              ?? `unknown (${state})`)
-        this.publishProperty('process_state',  PROCESS_STATES[processState] ?? `unknown (${processState})`)
+        this.publishProperty('power', isOff ? 'OFF' : 'ON')
+        this.publishProperty('run_state', STATES[state] ?? `unknown (${state})`)
+        this.publishProperty('process_state', PROCESS_STATES[processState] ?? `unknown (${processState})`)
         this.publishProperty('remaining_time', remainingTime)
-        this.publishProperty('initial_time',   initialTime)
-        this.publishProperty('remote_start',   remoteStart ? 'ON' : 'OFF')
-        this.publishProperty('run_completed',  isEnd ? 'ON' : 'OFF')
-        this.publishProperty('error',          hasError ? 'ON' : 'OFF')
-        this.publishProperty('error_message',  ERRORS[errorCode] ?? `unknown (0x${errorCode.toString(16)})`)
+        this.publishProperty('initial_time', initialTime)
+        this.publishProperty('remote_start', remoteStart ? 'ON' : 'OFF')
+        this.publishProperty('run_completed', isEnd ? 'ON' : 'OFF')
+        this.publishProperty('error', hasError ? 'ON' : 'OFF')
+        this.publishProperty('error_message', ERRORS[errorCode] ?? `unknown (0x${errorCode.toString(16)})`)
 
         // Publish selectors (only if not locked by a recent user edit)
         if (!this.isSelectorLocked('cycle')) {
             // If a downloaded SmartCourse is active, show its name instead of the base cycle
-            const cycleName = (downloadedCycleId && DOWNLOADED_CYCLES[downloadedCycleId])
-                ? DOWNLOADED_CYCLES[downloadedCycleId].label
-                : CYCLES[cycle] ?? `unknown (0x${cycle.toString(16)})`
+            const cycleName =
+                downloadedCycleId && DOWNLOADED_CYCLES[downloadedCycleId]
+                    ? DOWNLOADED_CYCLES[downloadedCycleId].label
+                    : (CYCLES[cycle] ?? `unknown (0x${cycle.toString(16)})`)
             this.publishProperty('cycle', cycleName)
         }
-        this.publishProperty('downloaded_cycle_id',
-            downloadedCycleId ? `0x${downloadedCycleId.toString(16)}` : '-'
-        )
+        this.publishProperty('downloaded_cycle_id', downloadedCycleId ? `0x${downloadedCycleId.toString(16)}` : '-')
         if (!this.isSelectorLocked('dry_level')) {
-            this.publishProperty('dry_level',  DRY_LEVELS[this.selectedDryLevel]  ?? `unknown (${this.selectedDryLevel})`)
+            this.publishProperty('dry_level', DRY_LEVELS[this.selectedDryLevel] ?? `unknown (${this.selectedDryLevel})`)
         }
         if (!this.isSelectorLocked('eco_hybrid')) {
-            this.publishProperty('eco_hybrid', ECO_HYBRID[this.selectedEcoHybrid] ?? `unknown (${this.selectedEcoHybrid})`)
+            this.publishProperty(
+                'eco_hybrid',
+                ECO_HYBRID[this.selectedEcoHybrid] ?? `unknown (${this.selectedEcoHybrid})`,
+            )
         }
         if (!this.isSelectorLocked('anti_crease')) {
             this.publishProperty('anti_crease', antiCrease ? 'ON' : 'OFF')
@@ -577,15 +600,19 @@ export default class Device extends AABBDevice {
         // or any case where selectors get out of sync with the schema.
         // Also handles downloaded cycles which have their own defaults.
         const schema = CYCLE_SCHEMA[this.selectedCycle]
-        let dryLevel  = this.selectedDryLevel
+        let dryLevel = this.selectedDryLevel
         let ecoHybrid = this.selectedEcoHybrid
         if (schema) {
             if (schema.dryLevels.length > 0 && !schema.dryLevels.includes(dryLevel)) {
-                console.warn(`[RH90V9] dry_level ${DRY_LEVELS[dryLevel]} invalid for ${CYCLES[this.selectedCycle]}, using default`)
+                console.warn(
+                    `[RH90V9] dry_level ${DRY_LEVELS[dryLevel]} invalid for ${CYCLES[this.selectedCycle]}, using default`,
+                )
                 dryLevel = schema.defaultDryLevel
             }
             if (!schema.ecoHybrids.includes(ecoHybrid)) {
-                console.warn(`[RH90V9] eco_hybrid ${ECO_HYBRID[ecoHybrid]} invalid for ${CYCLES[this.selectedCycle]}, using default`)
+                console.warn(
+                    `[RH90V9] eco_hybrid ${ECO_HYBRID[ecoHybrid]} invalid for ${CYCLES[this.selectedCycle]}, using default`,
+                )
                 ecoHybrid = schema.defaultEcoHybrid
             }
         }
@@ -600,14 +627,14 @@ export default class Device extends AABBDevice {
         // [12]   = operation (0x03=start, 0x01=resume/update)
         // [14]   = SmartCourse ID (0x00 for base courses)
         const inner = Buffer.alloc(16, 0)
-        inner[0]  = 0xf0
-        inner[1]  = 0x26
-        inner[2]  = this.selectedCycle
-        inner[3]  = dryLevel
-        inner[4]  = ecoHybrid
-        inner[8]  = this.selectedReservation
+        inner[0] = 0xf0
+        inner[1] = 0x26
+        inner[2] = this.selectedCycle
+        inner[3] = dryLevel
+        inner[4] = ecoHybrid
+        inner[8] = this.selectedReservation
         inner[11] = this.selectedAntiCrease ? 0x02 : 0x00
-        inner[12] = 0x03  // start new cycle
+        inner[12] = 0x03 // start new cycle
         return inner
     }
 

--- a/rethink/cloud/devices/RH90V9_WW.ts
+++ b/rethink/cloud/devices/RH90V9_WW.ts
@@ -148,48 +148,29 @@ type DownloadedCycle = {
 }
 
 const DOWNLOADED_CYCLES: Record<number, DownloadedCycle> = {
-    // ── Confirmed wire IDs ────────────────────────────────────────────────────
-    0x66: {
-        name: 'GYMCLOTHES',
-        label: 'Gym Clothes',
-        baseId: 0x08,
-        defaultDryLevel: 0,
-        defaultEcoHybrid: 1,
-        defaultTime: 60,
-    },
-    0x6b: {
-        name: 'DEODORIZATION',
-        label: 'Deodorization',
-        baseId: null,
-        defaultDryLevel: 0,
-        defaultEcoHybrid: 3,
-        defaultTime: 39,
-    },
-
-    // ── Wire ID unknown — uncomment and fill in 0x?? when captured ────────────
-    // 0x??: { name: 'SHOESFABRICDOLL',  label: 'Shoes / Fabric Doll',  baseId: 0x0c, defaultDryLevel: 0, defaultEcoHybrid: 1, defaultTime: 180 },
-    // 0x??: { name: 'BABYWEAR',         label: 'Baby Wear',             baseId: 0x02, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 130 },
-    // 0x??: { name: 'BLANKET',          label: 'Blanket',               baseId: 0x04, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 165 },
-    // 0x??: { name: 'BLANKETREFRESH',   label: 'Blanket Refresh',       baseId: null, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 30  },
-    // 0x??: { name: 'SINGLEGARMENTS',   label: 'Single Garments',       baseId: 0x0e, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 40  },
-    // 0x??: { name: 'LINGERIE',         label: 'Lingerie',              baseId: 0x0a, defaultDryLevel: 0, defaultEcoHybrid: 1, defaultTime: 50  },
-    // 0x??: { name: 'RAINYSEASON',      label: 'Rainy Season',          baseId: 0x0e, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 30  },
-    // 0x??: { name: 'SMALLLOAD',        label: 'Small Load',            baseId: 0x0e, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 50  },
-    // 0x??: { name: 'EASYIRON',         label: 'Easy Iron',             baseId: 0x19, defaultDryLevel: 1, defaultEcoHybrid: 1, defaultTime: 110 },
-    // 0x??: { name: 'SUPERDRY',         label: 'Super Dry',             baseId: 0x19, defaultDryLevel: 4, defaultEcoHybrid: 3, defaultTime: 160 },
-    // 0x??: { name: 'ECONOMICDRY',      label: 'Economic Dry',          baseId: 0x19, defaultDryLevel: 3, defaultEcoHybrid: 1, defaultTime: 150 },
-    // 0x??: { name: 'BIGSIZEITEM',      label: 'Big Size Item',         baseId: 0x04, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 165 },
-    // 0x??: { name: 'MINIMIZEWRINKLES', label: 'Minimize Wrinkles',     baseId: 0x19, defaultDryLevel: 3, defaultEcoHybrid: 3, defaultTime: 130 },
-    // 0x??: { name: 'FULLSIZELOAD',     label: 'Full Size Load',        baseId: 0x19, defaultDryLevel: 4, defaultEcoHybrid: 3, defaultTime: 160 },
+    // ── All wire IDs confirmed from packet captures ────────────────────────────
+    0x65: { name: 'BABYWEAR',         label: 'Baby Wear',          baseId: 0x02, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 130 },
+    0x66: { name: 'GYMCLOTHES',       label: 'Gym Clothes',        baseId: 0x08, defaultDryLevel: 0, defaultEcoHybrid: 1, defaultTime: 60  },
+    0x67: { name: 'BLANKET',          label: 'Blanket',            baseId: 0x04, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 165 },
+    0x68: { name: 'BLANKETREFRESH',   label: 'Blanket Refresh',    baseId: null, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 30  },
+    0x69: { name: 'RAINYSEASON',      label: 'Rainy Day',          baseId: 0x0e, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 30  },
+    0x6a: { name: 'SINGLEGARMENTS',   label: 'Single Garments',    baseId: 0x0e, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 40  },
+    0x6b: { name: 'DEODORIZATION',    label: 'Deodorization',      baseId: null, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 39  },
+    0x6c: { name: 'SMALLLOAD',        label: 'Small Load',         baseId: 0x0e, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 50  },
+    0x6d: { name: 'LINGERIE',         label: 'Lingerie',           baseId: 0x0a, defaultDryLevel: 0, defaultEcoHybrid: 1, defaultTime: 50  },
+    0x6e: { name: 'EASYIRON',         label: 'Easy Ironing',       baseId: 0x19, defaultDryLevel: 1, defaultEcoHybrid: 1, defaultTime: 110 },
+    0x6f: { name: 'SUPERDRY',         label: 'Super Dry',          baseId: 0x19, defaultDryLevel: 4, defaultEcoHybrid: 3, defaultTime: 160 },
+    0x70: { name: 'ECONOMICDRY',      label: 'Economic Dry',       baseId: 0x19, defaultDryLevel: 3, defaultEcoHybrid: 1, defaultTime: 150 },
+    0x71: { name: 'BIGSIZEITEM',      label: 'Big Size Item',      baseId: 0x04, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 165 },
+    0x72: { name: 'MINIMIZEWRINKLES', label: 'Minimize Wrinkles',  baseId: 0x19, defaultDryLevel: 3, defaultEcoHybrid: 3, defaultTime: 130 },
+    0x73: { name: 'SHOESFABRICDOLL',  label: 'Shoes / Fabric Doll',baseId: 0x0c, defaultDryLevel: 0, defaultEcoHybrid: 1, defaultTime: 180 },
+    0x74: { name: 'FULLSIZELOAD',     label: 'Full Size Load',     baseId: 0x19, defaultDryLevel: 4, defaultEcoHybrid: 3, defaultTime: 160 },
 }
 
 // ─── Per-cycle schema ──────────────────────────────────────────────────────────
-// Derived from modelJson Course.function — defines which dry levels and eco hybrid
-// modes are valid per cycle, plus the defaults to apply when a cycle is selected.
-
 type CycleSchema = {
-    dryLevels: number[] // valid dry level indices (empty = only None supported)
-    ecoHybrids: number[] // valid eco hybrid indices
+    dryLevels: number[]
+    ecoHybrids: number[]
     defaultDryLevel: number
     defaultEcoHybrid: number
 }
@@ -215,17 +196,14 @@ const CYCLE_SCHEMA: Record<number, CycleSchema> = {
 // ─── Device class ──────────────────────────────────────────────────────────────
 
 export default class Device extends AABBDevice {
-    // Pending command state — populated by selector changes, sent on start
     private selectedCycle: number | null = null
-    private selectedDryLevel: number = 0 // NO_DRYLEVEL
-    private selectedEcoHybrid: number = 0 // NO_ECOHYBRID
+    private selectedDryLevel: number = 0
+    private selectedEcoHybrid: number = 0
     private selectedAntiCrease: boolean = false
-    private selectedReservation: number = 0 // Off
+    private selectedReservation: number = 0
 
-    // Safety lock — gates Power On and Remote Start, resets each session
     private safetyLockDisabled: boolean = false
 
-    // Debounce: suppress state-packet selector updates briefly after user edits
     private selectorLockUntil: Record<string, number> = {}
     private readonly SELECTOR_LOCK_MS = 10000
 
@@ -236,9 +214,6 @@ export default class Device extends AABBDevice {
                 ...HADevice.config(meta, { name: 'LG Dryer' }),
                 components: {
                     // ── Safety Lock ──────────────────────────────────────────
-                    // Gates Power On and Remote Start — both can operate the dryer
-                    // without anyone present. Matches the physical Safety Lock button
-                    // on the machine. Resets to Enabled each session.
                     safety_lock: {
                         platform: 'select',
                         unique_id: '$deviceid-safety-lock',
@@ -249,8 +224,6 @@ export default class Device extends AABBDevice {
                         options: [SAFETY_LOCK_ENABLED, SAFETY_LOCK_DISABLED],
                         entity_category: 'config',
                     },
-                    // Power ON — works at wire level but rejected by LG cloud.
-                    // Gated behind Safety Lock.
                     power: {
                         platform: 'switch',
                         unique_id: '$deviceid-power',
@@ -259,9 +232,6 @@ export default class Device extends AABBDevice {
                         name: '',
                         icon: 'mdi:tumble-dryer',
                     },
-                    // Remote Start — read-only status indicator
-                    // Reflects whether the machine has remote start armed physically
-                    // Cannot be armed remotely — must be done on the machine
                     remote_start: {
                         platform: 'binary_sensor',
                         unique_id: '$deviceid-remote-start',
@@ -339,6 +309,19 @@ export default class Device extends AABBDevice {
                         icon: 'mdi:pause-circle-outline',
                     },
 
+                    // ── Diagnostic ───────────────────────────────────────────
+                    // Sends F0 ED handshake — wakes dryer if polling has stalled
+                    // and logs the 30 EB compact state response.
+                    ping: {
+                        platform: 'button',
+                        unique_id: '$deviceid-ping',
+                        command_topic: '$this/ping/set',
+                        payload_press: '',
+                        name: 'Poll (Debug)',
+                        icon: 'mdi:connection',
+                        entity_category: 'diagnostic',
+                    },
+
                     // ── Status sensors ───────────────────────────────────────
                     run_state: {
                         platform: 'sensor',
@@ -410,10 +393,7 @@ export default class Device extends AABBDevice {
             }),
         )
 
-        // Safety lock always starts enabled — resets each session
         this.publishProperty('safety_lock', SAFETY_LOCK_ENABLED)
-
-        // Reservation starts at Off
         this.publishProperty('reservation', 'Off')
     }
 
@@ -429,29 +409,21 @@ export default class Device extends AABBDevice {
 
     // ── Dynamic options update ────────────────────────────────────────────────
 
-    // When cycle changes, update dry_level and eco_hybrid selector options
-    // to only show valid options for that cycle, reset to defaults, republish
-    // config, then immediately re-publish state values to prevent "unknown" flash.
     private updateCycleOptions(cycleId: number) {
         const schema = CYCLE_SCHEMA[cycleId]
         if (!schema || !this.config) return
 
-        const dryOptions = schema.dryLevels.length > 0 ? schema.dryLevels.map((id) => DRY_LEVELS[id]) : [DRY_LEVELS[0]] // None only — selector will be hidden via availability
-
+        const dryOptions = schema.dryLevels.length > 0 ? schema.dryLevels.map((id) => DRY_LEVELS[id]) : [DRY_LEVELS[0]]
         const ecoOptions = schema.ecoHybrids.map((id) => ECO_HYBRID[id])
 
-        // Mutate config in place and republish
         ;(this.config.components.dry_level as any).options = dryOptions
         ;(this.config.components.eco_hybrid as any).options = ecoOptions
 
-        // Apply defaults for this cycle
         this.selectedDryLevel = schema.defaultDryLevel
         this.selectedEcoHybrid = schema.defaultEcoHybrid
 
-        // Republish full device config with updated options
         this.publishConfig()
 
-        // Re-publish current values immediately to prevent "unknown" flash
         this.publishProperty('dry_level', DRY_LEVELS[this.selectedDryLevel] ?? 'None')
         this.publishProperty('eco_hybrid', ECO_HYBRID[this.selectedEcoHybrid] ?? 'None')
     }
@@ -474,7 +446,7 @@ export default class Device extends AABBDevice {
         //   [7]  dry level
         //   [8]  eco hybrid
         //   [9]  process state
-        //   [10]  reservation hours (0=off, 3-19=delayed end)
+        //   [10] reservation hours (0=off, 3-19=delayed end)
         //   [11-13] unknown
         //   [14] flags: bit 0x02=anti-crease
         //   [15] flags: bit 0x01=remote-start
@@ -484,35 +456,32 @@ export default class Device extends AABBDevice {
 
         if (buf.length !== 56 || buf[0] !== 0x30 || buf[1] !== 0xec) return
 
-        const Bd = buf.subarray(31) // 25 bytes after 0x19 marker
+        const Bd = buf.subarray(31)
 
-        const state = Bd[0]
-        const remainHr = Bd[1]
-        const remainMin = Bd[2]
-        const initialHr = Bd[3]
-        const initialMin = Bd[4]
-        const cycle = Bd[5]
-        const errorCode = Bd[6]
-        const dryLevel = Bd[7]
-        const ecoHybrid = Bd[8]
+        const state        = Bd[0]
+        const remainHr     = Bd[1]
+        const remainMin    = Bd[2]
+        const initialHr    = Bd[3]
+        const initialMin   = Bd[4]
+        const cycle        = Bd[5]
+        const errorCode    = Bd[6]
+        const dryLevel     = Bd[7]
+        const ecoHybrid    = Bd[8]
         const processState = Bd[9]
-        const reservation = Bd[10] // reservation hours (0=off, 3-19=delayed end)
-        const flags14 = Bd[14]
-        const flags15 = Bd[15]
-        const downloadedCycleId = Bd[20] // SmartCourse/downloaded cycle ID (0=none)
+        const reservation  = Bd[10]
+        const flags14      = Bd[14]
+        const flags15      = Bd[15]
+        const downloadedCycleId = Bd[20]
 
         const remainingTime = remainHr * 60 + remainMin
-        const initialTime = initialHr * 60 + initialMin
+        const initialTime   = initialHr * 60 + initialMin
 
-        const isOff = state === 0
-        const isEnd = state === 4
-        const hasError = errorCode !== 0
+        const isOff       = state === 0
+        const isEnd       = state === 4
+        const hasError    = errorCode !== 0
         const remoteStart = !!(flags15 & FLAG15_REMOTE_START)
-        const antiCrease = !!(flags14 & FLAG14_ANTI_CREASE)
+        const antiCrease  = !!(flags14 & FLAG14_ANTI_CREASE)
 
-        // Sync pending command state from machine — respects selector lock
-        // so in-progress HA edits aren't clobbered by incoming state packets.
-        // When cycle changes from the machine side, also update options.
         if (!this.isSelectorLocked('cycle') && cycle !== 0) {
             if (this.selectedCycle !== cycle) {
                 this.selectedCycle = cycle
@@ -520,50 +489,43 @@ export default class Device extends AABBDevice {
             }
         }
 
-        // Sync dry level and eco hybrid from packet, but apply schema defaults
-        // if the packet reports None/0 for a field the cycle actually supports.
-        // This handles the case where the machine is in standby with a cycle selected
-        // but hasn't set the options yet, or reports 0 before user interaction.
         const schema = this.selectedCycle !== null ? CYCLE_SCHEMA[this.selectedCycle] : null
         if (!this.isSelectorLocked('dry_level')) {
             let effectiveDryLevel: number
             if (!schema || schema.dryLevels.length === 0) {
-                effectiveDryLevel = 0 // cycle has no dry level support — always None
+                effectiveDryLevel = 0
             } else if (schema.dryLevels.includes(dryLevel)) {
-                effectiveDryLevel = dryLevel // valid for this cycle
+                effectiveDryLevel = dryLevel
             } else {
-                effectiveDryLevel = schema.defaultDryLevel // stale/invalid — use default
+                effectiveDryLevel = schema.defaultDryLevel
             }
             this.selectedDryLevel = effectiveDryLevel
         }
         if (!this.isSelectorLocked('eco_hybrid')) {
             let effectiveEcoHybrid: number
             if (!schema || schema.ecoHybrids.length === 0) {
-                effectiveEcoHybrid = 0 // no eco hybrid support
+                effectiveEcoHybrid = 0
             } else if (schema.ecoHybrids.includes(ecoHybrid)) {
-                effectiveEcoHybrid = ecoHybrid // valid for this cycle
+                effectiveEcoHybrid = ecoHybrid
             } else {
-                effectiveEcoHybrid = schema.defaultEcoHybrid // stale/invalid — use default
+                effectiveEcoHybrid = schema.defaultEcoHybrid
             }
             this.selectedEcoHybrid = effectiveEcoHybrid
         }
         if (!this.isSelectorLocked('anti_crease')) this.selectedAntiCrease = antiCrease
         if (!this.isSelectorLocked('reservation')) this.selectedReservation = reservation
 
-        // Publish status sensors
-        this.publishProperty('power', isOff ? 'OFF' : 'ON')
-        this.publishProperty('run_state', STATES[state] ?? `unknown (${state})`)
-        this.publishProperty('process_state', PROCESS_STATES[processState] ?? `unknown (${processState})`)
+        this.publishProperty('power',          isOff ? 'OFF' : 'ON')
+        this.publishProperty('run_state',      STATES[state] ?? `unknown (${state})`)
+        this.publishProperty('process_state',  PROCESS_STATES[processState] ?? `unknown (${processState})`)
         this.publishProperty('remaining_time', remainingTime)
-        this.publishProperty('initial_time', initialTime)
-        this.publishProperty('remote_start', remoteStart ? 'ON' : 'OFF')
-        this.publishProperty('run_completed', isEnd ? 'ON' : 'OFF')
-        this.publishProperty('error', hasError ? 'ON' : 'OFF')
-        this.publishProperty('error_message', ERRORS[errorCode] ?? `unknown (0x${errorCode.toString(16)})`)
+        this.publishProperty('initial_time',   initialTime)
+        this.publishProperty('remote_start',   remoteStart ? 'ON' : 'OFF')
+        this.publishProperty('run_completed',  isEnd ? 'ON' : 'OFF')
+        this.publishProperty('error',          hasError ? 'ON' : 'OFF')
+        this.publishProperty('error_message',  ERRORS[errorCode] ?? `unknown (0x${errorCode.toString(16)})`)
 
-        // Publish selectors (only if not locked by a recent user edit)
         if (!this.isSelectorLocked('cycle')) {
-            // If a downloaded SmartCourse is active, show its name instead of the base cycle
             const cycleName =
                 downloadedCycleId && DOWNLOADED_CYCLES[downloadedCycleId]
                     ? DOWNLOADED_CYCLES[downloadedCycleId].label
@@ -575,10 +537,7 @@ export default class Device extends AABBDevice {
             this.publishProperty('dry_level', DRY_LEVELS[this.selectedDryLevel] ?? `unknown (${this.selectedDryLevel})`)
         }
         if (!this.isSelectorLocked('eco_hybrid')) {
-            this.publishProperty(
-                'eco_hybrid',
-                ECO_HYBRID[this.selectedEcoHybrid] ?? `unknown (${this.selectedEcoHybrid})`,
-            )
+            this.publishProperty('eco_hybrid', ECO_HYBRID[this.selectedEcoHybrid] ?? `unknown (${this.selectedEcoHybrid})`)
         }
         if (!this.isSelectorLocked('anti_crease')) {
             this.publishProperty('anti_crease', antiCrease ? 'ON' : 'OFF')
@@ -596,23 +555,16 @@ export default class Device extends AABBDevice {
             return null
         }
 
-        // Enforce per-cycle schema at send time — safety net for raw JSON commands
-        // or any case where selectors get out of sync with the schema.
-        // Also handles downloaded cycles which have their own defaults.
         const schema = CYCLE_SCHEMA[this.selectedCycle]
-        let dryLevel = this.selectedDryLevel
+        let dryLevel  = this.selectedDryLevel
         let ecoHybrid = this.selectedEcoHybrid
         if (schema) {
             if (schema.dryLevels.length > 0 && !schema.dryLevels.includes(dryLevel)) {
-                console.warn(
-                    `[RH90V9] dry_level ${DRY_LEVELS[dryLevel]} invalid for ${CYCLES[this.selectedCycle]}, using default`,
-                )
+                console.warn(`[RH90V9] dry_level ${DRY_LEVELS[dryLevel]} invalid for ${CYCLES[this.selectedCycle]}, using default`)
                 dryLevel = schema.defaultDryLevel
             }
             if (!schema.ecoHybrids.includes(ecoHybrid)) {
-                console.warn(
-                    `[RH90V9] eco_hybrid ${ECO_HYBRID[ecoHybrid]} invalid for ${CYCLES[this.selectedCycle]}, using default`,
-                )
+                console.warn(`[RH90V9] eco_hybrid ${ECO_HYBRID[ecoHybrid]} invalid for ${CYCLES[this.selectedCycle]}, using default`)
                 ecoHybrid = schema.defaultEcoHybrid
             }
         }
@@ -627,30 +579,26 @@ export default class Device extends AABBDevice {
         // [12]   = operation (0x03=start, 0x01=resume/update)
         // [14]   = SmartCourse ID (0x00 for base courses)
         const inner = Buffer.alloc(16, 0)
-        inner[0] = 0xf0
-        inner[1] = 0x26
-        inner[2] = this.selectedCycle
-        inner[3] = dryLevel
-        inner[4] = ecoHybrid
-        inner[8] = this.selectedReservation
+        inner[0]  = 0xf0
+        inner[1]  = 0x26
+        inner[2]  = this.selectedCycle
+        inner[3]  = dryLevel
+        inner[4]  = ecoHybrid
+        inner[8]  = this.selectedReservation
         inner[11] = this.selectedAntiCrease ? 0x02 : 0x00
-        inner[12] = 0x03 // start new cycle
+        inner[12] = 0x03
         return inner
     }
 
     // ── HA command handler ────────────────────────────────────────────────────
 
     setProperty(prop: string, mqttValue: string) {
-        // Safety lock
         if (prop === 'safety_lock') {
             this.safetyLockDisabled = mqttValue === SAFETY_LOCK_DISABLED
             this.publishProperty('safety_lock', mqttValue)
             return
         }
 
-        // Power ON — gated behind safety lock
-        // Wire-level confirmed working (aa08f02a010098bb)
-        // Rejected by LG cloud: "Not support dryer_operation_mode: POWER_ON"
         if (prop === 'power') {
             if (mqttValue === 'ON') {
                 if (!this.safetyLockDisabled) {
@@ -660,13 +608,19 @@ export default class Device extends AABBDevice {
                 }
                 this.send(Buffer.from('F02A0100', 'hex'))
             } else if (mqttValue === 'OFF') {
-                // Confirmed: aa09f0240101009cbb
                 this.send(Buffer.from('F024010100', 'hex'))
             }
             return
         }
 
-        // Cycle — also triggers dynamic options update for dry_level and eco_hybrid
+        // Poll (Debug) — sends F0 ED handshake, wakes dryer if polling has stalled
+        // Dryer replies with 30 EB compact state snapshot (logged by rethink)
+        if (prop === 'ping') {
+            console.log('[RH90V9] Sending poll (F0 ED handshake)')
+            this.send(Buffer.from('F0ED1121010000001804131400005a', 'hex'))
+            return
+        }
+
         if (prop === 'cycle') {
             const id = CYCLE_IDS[mqttValue]
             if (id !== undefined) {
@@ -717,13 +671,11 @@ export default class Device extends AABBDevice {
             return
         }
 
-        // Pause — confirmed: aa09f02404010099bb
         if (prop === 'pause') {
             this.send(Buffer.from('F024040100', 'hex'))
             return
         }
 
-        // Start / Resume
         if (prop === 'start') {
             const cmd = this.buildStartCommand()
             if (cmd) this.send(cmd)

--- a/rethink/cloud/devices/RH90V9_WW.ts
+++ b/rethink/cloud/devices/RH90V9_WW.ts
@@ -40,7 +40,7 @@ const CYCLES: Record<number, string> = {
     0x19: 'Eco (Cotton+)', // COTTONPLUS
 }
 
-// Inverse cycle lookup for commands
+// Inverse cycle lookup for start payload
 const CYCLE_IDS: Record<string, number> = Object.fromEntries(Object.entries(CYCLES).map(([k, v]) => [v, Number(k)]))
 
 // Bd[7] — dry level (modelJson dryLevel.valueMapping indices)
@@ -125,13 +125,6 @@ const RESERVATION_IDS: Record<string, number> = Object.fromEntries(
 // Flag bits
 const FLAG14_ANTI_CREASE = 0x02 // Bd[14] ✓
 const FLAG15_REMOTE_START = 0x01 // Bd[15] ✓
-
-// Safety Lock — gates both Power On and Remote Start commands.
-// Both are potentially dangerous without someone present at the machine.
-// Must be re-acknowledged each session.
-const SAFETY_LOCK_ENABLED = 'Enabled'
-const SAFETY_LOCK_DISABLED =
-    'Disabled (I accept the safety/fire risk, not recommended, use with caution, see docs for details)'
 
 // Bd[20] — downloaded/smart cycle ID
 // Each entry carries the schema from modelJson SmartCourse so defaults are correct.
@@ -308,18 +301,15 @@ const CYCLE_SCHEMA: Record<number, CycleSchema> = {
 // ─── Device class ──────────────────────────────────────────────────────────────
 
 export default class Device extends AABBDevice {
-    private selectedCycle: number | null = null
-    private selectedDryLevel: number = 0
-    private selectedEcoHybrid: number = 0
-    private selectedAntiCrease: boolean = false
-    private selectedReservation: number = 0
-
-    private safetyLockDisabled: boolean = false
     private lastDownloadedCycleId: number = 0 // tracks last known SmartCourse ID for wake sequence
     private cycleStartTime: Date | null = null // set when state transitions to Running
 
-    private selectorLockUntil: Record<string, number> = {}
-    private readonly SELECTOR_LOCK_MS = 10000
+    // Last known Bd values — used as fallback for start payload missing fields
+    private lastBdCycle: number = 0
+    private lastBdDryLevel: number = 0
+    private lastBdEcoHybrid: number = 0
+    private lastBdAntiCrease: boolean = false
+    private lastBdReservation: number = 0
 
     constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
         super(HA, thinq)
@@ -327,17 +317,6 @@ export default class Device extends AABBDevice {
             allowExtendedType({
                 ...HADevice.config(meta, { name: 'LG Dryer' }),
                 components: {
-                    // ── Safety Lock ──────────────────────────────────────────
-                    safety_lock: {
-                        platform: 'select',
-                        unique_id: '$deviceid-safety-lock',
-                        state_topic: '$this/safety_lock',
-                        command_topic: '$this/safety_lock/set',
-                        name: '🔒 Safety Lock',
-                        icon: 'mdi:lock-alert-outline',
-                        options: [SAFETY_LOCK_ENABLED, SAFETY_LOCK_DISABLED],
-                        entity_category: 'config',
-                    },
                     power: {
                         platform: 'switch',
                         unique_id: '$deviceid-power',
@@ -354,36 +333,33 @@ export default class Device extends AABBDevice {
                         icon: 'mdi:remote',
                     },
 
-                    // ── Cycle controls ───────────────────────────────────────
+                    // ── Read-only status sensors ──────────────────────────────
                     cycle: {
-                        platform: 'select',
+                        platform: 'sensor',
                         unique_id: '$deviceid-cycle',
                         state_topic: '$this/cycle',
-                        command_topic: '$this/cycle/set',
                         name: 'Cycle',
                         icon: 'mdi:pin-outline',
+                        device_class: 'enum',
                         options: ['None', ...Object.values(CYCLES)],
-                        optimistic: false,
                     },
                     dry_level: {
-                        platform: 'select',
+                        platform: 'sensor',
                         unique_id: '$deviceid-dry-level',
                         state_topic: '$this/dry_level',
-                        command_topic: '$this/dry_level/set',
                         name: 'Dry level',
                         icon: 'mdi:water-percent',
+                        device_class: 'enum',
                         options: Object.values(DRY_LEVELS),
-                        optimistic: false,
                     },
                     eco_hybrid: {
-                        platform: 'select',
+                        platform: 'sensor',
                         unique_id: '$deviceid-eco-hybrid',
                         state_topic: '$this/eco_hybrid',
-                        command_topic: '$this/eco_hybrid/set',
                         name: 'Eco hybrid',
                         icon: 'mdi:leaf',
+                        device_class: 'enum',
                         options: Object.values(ECO_HYBRID),
-                        optimistic: false,
                     },
                     anti_crease: {
                         platform: 'switch',
@@ -395,17 +371,20 @@ export default class Device extends AABBDevice {
                         optimistic: false,
                     },
                     reservation: {
-                        platform: 'select',
+                        platform: 'sensor',
                         unique_id: '$deviceid-reservation',
                         state_topic: '$this/reservation',
-                        command_topic: '$this/reservation/set',
                         name: 'Delayed end',
                         icon: 'mdi:clock-end',
+                        device_class: 'enum',
                         options: Object.values(RESERVATION),
-                        optimistic: false,
                     },
 
                     // ── Actions ──────────────────────────────────────────────
+                    // start accepts an optional JSON payload:
+                    //   {"cycle":"Mixed Fabric","dry_level":"Cupboard Dry","eco_hybrid":"Time",
+                    //    "reservation":"Off","anti_crease":false}
+                    // Any missing field falls back to the last known Bd value.
                     start: {
                         platform: 'button',
                         unique_id: '$deviceid-start',
@@ -531,41 +510,6 @@ export default class Device extends AABBDevice {
                 },
             }),
         )
-
-        this.publishProperty('safety_lock', SAFETY_LOCK_ENABLED)
-        this.publishProperty('reservation', 'Off')
-    }
-
-    // ── Selector lock helpers ─────────────────────────────────────────────────
-
-    private lockSelector(prop: string) {
-        this.selectorLockUntil[prop] = Date.now() + this.SELECTOR_LOCK_MS
-    }
-
-    private isSelectorLocked(prop: string): boolean {
-        return Date.now() < (this.selectorLockUntil[prop] ?? 0)
-    }
-
-    // ── Dynamic options update ────────────────────────────────────────────────
-
-    private updateCycleOptions(cycleId: number) {
-        const schema = CYCLE_SCHEMA[cycleId]
-        if (!schema || !this.config) return
-
-        const dryOptions = schema.dryLevels.length > 0 ? schema.dryLevels.map((id) => DRY_LEVELS[id]) : [DRY_LEVELS[0]]
-        const ecoOptions = schema.ecoHybrids.map((id) => ECO_HYBRID[id])
-
-        ;(this.config.components.dry_level as any).options = dryOptions
-        ;(this.config.components.eco_hybrid as any).options = ecoOptions
-
-        // Apply defaults — only if not locked by a recent user edit
-        if (!this.isSelectorLocked('dry_level')) this.selectedDryLevel = schema.defaultDryLevel
-        if (!this.isSelectorLocked('eco_hybrid')) this.selectedEcoHybrid = schema.defaultEcoHybrid
-
-        this.publishConfig()
-
-        this.publishProperty('dry_level', DRY_LEVELS[this.selectedDryLevel] ?? 'None')
-        this.publishProperty('eco_hybrid', ECO_HYBRID[this.selectedEcoHybrid] ?? 'None')
     }
 
     // ── State packet processing ───────────────────────────────────────────────
@@ -632,38 +576,14 @@ export default class Device extends AABBDevice {
             this.cycleStartTime = null
         }
 
-        if (!this.isSelectorLocked('cycle') && cycle > 1) {
-            if (this.selectedCycle !== cycle) {
-                this.selectedCycle = cycle
-                this.updateCycleOptions(cycle)
-            }
+        // Retain last known Bd values while a cycle is active (used as start fallback)
+        if (cycle > 1) {
+            this.lastBdCycle = cycle
+            this.lastBdDryLevel = dryLevel
+            this.lastBdEcoHybrid = ecoHybrid
+            this.lastBdAntiCrease = antiCrease
+            this.lastBdReservation = reservation
         }
-
-        const schema = this.selectedCycle !== null ? CYCLE_SCHEMA[this.selectedCycle] : null
-        if (!this.isSelectorLocked('dry_level')) {
-            let effectiveDryLevel: number
-            if (!schema || schema.dryLevels.length === 0) {
-                effectiveDryLevel = 0
-            } else if (schema.dryLevels.includes(dryLevel)) {
-                effectiveDryLevel = dryLevel
-            } else {
-                effectiveDryLevel = schema.defaultDryLevel
-            }
-            this.selectedDryLevel = effectiveDryLevel
-        }
-        if (!this.isSelectorLocked('eco_hybrid')) {
-            let effectiveEcoHybrid: number
-            if (!schema || schema.ecoHybrids.length === 0) {
-                effectiveEcoHybrid = 0
-            } else if (schema.ecoHybrids.includes(ecoHybrid)) {
-                effectiveEcoHybrid = ecoHybrid
-            } else {
-                effectiveEcoHybrid = schema.defaultEcoHybrid
-            }
-            this.selectedEcoHybrid = effectiveEcoHybrid
-        }
-        if (!this.isSelectorLocked('anti_crease')) this.selectedAntiCrease = antiCrease
-        if (!this.isSelectorLocked('reservation')) this.selectedReservation = reservation
 
         this.publishProperty('power', isOff ? 'OFF' : 'ON')
         this.publishProperty('run_state', STATES[state] ?? `unknown (${state})`)
@@ -687,36 +607,21 @@ export default class Device extends AABBDevice {
             this.publishProperty('cycle_duration', 0)
             this.publishProperty('cycle_end_time', '-')
         }
+
         this.publishProperty('error', hasError ? 'ON' : 'OFF')
         this.publishProperty('error_message', ERRORS[errorCode] ?? `unknown (0x${errorCode.toString(16)})`)
 
-        if (!this.isSelectorLocked('cycle')) {
-            if (cycle <= 1) {
-                this.publishProperty('cycle', 'None')
-            } else if (CYCLES[cycle]) {
-                this.publishProperty('cycle', CYCLES[cycle])
-            } else {
-                console.warn(`[RH90V9] Unknown cycle ID 0x${cycle.toString(16)} — not publishing to cycle selector`)
-            }
-        }
+        this.publishProperty('cycle', cycle <= 1 ? 'None' : (CYCLES[cycle] ?? `unknown (0x${cycle.toString(16)})`))
         this.publishProperty(
             'downloaded_cycle_id',
             downloadedCycleId
                 ? `0x${downloadedCycleId.toString(16)} (${DOWNLOADED_CYCLES[downloadedCycleId]?.label ?? 'unknown'})`
                 : '-',
         )
-        if (!this.isSelectorLocked('dry_level')) {
-            this.publishProperty('dry_level', DRY_LEVELS[this.selectedDryLevel] ?? 'None')
-        }
-        if (!this.isSelectorLocked('eco_hybrid')) {
-            this.publishProperty('eco_hybrid', ECO_HYBRID[this.selectedEcoHybrid] ?? 'None')
-        }
-        if (!this.isSelectorLocked('anti_crease')) {
-            this.publishProperty('anti_crease', antiCrease ? 'ON' : 'OFF')
-        }
-        if (!this.isSelectorLocked('reservation')) {
-            this.publishProperty('reservation', RESERVATION[reservation] ?? 'Off')
-        }
+        this.publishProperty('dry_level', DRY_LEVELS[dryLevel] ?? `unknown (${dryLevel})`)
+        this.publishProperty('eco_hybrid', ECO_HYBRID[ecoHybrid] ?? `unknown (${ecoHybrid})`)
+        this.publishProperty('anti_crease', antiCrease ? 'ON' : 'OFF')
+        this.publishProperty('reservation', RESERVATION[reservation] ?? 'Off')
     }
 
     // ── F0 25 SmartCourse select — used as idle safety timer reset ────────────
@@ -749,30 +654,30 @@ export default class Device extends AABBDevice {
 
     // ── Command builder ───────────────────────────────────────────────────────
 
-    private buildStartCommand(): Buffer | null {
-        if (this.selectedCycle === null) {
-            console.warn('[RH90V9] Start ignored: no cycle selected')
-            return null
-        }
-
-        const schema = CYCLE_SCHEMA[this.selectedCycle]
-        let dryLevel = this.selectedDryLevel
-        let ecoHybrid = this.selectedEcoHybrid
+    private buildStartCommand(
+        cycleId: number,
+        dryLevel: number,
+        ecoHybrid: number,
+        antiCrease: boolean,
+        reservation: number,
+    ): Buffer {
+        const schema = CYCLE_SCHEMA[cycleId]
+        let effectiveDryLevel = dryLevel
+        let effectiveEcoHybrid = ecoHybrid
         if (schema) {
             if (schema.dryLevels.length === 0) {
-                // Cycle has no dry level support — always force None
-                dryLevel = 0
-            } else if (!schema.dryLevels.includes(dryLevel)) {
+                effectiveDryLevel = 0
+            } else if (!schema.dryLevels.includes(effectiveDryLevel)) {
                 console.warn(
-                    `[RH90V9] dry_level ${DRY_LEVELS[dryLevel]} invalid for ${CYCLES[this.selectedCycle]}, using default`,
+                    `[RH90V9] dry_level ${DRY_LEVELS[effectiveDryLevel] ?? effectiveDryLevel} invalid for ${CYCLES[cycleId]}, correcting to default`,
                 )
-                dryLevel = schema.defaultDryLevel
+                effectiveDryLevel = schema.defaultDryLevel
             }
-            if (!schema.ecoHybrids.includes(ecoHybrid)) {
+            if (!schema.ecoHybrids.includes(effectiveEcoHybrid)) {
                 console.warn(
-                    `[RH90V9] eco_hybrid ${ECO_HYBRID[ecoHybrid]} invalid for ${CYCLES[this.selectedCycle]}, using default`,
+                    `[RH90V9] eco_hybrid ${ECO_HYBRID[effectiveEcoHybrid] ?? effectiveEcoHybrid} invalid for ${CYCLES[cycleId]}, correcting to default`,
                 )
-                ecoHybrid = schema.defaultEcoHybrid
+                effectiveEcoHybrid = schema.defaultEcoHybrid
             }
         }
 
@@ -788,11 +693,11 @@ export default class Device extends AABBDevice {
         const inner = Buffer.alloc(16, 0)
         inner[0] = 0xf0
         inner[1] = 0x26
-        inner[2] = this.selectedCycle
-        inner[3] = dryLevel
-        inner[4] = ecoHybrid
-        inner[8] = this.selectedReservation
-        inner[11] = this.selectedAntiCrease ? 0x02 : 0x00
+        inner[2] = cycleId
+        inner[3] = effectiveDryLevel
+        inner[4] = effectiveEcoHybrid
+        inner[8] = reservation
+        inner[11] = antiCrease ? 0x02 : 0x00
         inner[12] = 0x03
         return inner
     }
@@ -800,19 +705,8 @@ export default class Device extends AABBDevice {
     // ── HA command handler ────────────────────────────────────────────────────
 
     setProperty(prop: string, mqttValue: string) {
-        if (prop === 'safety_lock') {
-            this.safetyLockDisabled = mqttValue === SAFETY_LOCK_DISABLED
-            this.publishProperty('safety_lock', mqttValue)
-            return
-        }
-
         if (prop === 'power') {
             if (mqttValue === 'ON') {
-                if (!this.safetyLockDisabled) {
-                    console.warn('[RH90V9] Power on blocked — disable Safety Lock first')
-                    this.publishProperty('power', 'OFF')
-                    return
-                }
                 // F0 25 resets the idle safety timer before F0 2A power on.
                 // Dryer treats SmartCourse select as user interaction, unlocking
                 // the firmware safety gate that blocks remote power on after ~3-5min idle.
@@ -842,54 +736,9 @@ export default class Device extends AABBDevice {
             return
         }
 
-        if (prop === 'cycle') {
-            if (mqttValue === 'None') return // not a real cycle
-            const id = CYCLE_IDS[mqttValue]
-            if (id !== undefined) {
-                this.selectedCycle = id
-                this.lockSelector('cycle')
-                this.lockSelector('dry_level')
-                this.lockSelector('eco_hybrid')
-                this.publishProperty('cycle', mqttValue)
-                this.updateCycleOptions(id)
-            }
-            return
-        }
-
-        if (prop === 'dry_level') {
-            const id = DRY_LEVEL_IDS[mqttValue]
-            if (id !== undefined) {
-                this.selectedDryLevel = id
-                this.lockSelector('dry_level')
-                this.publishProperty('dry_level', mqttValue)
-            }
-            return
-        }
-
-        if (prop === 'eco_hybrid') {
-            const id = ECO_HYBRID_IDS[mqttValue]
-            if (id !== undefined) {
-                this.selectedEcoHybrid = id
-                this.lockSelector('eco_hybrid')
-                this.publishProperty('eco_hybrid', mqttValue)
-            }
-            return
-        }
-
         if (prop === 'anti_crease') {
-            this.selectedAntiCrease = mqttValue === 'ON'
-            this.lockSelector('anti_crease')
+            this.lastBdAntiCrease = mqttValue === 'ON'
             this.publishProperty('anti_crease', mqttValue)
-            return
-        }
-
-        if (prop === 'reservation') {
-            const hours = RESERVATION_IDS[mqttValue]
-            if (hours !== undefined) {
-                this.selectedReservation = hours
-                this.lockSelector('reservation')
-                this.publishProperty('reservation', mqttValue)
-            }
             return
         }
 
@@ -899,8 +748,50 @@ export default class Device extends AABBDevice {
         }
 
         if (prop === 'start') {
-            const cmd = this.buildStartCommand()
-            if (cmd) this.send(cmd)
+            // Start payload is optional JSON; any missing field falls back to last known Bd value.
+            let cycleId = this.lastBdCycle
+            let dryLevel = this.lastBdDryLevel
+            let ecoHybrid = this.lastBdEcoHybrid
+            let antiCrease = this.lastBdAntiCrease
+            let reservation = this.lastBdReservation
+
+            if (mqttValue.trim()) {
+                try {
+                    const payload = JSON.parse(mqttValue) as Record<string, unknown>
+                    if (payload.cycle !== undefined) {
+                        const id = CYCLE_IDS[payload.cycle as string]
+                        if (id !== undefined) cycleId = id
+                        else console.warn(`[RH90V9] Unknown cycle '${payload.cycle}' in start payload`)
+                    }
+                    if (payload.dry_level !== undefined) {
+                        const id = DRY_LEVEL_IDS[payload.dry_level as string]
+                        if (id !== undefined) dryLevel = id
+                        else console.warn(`[RH90V9] Unknown dry_level '${payload.dry_level}' in start payload`)
+                    }
+                    if (payload.eco_hybrid !== undefined) {
+                        const id = ECO_HYBRID_IDS[payload.eco_hybrid as string]
+                        if (id !== undefined) ecoHybrid = id
+                        else console.warn(`[RH90V9] Unknown eco_hybrid '${payload.eco_hybrid}' in start payload`)
+                    }
+                    if (payload.anti_crease !== undefined) {
+                        antiCrease = Boolean(payload.anti_crease)
+                    }
+                    if (payload.reservation !== undefined) {
+                        const id = RESERVATION_IDS[payload.reservation as string]
+                        if (id !== undefined) reservation = id
+                        else console.warn(`[RH90V9] Unknown reservation '${payload.reservation}' in start payload`)
+                    }
+                } catch {
+                    console.warn('[RH90V9] start payload is not valid JSON — using last known Bd values')
+                }
+            }
+
+            if (cycleId < 2) {
+                console.warn('[RH90V9] Start ignored: no cycle known')
+                return
+            }
+
+            this.send(this.buildStartCommand(cycleId, dryLevel, ecoHybrid, antiCrease, reservation))
             return
         }
     }

--- a/rethink/cloud/devices/RH90V9_WW.ts
+++ b/rethink/cloud/devices/RH90V9_WW.ts
@@ -149,22 +149,134 @@ type DownloadedCycle = {
 
 const DOWNLOADED_CYCLES: Record<number, DownloadedCycle> = {
     // ── All wire IDs confirmed from packet captures ────────────────────────────
-    0x65: { name: 'BABYWEAR',         label: 'Baby Wear',          baseId: 0x02, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 130 },
-    0x66: { name: 'GYMCLOTHES',       label: 'Gym Clothes',        baseId: 0x08, defaultDryLevel: 0, defaultEcoHybrid: 1, defaultTime: 60  },
-    0x67: { name: 'BLANKET',          label: 'Blanket',            baseId: 0x04, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 165 },
-    0x68: { name: 'BLANKETREFRESH',   label: 'Blanket Refresh',    baseId: null, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 30  },
-    0x69: { name: 'RAINYSEASON',      label: 'Rainy Day',          baseId: 0x0e, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 30  },
-    0x6a: { name: 'SINGLEGARMENTS',   label: 'Single Garments',    baseId: 0x0e, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 40  },
-    0x6b: { name: 'DEODORIZATION',    label: 'Deodorization',      baseId: null, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 39  },
-    0x6c: { name: 'SMALLLOAD',        label: 'Small Load',         baseId: 0x0e, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 50  },
-    0x6d: { name: 'LINGERIE',         label: 'Lingerie',           baseId: 0x0a, defaultDryLevel: 0, defaultEcoHybrid: 1, defaultTime: 50  },
-    0x6e: { name: 'EASYIRON',         label: 'Easy Ironing',       baseId: 0x19, defaultDryLevel: 1, defaultEcoHybrid: 1, defaultTime: 110 },
-    0x6f: { name: 'SUPERDRY',         label: 'Super Dry',          baseId: 0x19, defaultDryLevel: 4, defaultEcoHybrid: 3, defaultTime: 160 },
-    0x70: { name: 'ECONOMICDRY',      label: 'Economic Dry',       baseId: 0x19, defaultDryLevel: 3, defaultEcoHybrid: 1, defaultTime: 150 },
-    0x71: { name: 'BIGSIZEITEM',      label: 'Big Size Item',      baseId: 0x04, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 165 },
-    0x72: { name: 'MINIMIZEWRINKLES', label: 'Minimize Wrinkles',  baseId: 0x19, defaultDryLevel: 3, defaultEcoHybrid: 3, defaultTime: 130 },
-    0x73: { name: 'SHOESFABRICDOLL',  label: 'Shoes / Fabric Doll',baseId: 0x0c, defaultDryLevel: 0, defaultEcoHybrid: 1, defaultTime: 180 },
-    0x74: { name: 'FULLSIZELOAD',     label: 'Full Size Load',     baseId: 0x19, defaultDryLevel: 4, defaultEcoHybrid: 3, defaultTime: 160 },
+    0x65: {
+        name: 'BABYWEAR',
+        label: 'Baby Wear',
+        baseId: 0x02,
+        defaultDryLevel: 0,
+        defaultEcoHybrid: 3,
+        defaultTime: 130,
+    },
+    0x66: {
+        name: 'GYMCLOTHES',
+        label: 'Gym Clothes',
+        baseId: 0x08,
+        defaultDryLevel: 0,
+        defaultEcoHybrid: 1,
+        defaultTime: 60,
+    },
+    0x67: {
+        name: 'BLANKET',
+        label: 'Blanket',
+        baseId: 0x04,
+        defaultDryLevel: 0,
+        defaultEcoHybrid: 3,
+        defaultTime: 165,
+    },
+    0x68: {
+        name: 'BLANKETREFRESH',
+        label: 'Blanket Refresh',
+        baseId: null,
+        defaultDryLevel: 0,
+        defaultEcoHybrid: 3,
+        defaultTime: 30,
+    },
+    0x69: {
+        name: 'RAINYSEASON',
+        label: 'Rainy Day',
+        baseId: 0x0e,
+        defaultDryLevel: 0,
+        defaultEcoHybrid: 3,
+        defaultTime: 30,
+    },
+    0x6a: {
+        name: 'SINGLEGARMENTS',
+        label: 'Single Garments',
+        baseId: 0x0e,
+        defaultDryLevel: 0,
+        defaultEcoHybrid: 3,
+        defaultTime: 40,
+    },
+    0x6b: {
+        name: 'DEODORIZATION',
+        label: 'Deodorization',
+        baseId: null,
+        defaultDryLevel: 0,
+        defaultEcoHybrid: 3,
+        defaultTime: 39,
+    },
+    0x6c: {
+        name: 'SMALLLOAD',
+        label: 'Small Load',
+        baseId: 0x0e,
+        defaultDryLevel: 0,
+        defaultEcoHybrid: 3,
+        defaultTime: 50,
+    },
+    0x6d: {
+        name: 'LINGERIE',
+        label: 'Lingerie',
+        baseId: 0x0a,
+        defaultDryLevel: 0,
+        defaultEcoHybrid: 1,
+        defaultTime: 50,
+    },
+    0x6e: {
+        name: 'EASYIRON',
+        label: 'Easy Ironing',
+        baseId: 0x19,
+        defaultDryLevel: 1,
+        defaultEcoHybrid: 1,
+        defaultTime: 110,
+    },
+    0x6f: {
+        name: 'SUPERDRY',
+        label: 'Super Dry',
+        baseId: 0x19,
+        defaultDryLevel: 4,
+        defaultEcoHybrid: 3,
+        defaultTime: 160,
+    },
+    0x70: {
+        name: 'ECONOMICDRY',
+        label: 'Economic Dry',
+        baseId: 0x19,
+        defaultDryLevel: 3,
+        defaultEcoHybrid: 1,
+        defaultTime: 150,
+    },
+    0x71: {
+        name: 'BIGSIZEITEM',
+        label: 'Big Size Item',
+        baseId: 0x04,
+        defaultDryLevel: 0,
+        defaultEcoHybrid: 3,
+        defaultTime: 165,
+    },
+    0x72: {
+        name: 'MINIMIZEWRINKLES',
+        label: 'Minimize Wrinkles',
+        baseId: 0x19,
+        defaultDryLevel: 3,
+        defaultEcoHybrid: 3,
+        defaultTime: 130,
+    },
+    0x73: {
+        name: 'SHOESFABRICDOLL',
+        label: 'Shoes / Fabric Doll',
+        baseId: 0x0c,
+        defaultDryLevel: 0,
+        defaultEcoHybrid: 1,
+        defaultTime: 180,
+    },
+    0x74: {
+        name: 'FULLSIZELOAD',
+        label: 'Full Size Load',
+        baseId: 0x19,
+        defaultDryLevel: 4,
+        defaultEcoHybrid: 3,
+        defaultTime: 160,
+    },
 }
 
 // ─── Per-cycle schema ──────────────────────────────────────────────────────────
@@ -458,29 +570,29 @@ export default class Device extends AABBDevice {
 
         const Bd = buf.subarray(31)
 
-        const state        = Bd[0]
-        const remainHr     = Bd[1]
-        const remainMin    = Bd[2]
-        const initialHr    = Bd[3]
-        const initialMin   = Bd[4]
-        const cycle        = Bd[5]
-        const errorCode    = Bd[6]
-        const dryLevel     = Bd[7]
-        const ecoHybrid    = Bd[8]
+        const state = Bd[0]
+        const remainHr = Bd[1]
+        const remainMin = Bd[2]
+        const initialHr = Bd[3]
+        const initialMin = Bd[4]
+        const cycle = Bd[5]
+        const errorCode = Bd[6]
+        const dryLevel = Bd[7]
+        const ecoHybrid = Bd[8]
         const processState = Bd[9]
-        const reservation  = Bd[10]
-        const flags14      = Bd[14]
-        const flags15      = Bd[15]
+        const reservation = Bd[10]
+        const flags14 = Bd[14]
+        const flags15 = Bd[15]
         const downloadedCycleId = Bd[20]
 
         const remainingTime = remainHr * 60 + remainMin
-        const initialTime   = initialHr * 60 + initialMin
+        const initialTime = initialHr * 60 + initialMin
 
-        const isOff       = state === 0
-        const isEnd       = state === 4
-        const hasError    = errorCode !== 0
+        const isOff = state === 0
+        const isEnd = state === 4
+        const hasError = errorCode !== 0
         const remoteStart = !!(flags15 & FLAG15_REMOTE_START)
-        const antiCrease  = !!(flags14 & FLAG14_ANTI_CREASE)
+        const antiCrease = !!(flags14 & FLAG14_ANTI_CREASE)
 
         if (!this.isSelectorLocked('cycle') && cycle !== 0) {
             if (this.selectedCycle !== cycle) {
@@ -515,15 +627,15 @@ export default class Device extends AABBDevice {
         if (!this.isSelectorLocked('anti_crease')) this.selectedAntiCrease = antiCrease
         if (!this.isSelectorLocked('reservation')) this.selectedReservation = reservation
 
-        this.publishProperty('power',          isOff ? 'OFF' : 'ON')
-        this.publishProperty('run_state',      STATES[state] ?? `unknown (${state})`)
-        this.publishProperty('process_state',  PROCESS_STATES[processState] ?? `unknown (${processState})`)
+        this.publishProperty('power', isOff ? 'OFF' : 'ON')
+        this.publishProperty('run_state', STATES[state] ?? `unknown (${state})`)
+        this.publishProperty('process_state', PROCESS_STATES[processState] ?? `unknown (${processState})`)
         this.publishProperty('remaining_time', remainingTime)
-        this.publishProperty('initial_time',   initialTime)
-        this.publishProperty('remote_start',   remoteStart ? 'ON' : 'OFF')
-        this.publishProperty('run_completed',  isEnd ? 'ON' : 'OFF')
-        this.publishProperty('error',          hasError ? 'ON' : 'OFF')
-        this.publishProperty('error_message',  ERRORS[errorCode] ?? `unknown (0x${errorCode.toString(16)})`)
+        this.publishProperty('initial_time', initialTime)
+        this.publishProperty('remote_start', remoteStart ? 'ON' : 'OFF')
+        this.publishProperty('run_completed', isEnd ? 'ON' : 'OFF')
+        this.publishProperty('error', hasError ? 'ON' : 'OFF')
+        this.publishProperty('error_message', ERRORS[errorCode] ?? `unknown (0x${errorCode.toString(16)})`)
 
         if (!this.isSelectorLocked('cycle')) {
             const cycleName =
@@ -537,7 +649,10 @@ export default class Device extends AABBDevice {
             this.publishProperty('dry_level', DRY_LEVELS[this.selectedDryLevel] ?? `unknown (${this.selectedDryLevel})`)
         }
         if (!this.isSelectorLocked('eco_hybrid')) {
-            this.publishProperty('eco_hybrid', ECO_HYBRID[this.selectedEcoHybrid] ?? `unknown (${this.selectedEcoHybrid})`)
+            this.publishProperty(
+                'eco_hybrid',
+                ECO_HYBRID[this.selectedEcoHybrid] ?? `unknown (${this.selectedEcoHybrid})`,
+            )
         }
         if (!this.isSelectorLocked('anti_crease')) {
             this.publishProperty('anti_crease', antiCrease ? 'ON' : 'OFF')
@@ -556,15 +671,19 @@ export default class Device extends AABBDevice {
         }
 
         const schema = CYCLE_SCHEMA[this.selectedCycle]
-        let dryLevel  = this.selectedDryLevel
+        let dryLevel = this.selectedDryLevel
         let ecoHybrid = this.selectedEcoHybrid
         if (schema) {
             if (schema.dryLevels.length > 0 && !schema.dryLevels.includes(dryLevel)) {
-                console.warn(`[RH90V9] dry_level ${DRY_LEVELS[dryLevel]} invalid for ${CYCLES[this.selectedCycle]}, using default`)
+                console.warn(
+                    `[RH90V9] dry_level ${DRY_LEVELS[dryLevel]} invalid for ${CYCLES[this.selectedCycle]}, using default`,
+                )
                 dryLevel = schema.defaultDryLevel
             }
             if (!schema.ecoHybrids.includes(ecoHybrid)) {
-                console.warn(`[RH90V9] eco_hybrid ${ECO_HYBRID[ecoHybrid]} invalid for ${CYCLES[this.selectedCycle]}, using default`)
+                console.warn(
+                    `[RH90V9] eco_hybrid ${ECO_HYBRID[ecoHybrid]} invalid for ${CYCLES[this.selectedCycle]}, using default`,
+                )
                 ecoHybrid = schema.defaultEcoHybrid
             }
         }
@@ -579,12 +698,12 @@ export default class Device extends AABBDevice {
         // [12]   = operation (0x03=start, 0x01=resume/update)
         // [14]   = SmartCourse ID (0x00 for base courses)
         const inner = Buffer.alloc(16, 0)
-        inner[0]  = 0xf0
-        inner[1]  = 0x26
-        inner[2]  = this.selectedCycle
-        inner[3]  = dryLevel
-        inner[4]  = ecoHybrid
-        inner[8]  = this.selectedReservation
+        inner[0] = 0xf0
+        inner[1] = 0x26
+        inner[2] = this.selectedCycle
+        inner[3] = dryLevel
+        inner[4] = ecoHybrid
+        inner[8] = this.selectedReservation
         inner[11] = this.selectedAntiCrease ? 0x02 : 0x00
         inner[12] = 0x03
         return inner

--- a/rethink/cloud/devices/RH90V9_WW.ts
+++ b/rethink/cloud/devices/RH90V9_WW.ts
@@ -315,6 +315,8 @@ export default class Device extends AABBDevice {
     private selectedReservation: number = 0
 
     private safetyLockDisabled: boolean = false
+    private lastDownloadedCycleId: number = 0 // tracks last known SmartCourse ID for wake sequence
+    private cycleStartTime: Date | null = null // set when state transitions to Running
 
     private selectorLockUntil: Record<string, number> = {}
     private readonly SELECTOR_LOCK_MS = 10000
@@ -360,7 +362,7 @@ export default class Device extends AABBDevice {
                         command_topic: '$this/cycle/set',
                         name: 'Cycle',
                         icon: 'mdi:pin-outline',
-                        options: Object.values(CYCLES),
+                        options: ['None', ...Object.values(CYCLES)],
                         optimistic: false,
                     },
                     dry_level: {
@@ -451,7 +453,7 @@ export default class Device extends AABBDevice {
                         name: 'Process state',
                         icon: 'mdi:cog-outline',
                         device_class: 'enum',
-                        options: [...new Set(Object.values(PROCESS_STATES))],
+                        options: ['-', ...new Set(Object.values(PROCESS_STATES))],
                     },
                     remaining_time: {
                         platform: 'sensor',
@@ -475,6 +477,31 @@ export default class Device extends AABBDevice {
                         state_topic: '$this/run_completed',
                         name: 'Run completed',
                         icon: 'mdi:check-circle-outline',
+                    },
+                    cycle_start_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-cycle-start-time',
+                        state_topic: '$this/cycle_start_time',
+                        name: 'Cycle start time',
+                        device_class: 'timestamp',
+                        icon: 'mdi:clock-start',
+                    },
+                    cycle_end_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-cycle-end-time',
+                        state_topic: '$this/cycle_end_time',
+                        name: 'Cycle end time',
+                        device_class: 'timestamp',
+                        icon: 'mdi:clock-end',
+                    },
+                    cycle_duration: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-cycle-duration',
+                        state_topic: '$this/cycle_duration',
+                        name: 'Cycle duration',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        icon: 'mdi:timer-outline',
                     },
                     error: {
                         platform: 'binary_sensor',
@@ -563,9 +590,9 @@ export default class Device extends AABBDevice {
         //   [11-13] unknown
         //   [14] flags: bit 0x02=anti-crease
         //   [15] flags: bit 0x01=remote-start
-        //   [16-19] unknown/counter
-        //   [20] downloaded/smart cycle ID (0=none, see DOWNLOADED_CYCLES)
-        //   [21-24] unknown/marker
+        //   [16-22] unknown/counter
+        //   [23] downloaded/smart cycle ID (0=none, see DOWNLOADED_CYCLES) ✓ confirmed inner[54]
+        //   [24] unknown
 
         if (buf.length !== 56 || buf[0] !== 0x30 || buf[1] !== 0xec) return
 
@@ -584,16 +611,26 @@ export default class Device extends AABBDevice {
         const reservation = Bd[10]
         const flags14 = Bd[14]
         const flags15 = Bd[15]
-        const downloadedCycleId = Bd[20]
+        const downloadedCycleId = Bd[23] // SmartCourse/downloaded cycle ID — confirmed inner[54]=Bd[23]
+        if (downloadedCycleId) this.lastDownloadedCycleId = downloadedCycleId
 
         const remainingTime = remainHr * 60 + remainMin
         const initialTime = initialHr * 60 + initialMin
 
         const isOff = state === 0
+        const isRunning = state === 2
         const isEnd = state === 4
         const hasError = errorCode !== 0
         const remoteStart = !!(flags15 & FLAG15_REMOTE_START)
         const antiCrease = !!(flags14 & FLAG14_ANTI_CREASE)
+
+        // Track cycle start time — set on first Running packet, cleared on Off/End
+        if (isRunning && !this.cycleStartTime) {
+            this.cycleStartTime = new Date()
+            this.publishProperty('cycle_start_time', this.cycleStartTime.toISOString())
+        } else if (isOff || isEnd) {
+            this.cycleStartTime = null
+        }
 
         if (!this.isSelectorLocked('cycle') && cycle > 1) {
             if (this.selectedCycle !== cycle) {
@@ -630,21 +667,35 @@ export default class Device extends AABBDevice {
 
         this.publishProperty('power', isOff ? 'OFF' : 'ON')
         this.publishProperty('run_state', STATES[state] ?? `unknown (${state})`)
-        this.publishProperty('process_state', PROCESS_STATES[processState] ?? `unknown (${processState})`)
+        this.publishProperty(
+            'process_state',
+            isOff ? '-' : (PROCESS_STATES[processState] ?? `unknown (${processState})`),
+        )
         this.publishProperty('remaining_time', remainingTime)
         this.publishProperty('initial_time', initialTime)
         this.publishProperty('remote_start', remoteStart ? 'ON' : 'OFF')
         this.publishProperty('run_completed', isEnd ? 'ON' : 'OFF')
+
+        // Cycle timing — only meaningful while running
+        if (this.cycleStartTime) {
+            const now = new Date()
+            const durationMin = Math.floor((now.getTime() - this.cycleStartTime.getTime()) / 60000)
+            const endTime = new Date(now.getTime() + remainingTime * 60000)
+            this.publishProperty('cycle_duration', durationMin)
+            this.publishProperty('cycle_end_time', endTime.toISOString())
+        } else {
+            this.publishProperty('cycle_duration', 0)
+            this.publishProperty('cycle_end_time', '-')
+        }
         this.publishProperty('error', hasError ? 'ON' : 'OFF')
         this.publishProperty('error_message', ERRORS[errorCode] ?? `unknown (0x${errorCode.toString(16)})`)
 
         if (!this.isSelectorLocked('cycle')) {
-            // Only publish base course names to the cycle selector
-            // Downloaded cycle names are not in the options list — causes HA errors
-            // The downloaded_cycle_id sensor handles SmartCourse identification
-            if (CYCLES[cycle]) {
+            if (cycle <= 1) {
+                this.publishProperty('cycle', 'None')
+            } else if (CYCLES[cycle]) {
                 this.publishProperty('cycle', CYCLES[cycle])
-            } else if (cycle > 1) {
+            } else {
                 console.warn(`[RH90V9] Unknown cycle ID 0x${cycle.toString(16)} — not publishing to cycle selector`)
             }
         }
@@ -655,13 +706,10 @@ export default class Device extends AABBDevice {
                 : '-',
         )
         if (!this.isSelectorLocked('dry_level')) {
-            this.publishProperty('dry_level', DRY_LEVELS[this.selectedDryLevel] ?? `unknown (${this.selectedDryLevel})`)
+            this.publishProperty('dry_level', DRY_LEVELS[this.selectedDryLevel] ?? 'None')
         }
         if (!this.isSelectorLocked('eco_hybrid')) {
-            this.publishProperty(
-                'eco_hybrid',
-                ECO_HYBRID[this.selectedEcoHybrid] ?? `unknown (${this.selectedEcoHybrid})`,
-            )
+            this.publishProperty('eco_hybrid', ECO_HYBRID[this.selectedEcoHybrid] ?? 'None')
         }
         if (!this.isSelectorLocked('anti_crease')) {
             this.publishProperty('anti_crease', antiCrease ? 'ON' : 'OFF')
@@ -669,6 +717,34 @@ export default class Device extends AABBDevice {
         if (!this.isSelectorLocked('reservation')) {
             this.publishProperty('reservation', RESERVATION[reservation] ?? 'Off')
         }
+    }
+
+    // ── F0 25 SmartCourse select — used as idle safety timer reset ────────────
+    // Sending F0 25 resets the dryer's idle safety lockout, allowing F0 2A
+    // (power on) to work after the machine has been idle for 3-5+ minutes.
+    // The dryer treats F0 25 as user interaction, resetting the timer.
+    // Layout confirmed from captures:
+    //   [2]  = eco hybrid default
+    //   [3]  = 0x15 (constant)
+    //   [5]  = eco hybrid
+    //   [6]  = default time (minutes)
+    //   [14] = base course ID (or 0x00)
+    //   [15] = SmartCourse ID
+    //   [19] = dry level default
+    private buildF025(smartCourseId: number): Buffer | null {
+        const course = DOWNLOADED_CYCLES[smartCourseId]
+        if (!course) return null
+        const inner = Buffer.alloc(25, 0)
+        inner[0] = 0xf0
+        inner[1] = 0x25
+        inner[2] = course.defaultEcoHybrid
+        inner[3] = 0x15
+        inner[5] = course.defaultEcoHybrid
+        inner[6] = course.defaultTime
+        inner[14] = course.baseId ?? 0x00
+        inner[15] = smartCourseId
+        inner[19] = course.defaultDryLevel
+        return inner
     }
 
     // ── Command builder ───────────────────────────────────────────────────────
@@ -737,7 +813,21 @@ export default class Device extends AABBDevice {
                     this.publishProperty('power', 'OFF')
                     return
                 }
-                this.send(Buffer.from('F02A0100', 'hex'))
+                // F0 25 resets the idle safety timer before F0 2A power on.
+                // Dryer treats SmartCourse select as user interaction, unlocking
+                // the firmware safety gate that blocks remote power on after ~3-5min idle.
+                const wake = this.lastDownloadedCycleId ? this.buildF025(this.lastDownloadedCycleId) : null
+                if (wake) {
+                    console.log(
+                        `[RH90V9] Sending wake (F0 25 with 0x${this.lastDownloadedCycleId.toString(16)}) before power on`,
+                    )
+                    this.send(wake)
+                    setTimeout(() => this.send(Buffer.from('F02A0100', 'hex')), 500)
+                } else {
+                    // No downloaded cycle known — send power on directly (may fail if idle)
+                    console.warn('[RH90V9] No downloaded cycle known for wake sequence — sending F0 2A directly')
+                    this.send(Buffer.from('F02A0100', 'hex'))
+                }
             } else if (mqttValue === 'OFF') {
                 this.send(Buffer.from('F024010100', 'hex'))
             }
@@ -753,6 +843,7 @@ export default class Device extends AABBDevice {
         }
 
         if (prop === 'cycle') {
+            if (mqttValue === 'None') return // not a real cycle
             const id = CYCLE_IDS[mqttValue]
             if (id !== undefined) {
                 this.selectedCycle = id

--- a/rethink/cloud/devices/RH90V9_WW.ts
+++ b/rethink/cloud/devices/RH90V9_WW.ts
@@ -594,7 +594,7 @@ export default class Device extends AABBDevice {
         const remoteStart = !!(flags15 & FLAG15_REMOTE_START)
         const antiCrease = !!(flags14 & FLAG14_ANTI_CREASE)
 
-        if (!this.isSelectorLocked('cycle') && cycle !== 0) {
+        if (!this.isSelectorLocked('cycle') && cycle > 1) {
             if (this.selectedCycle !== cycle) {
                 this.selectedCycle = cycle
                 this.updateCycleOptions(cycle)
@@ -638,13 +638,21 @@ export default class Device extends AABBDevice {
         this.publishProperty('error_message', ERRORS[errorCode] ?? `unknown (0x${errorCode.toString(16)})`)
 
         if (!this.isSelectorLocked('cycle')) {
-            const cycleName =
-                downloadedCycleId && DOWNLOADED_CYCLES[downloadedCycleId]
-                    ? DOWNLOADED_CYCLES[downloadedCycleId].label
-                    : (CYCLES[cycle] ?? `unknown (0x${cycle.toString(16)})`)
-            this.publishProperty('cycle', cycleName)
+            // Only publish base course names to the cycle selector
+            // Downloaded cycle names are not in the options list — causes HA errors
+            // The downloaded_cycle_id sensor handles SmartCourse identification
+            if (CYCLES[cycle]) {
+                this.publishProperty('cycle', CYCLES[cycle])
+            } else if (cycle > 1) {
+                console.warn(`[RH90V9] Unknown cycle ID 0x${cycle.toString(16)} — not publishing to cycle selector`)
+            }
         }
-        this.publishProperty('downloaded_cycle_id', downloadedCycleId ? `0x${downloadedCycleId.toString(16)}` : '-')
+        this.publishProperty(
+            'downloaded_cycle_id',
+            downloadedCycleId
+                ? `0x${downloadedCycleId.toString(16)} (${DOWNLOADED_CYCLES[downloadedCycleId]?.label ?? 'unknown'})`
+                : '-',
+        )
         if (!this.isSelectorLocked('dry_level')) {
             this.publishProperty('dry_level', DRY_LEVELS[this.selectedDryLevel] ?? `unknown (${this.selectedDryLevel})`)
         }

--- a/rethink/cloud/devices/RH90V9_WW.ts
+++ b/rethink/cloud/devices/RH90V9_WW.ts
@@ -1,0 +1,706 @@
+import HADevice from './base'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import AABBDevice from './aabb_device'
+
+// ─── Lookup tables ─────────────────────────────────────────────────────────────
+// All indices sourced from official modelJson MonitoringValue unless noted.
+
+// Bd[0] — run state
+const STATES: Record<number, string> = {
+    0:   'Off',
+    1:   'Initial',
+    2:   'Running',
+    3:   'Paused',
+    4:   'End',
+    5:   'Error',
+    8:   'Smart Diagnosis',
+    100: 'Reserved',
+}
+
+// Bd[5] — cycle/programme ID
+// Indices from packet captures; names from modelJson Cycle.cycleValue
+const CYCLES: Record<number, string> = {
+    0x02: 'Towels',
+    0x04: 'Duvet',           // BULKYITEM
+    0x05: 'Easy Care',       // EASYCARE
+    0x06: 'Mixed Fabric',    // MIXFABRIC ✓ confirmed via API snapshot
+    0x07: 'Cotton',          // COTTONNORMAL
+    0x08: 'Sports Wear',     // SPORTWEAR
+    0x09: 'Speed 30',        // QUICKDRY
+    0x0a: 'Delicates',       // DELICATES
+    0x0b: 'Wool',            // WOOL
+    0x0c: 'Rack Dry',        // RACKDRY
+    0x0e: 'Warm Air',        // WARMAIR
+    0x10: 'Allergy Care',    // ALLERGYCARE
+    0x12: 'Condenser Care',  // CONDENSER_CARE
+    0x13: 'Drum Care',       // TUB_CLEAN
+    0x19: 'Eco (Cotton+)',   // COTTONPLUS
+}
+
+// Inverse cycle lookup for commands
+const CYCLE_IDS: Record<string, number> = Object.fromEntries(
+    Object.entries(CYCLES).map(([k, v]) => [v, Number(k)])
+)
+
+// Bd[7] — dry level (modelJson dryLevel.valueMapping indices)
+const DRY_LEVELS: Record<number, string> = {
+    0: 'None',
+    1: 'Iron Dry',      // DRYLEVEL_IRON ✓
+    3: 'Cupboard Dry',  // DRYLEVEL_CUPBOARD ✓ confirmed via API snapshot
+    4: 'Extra Dry',     // DRYLEVEL_EXTRA ✓
+}
+const DRY_LEVEL_IDS: Record<string, number> = Object.fromEntries(
+    Object.entries(DRY_LEVELS).map(([k, v]) => [v, Number(k)])
+)
+
+// Bd[8] — eco hybrid (modelJson ecoHybrid.valueMapping indices)
+const ECO_HYBRID: Record<number, string> = {
+    0: 'None',
+    1: 'Energy',   // ECOHYBRID_ECO ✓
+    2: 'Normal',   // ECOHYBRID_NORMAL
+    3: 'Time',     // ECOHYBRID_TURBO ✓ confirmed via API snapshot
+}
+const ECO_HYBRID_IDS: Record<string, number> = Object.fromEntries(
+    Object.entries(ECO_HYBRID).map(([k, v]) => [v, Number(k)])
+)
+
+// Bd[9] — process state (modelJson processState.valueMapping indices)
+const PROCESS_STATES: Record<number, string> = {
+    0: 'Detecting',
+    1: 'Steam',
+    2: 'Dry',          // DRY_LV1 ✓ confirmed via API snapshot
+    3: 'Dry',          // DRY_LV2
+    4: 'Dry',          // DRY_LV3
+    5: 'Cooling',
+    6: 'Anti-crease',
+    7: 'End',
+}
+
+// Bd[6] — error code (modelJson error.valueMapping indices)
+const ERRORS: Record<number, string> = {
+    0:  '-',
+    1:  'TE1 (temperature)',
+    2:  'TE2 (temperature)',
+    4:  'TE4 (temperature)',
+    7:  'CE1 (communication)',
+    13: 'OE (drain motor)',
+    14: 'Empty water tank',
+    15: 'dE (door open)',    // ✓ confirmed 0x0f=15
+    17: 'No filter',
+    19: 'F1',
+    20: 'LE2 (motor)',
+    21: 'AE',
+    30: 'LE1 (motor)',
+    37: 'DE4 (door)',
+    42: 'DE2 (door lock)',
+}
+
+// Reservation hours for delayed end
+// modelJson: reserveTimeHour min=3, max=19 (0=off, 1 and 2 are invalid)
+const RESERVATION: Record<number, string> = {
+    0: 'Off',
+    3: '3h', 4: '4h', 5: '5h', 6: '6h', 7: '7h',
+    8: '8h', 9: '9h', 10: '10h', 11: '11h', 12: '12h',
+    13: '13h', 14: '14h', 15: '15h', 16: '16h', 17: '17h',
+    18: '18h', 19: '19h',
+}
+const RESERVATION_IDS: Record<string, number> = Object.fromEntries(
+    Object.entries(RESERVATION).map(([k, v]) => [v, Number(k)])
+)
+
+// Flag bits
+const FLAG14_ANTI_CREASE  = 0x02  // Bd[14] ✓
+const FLAG15_REMOTE_START = 0x01  // Bd[15] ✓
+
+// Safety Lock — gates both Power On and Remote Start commands.
+// Both are potentially dangerous without someone present at the machine.
+// Must be re-acknowledged each session.
+const SAFETY_LOCK_ENABLED  = 'Enabled'
+const SAFETY_LOCK_DISABLED = 'Disabled (I accept the safety/fire risk, not recommended, use with caution, see docs for details)'
+
+// Bd[20] — downloaded/smart cycle ID
+// Each entry carries the schema from modelJson SmartCourse so defaults are correct.
+// Wire IDs marked 0x?? are not yet captured — uncomment and add the ID when known.
+// To find an ID: start the cycle, check the `downloaded_cycle_id` diagnostic sensor.
+
+type DownloadedCycle = {
+    name:             string   // modelJson courseValue
+    label:            string   // human-friendly display name
+    baseId:           number | null  // base course wire ID (Bd[5])
+    defaultDryLevel:  number
+    defaultEcoHybrid: number
+    defaultTime:      number   // minutes
+}
+
+const DOWNLOADED_CYCLES: Record<number, DownloadedCycle> = {
+    // ── Confirmed wire IDs ────────────────────────────────────────────────────
+    0x66: { name: 'GYMCLOTHES',    label: 'Gym Clothes',       baseId: 0x08, defaultDryLevel: 0, defaultEcoHybrid: 1, defaultTime: 60  },
+    0x6b: { name: 'DEODORIZATION', label: 'Deodorization',     baseId: null, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 39  },
+
+    // ── Wire ID unknown — uncomment and fill in 0x?? when captured ────────────
+    // 0x??: { name: 'SHOESFABRICDOLL',  label: 'Shoes / Fabric Doll',  baseId: 0x0c, defaultDryLevel: 0, defaultEcoHybrid: 1, defaultTime: 180 },
+    // 0x??: { name: 'BABYWEAR',         label: 'Baby Wear',             baseId: 0x02, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 130 },
+    // 0x??: { name: 'BLANKET',          label: 'Blanket',               baseId: 0x04, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 165 },
+    // 0x??: { name: 'BLANKETREFRESH',   label: 'Blanket Refresh',       baseId: null, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 30  },
+    // 0x??: { name: 'SINGLEGARMENTS',   label: 'Single Garments',       baseId: 0x0e, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 40  },
+    // 0x??: { name: 'LINGERIE',         label: 'Lingerie',              baseId: 0x0a, defaultDryLevel: 0, defaultEcoHybrid: 1, defaultTime: 50  },
+    // 0x??: { name: 'RAINYSEASON',      label: 'Rainy Season',          baseId: 0x0e, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 30  },
+    // 0x??: { name: 'SMALLLOAD',        label: 'Small Load',            baseId: 0x0e, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 50  },
+    // 0x??: { name: 'EASYIRON',         label: 'Easy Iron',             baseId: 0x19, defaultDryLevel: 1, defaultEcoHybrid: 1, defaultTime: 110 },
+    // 0x??: { name: 'SUPERDRY',         label: 'Super Dry',             baseId: 0x19, defaultDryLevel: 4, defaultEcoHybrid: 3, defaultTime: 160 },
+    // 0x??: { name: 'ECONOMICDRY',      label: 'Economic Dry',          baseId: 0x19, defaultDryLevel: 3, defaultEcoHybrid: 1, defaultTime: 150 },
+    // 0x??: { name: 'BIGSIZEITEM',      label: 'Big Size Item',         baseId: 0x04, defaultDryLevel: 0, defaultEcoHybrid: 3, defaultTime: 165 },
+    // 0x??: { name: 'MINIMIZEWRINKLES', label: 'Minimize Wrinkles',     baseId: 0x19, defaultDryLevel: 3, defaultEcoHybrid: 3, defaultTime: 130 },
+    // 0x??: { name: 'FULLSIZELOAD',     label: 'Full Size Load',        baseId: 0x19, defaultDryLevel: 4, defaultEcoHybrid: 3, defaultTime: 160 },
+}
+
+// ─── Per-cycle schema ──────────────────────────────────────────────────────────
+// Derived from modelJson Course.function — defines which dry levels and eco hybrid
+// modes are valid per cycle, plus the defaults to apply when a cycle is selected.
+
+type CycleSchema = {
+    dryLevels:        number[]  // valid dry level indices (empty = only None supported)
+    ecoHybrids:       number[]  // valid eco hybrid indices
+    defaultDryLevel:  number
+    defaultEcoHybrid: number
+}
+
+const CYCLE_SCHEMA: Record<number, CycleSchema> = {
+    0x02: { dryLevels: [],      ecoHybrids: [3],   defaultDryLevel: 0, defaultEcoHybrid: 3 }, // Towels
+    0x04: { dryLevels: [],      ecoHybrids: [3],   defaultDryLevel: 0, defaultEcoHybrid: 3 }, // Duvet
+    0x05: { dryLevels: [1,3],   ecoHybrids: [1,3], defaultDryLevel: 3, defaultEcoHybrid: 3 }, // Easy Care
+    0x06: { dryLevels: [1,3,4], ecoHybrids: [1,3], defaultDryLevel: 3, defaultEcoHybrid: 3 }, // Mixed Fabric
+    0x07: { dryLevels: [1,3,4], ecoHybrids: [3],   defaultDryLevel: 3, defaultEcoHybrid: 3 }, // Cotton
+    0x08: { dryLevels: [],      ecoHybrids: [1],   defaultDryLevel: 0, defaultEcoHybrid: 1 }, // Sports Wear
+    0x09: { dryLevels: [],      ecoHybrids: [3],   defaultDryLevel: 0, defaultEcoHybrid: 3 }, // Speed 30
+    0x0a: { dryLevels: [],      ecoHybrids: [1],   defaultDryLevel: 0, defaultEcoHybrid: 1 }, // Delicates
+    0x0b: { dryLevels: [],      ecoHybrids: [1],   defaultDryLevel: 0, defaultEcoHybrid: 1 }, // Wool
+    0x0c: { dryLevels: [],      ecoHybrids: [1],   defaultDryLevel: 0, defaultEcoHybrid: 1 }, // Rack Dry
+    0x0e: { dryLevels: [],      ecoHybrids: [1,3], defaultDryLevel: 0, defaultEcoHybrid: 1 }, // Warm Air
+    0x10: { dryLevels: [],      ecoHybrids: [3],   defaultDryLevel: 0, defaultEcoHybrid: 3 }, // Allergy Care
+    0x12: { dryLevels: [],      ecoHybrids: [3],   defaultDryLevel: 0, defaultEcoHybrid: 3 }, // Condenser Care
+    0x13: { dryLevels: [],      ecoHybrids: [3],   defaultDryLevel: 0, defaultEcoHybrid: 3 }, // Drum Care
+    0x19: { dryLevels: [1,3,4], ecoHybrids: [1,3], defaultDryLevel: 3, defaultEcoHybrid: 1 }, // Eco (Cotton+)
+}
+
+// ─── Device class ──────────────────────────────────────────────────────────────
+
+export default class Device extends AABBDevice {
+    // Pending command state — populated by selector changes, sent on start
+    private selectedCycle:      number | null = null
+    private selectedDryLevel:   number        = 0    // NO_DRYLEVEL
+    private selectedEcoHybrid:  number        = 0    // NO_ECOHYBRID
+    private selectedAntiCrease: boolean       = false
+    private selectedReservation: number       = 0    // Off
+
+    // Safety lock — gates Power On and Remote Start, resets each session
+    private safetyLockDisabled: boolean = false
+
+    // Debounce: suppress state-packet selector updates briefly after user edits
+    private selectorLockUntil: Record<string, number> = {}
+    private readonly SELECTOR_LOCK_MS = 10000
+
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: 'LG Dryer' }),
+                components: {
+                    // ── Safety Lock ──────────────────────────────────────────
+                    // Gates Power On and Remote Start — both can operate the dryer
+                    // without anyone present. Matches the physical Safety Lock button
+                    // on the machine. Resets to Enabled each session.
+                    safety_lock: {
+                        platform: 'select',
+                        unique_id: '$deviceid-safety-lock',
+                        state_topic: '$this/safety_lock',
+                        command_topic: '$this/safety_lock/set',
+                        name: '🔒 Safety Lock',
+                        icon: 'mdi:lock-alert-outline',
+                        options: [
+                            SAFETY_LOCK_ENABLED,
+                            SAFETY_LOCK_DISABLED,
+                        ],
+                        entity_category: 'config',
+                    },
+                    // Power ON — works at wire level but rejected by LG cloud.
+                    // Gated behind Safety Lock.
+                    power: {
+                        platform: 'switch',
+                        unique_id: '$deviceid-power',
+                        state_topic: '$this/power',
+                        command_topic: '$this/power/set',
+                        name: '',
+                        icon: 'mdi:tumble-dryer',
+                    },
+                    // Remote Start — read-only status indicator
+                    // Reflects whether the machine has remote start armed physically
+                    // Cannot be armed remotely — must be done on the machine
+                    remote_start: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-remote-start',
+                        state_topic: '$this/remote_start',
+                        name: 'Remote Start',
+                        icon: 'mdi:remote',
+                    },
+
+                    // ── Cycle controls ───────────────────────────────────────
+                    cycle: {
+                        platform: 'select',
+                        unique_id: '$deviceid-cycle',
+                        state_topic: '$this/cycle',
+                        command_topic: '$this/cycle/set',
+                        name: 'Cycle',
+                        icon: 'mdi:pin-outline',
+                        options: Object.values(CYCLES),
+                        optimistic: false,
+                    },
+                    dry_level: {
+                        platform: 'select',
+                        unique_id: '$deviceid-dry-level',
+                        state_topic: '$this/dry_level',
+                        command_topic: '$this/dry_level/set',
+                        name: 'Dry level',
+                        icon: 'mdi:water-percent',
+                        options: Object.values(DRY_LEVELS),
+                        optimistic: false,
+                    },
+                    eco_hybrid: {
+                        platform: 'select',
+                        unique_id: '$deviceid-eco-hybrid',
+                        state_topic: '$this/eco_hybrid',
+                        command_topic: '$this/eco_hybrid/set',
+                        name: 'Eco hybrid',
+                        icon: 'mdi:leaf',
+                        options: Object.values(ECO_HYBRID),
+                        optimistic: false,
+                    },
+                    anti_crease: {
+                        platform: 'switch',
+                        unique_id: '$deviceid-anti-crease',
+                        state_topic: '$this/anti_crease',
+                        command_topic: '$this/anti_crease/set',
+                        name: 'Anti-crease',
+                        icon: 'mdi:iron-outline',
+                        optimistic: false,
+                    },
+                    reservation: {
+                        platform: 'select',
+                        unique_id: '$deviceid-reservation',
+                        state_topic: '$this/reservation',
+                        command_topic: '$this/reservation/set',
+                        name: 'Delayed end',
+                        icon: 'mdi:clock-end',
+                        options: Object.values(RESERVATION),
+                        optimistic: false,
+                    },
+
+                    // ── Actions ──────────────────────────────────────────────
+                    start: {
+                        platform: 'button',
+                        unique_id: '$deviceid-start',
+                        command_topic: '$this/start/set',
+                        payload_press: '',
+                        name: 'Start',
+                        icon: 'mdi:play-circle-outline',
+                    },
+                    pause: {
+                        platform: 'button',
+                        unique_id: '$deviceid-pause',
+                        command_topic: '$this/pause/set',
+                        payload_press: '',
+                        name: 'Pause',
+                        icon: 'mdi:pause-circle-outline',
+                    },
+
+                    // ── Status sensors ───────────────────────────────────────
+                    run_state: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-run-state',
+                        state_topic: '$this/run_state',
+                        name: 'Run state',
+                        icon: 'mdi:state-machine',
+                        device_class: 'enum',
+                        options: [...new Set(Object.values(STATES))],
+                    },
+                    process_state: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-process-state',
+                        state_topic: '$this/process_state',
+                        name: 'Process state',
+                        icon: 'mdi:cog-outline',
+                        device_class: 'enum',
+                        options: [...new Set(Object.values(PROCESS_STATES))],
+                    },
+                    remaining_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-remaining-time',
+                        state_topic: '$this/remaining_time',
+                        name: 'Remaining time',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                    },
+                    initial_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-initial-time',
+                        state_topic: '$this/initial_time',
+                        name: 'Initial time',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                    },
+                    run_completed: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-run-completed',
+                        state_topic: '$this/run_completed',
+                        name: 'Run completed',
+                        icon: 'mdi:check-circle-outline',
+                    },
+                    error: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-error',
+                        state_topic: '$this/error',
+                        name: 'Error state',
+                        icon: 'mdi:check-circle',
+                        device_class: 'problem',
+                        entity_category: 'diagnostic',
+                    },
+                    error_message: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-error-message',
+                        state_topic: '$this/error_message',
+                        name: 'Error message',
+                        icon: 'mdi:alert-circle-outline',
+                        entity_category: 'diagnostic',
+                    },
+                    downloaded_cycle_id: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-downloaded-cycle-id',
+                        state_topic: '$this/downloaded_cycle_id',
+                        name: 'Downloaded cycle ID',
+                        icon: 'mdi:download-circle-outline',
+                        entity_category: 'diagnostic',
+                    },
+                },
+            }),
+        )
+
+        // Safety lock always starts enabled — resets each session
+        this.publishProperty('safety_lock', SAFETY_LOCK_ENABLED)
+
+        // Reservation starts at Off
+        this.publishProperty('reservation', 'Off')
+    }
+
+    // ── Selector lock helpers ─────────────────────────────────────────────────
+
+    private lockSelector(prop: string) {
+        this.selectorLockUntil[prop] = Date.now() + this.SELECTOR_LOCK_MS
+    }
+
+    private isSelectorLocked(prop: string): boolean {
+        return Date.now() < (this.selectorLockUntil[prop] ?? 0)
+    }
+
+    // ── Dynamic options update ────────────────────────────────────────────────
+
+    // When cycle changes, update dry_level and eco_hybrid selector options
+    // to only show valid options for that cycle, reset to defaults, republish
+    // config, then immediately re-publish state values to prevent "unknown" flash.
+    private updateCycleOptions(cycleId: number) {
+        const schema = CYCLE_SCHEMA[cycleId]
+        if (!schema || !this.config) return
+
+        const dryOptions = schema.dryLevels.length > 0
+            ? schema.dryLevels.map(id => DRY_LEVELS[id])
+            : [DRY_LEVELS[0]]  // None only — selector will be hidden via availability
+
+        const ecoOptions = schema.ecoHybrids.map(id => ECO_HYBRID[id])
+
+        // Mutate config in place and republish
+        ;(this.config.components.dry_level  as any).options = dryOptions
+        ;(this.config.components.eco_hybrid as any).options = ecoOptions
+
+        // Apply defaults for this cycle
+        this.selectedDryLevel  = schema.defaultDryLevel
+        this.selectedEcoHybrid = schema.defaultEcoHybrid
+
+        // Republish full device config with updated options
+        this.publishConfig()
+
+        // Re-publish current values immediately to prevent "unknown" flash
+        this.publishProperty('dry_level',  DRY_LEVELS[this.selectedDryLevel]  ?? 'None')
+        this.publishProperty('eco_hybrid', ECO_HYBRID[this.selectedEcoHybrid] ?? 'None')
+    }
+
+    // ── State packet processing ───────────────────────────────────────────────
+
+    processAABB(buf: Buffer) {
+        // Packet: AA + len + inner(56) + chk + BB
+        // inner: header(4: 30 EC 00 19) + A block(26) + B block(26)
+        // B block: B[0]=0x19 marker, Bd=B[1..25] = current state (authoritative)
+        //
+        // Confirmed Bd field map (modelJson indices unless noted):
+        //   [0]  run state
+        //   [1]  remain hours
+        //   [2]  remain minutes
+        //   [3]  initial hours
+        //   [4]  initial minutes
+        //   [5]  cycle ID
+        //   [6]  error code
+        //   [7]  dry level
+        //   [8]  eco hybrid
+        //   [9]  process state
+        //   [10]  reservation hours (0=off, 3-19=delayed end)
+        //   [11-13] unknown
+        //   [14] flags: bit 0x02=anti-crease
+        //   [15] flags: bit 0x01=remote-start
+        //   [16-19] unknown/counter
+        //   [20] downloaded/smart cycle ID (0=none, see DOWNLOADED_CYCLES)
+        //   [21-24] unknown/marker
+
+        if (buf.length !== 56 || buf[0] !== 0x30 || buf[1] !== 0xec) return
+
+        const Bd = buf.subarray(31) // 25 bytes after 0x19 marker
+
+        const state        = Bd[0]
+        const remainHr     = Bd[1]
+        const remainMin    = Bd[2]
+        const initialHr    = Bd[3]
+        const initialMin   = Bd[4]
+        const cycle        = Bd[5]
+        const errorCode    = Bd[6]
+        const dryLevel     = Bd[7]
+        const ecoHybrid    = Bd[8]
+        const processState = Bd[9]
+        const reservation      = Bd[10]  // reservation hours (0=off, 3-19=delayed end)
+        const flags14          = Bd[14]
+        const flags15          = Bd[15]
+        const downloadedCycleId = Bd[20] // SmartCourse/downloaded cycle ID (0=none)
+
+        const remainingTime = remainHr * 60 + remainMin
+        const initialTime   = initialHr * 60 + initialMin
+
+        const isOff       = state === 0
+        const isEnd       = state === 4
+        const hasError    = errorCode !== 0
+        const remoteStart = !!(flags15 & FLAG15_REMOTE_START)
+        const antiCrease  = !!(flags14 & FLAG14_ANTI_CREASE)
+
+        // Sync pending command state from machine — respects selector lock
+        // so in-progress HA edits aren't clobbered by incoming state packets.
+        // When cycle changes from the machine side, also update options.
+        if (!this.isSelectorLocked('cycle') && cycle !== 0) {
+            if (this.selectedCycle !== cycle) {
+                this.selectedCycle = cycle
+                this.updateCycleOptions(cycle)
+            }
+        }
+
+        // Sync dry level and eco hybrid from packet, but apply schema defaults
+        // if the packet reports None/0 for a field the cycle actually supports.
+        // This handles the case where the machine is in standby with a cycle selected
+        // but hasn't set the options yet, or reports 0 before user interaction.
+        const schema = this.selectedCycle !== null ? CYCLE_SCHEMA[this.selectedCycle] : null
+        if (!this.isSelectorLocked('dry_level')) {
+            let effectiveDryLevel: number
+            if (!schema || schema.dryLevels.length === 0) {
+                effectiveDryLevel = 0  // cycle has no dry level support — always None
+            } else if (schema.dryLevels.includes(dryLevel)) {
+                effectiveDryLevel = dryLevel  // valid for this cycle
+            } else {
+                effectiveDryLevel = schema.defaultDryLevel  // stale/invalid — use default
+            }
+            this.selectedDryLevel = effectiveDryLevel
+        }
+        if (!this.isSelectorLocked('eco_hybrid')) {
+            let effectiveEcoHybrid: number
+            if (!schema || schema.ecoHybrids.length === 0) {
+                effectiveEcoHybrid = 0  // no eco hybrid support
+            } else if (schema.ecoHybrids.includes(ecoHybrid)) {
+                effectiveEcoHybrid = ecoHybrid  // valid for this cycle
+            } else {
+                effectiveEcoHybrid = schema.defaultEcoHybrid  // stale/invalid — use default
+            }
+            this.selectedEcoHybrid = effectiveEcoHybrid
+        }
+        if (!this.isSelectorLocked('anti_crease'))  this.selectedAntiCrease  = antiCrease
+        if (!this.isSelectorLocked('reservation'))  this.selectedReservation = reservation
+
+        // Publish status sensors
+        this.publishProperty('power',          isOff ? 'OFF' : 'ON')
+        this.publishProperty('run_state',      STATES[state]              ?? `unknown (${state})`)
+        this.publishProperty('process_state',  PROCESS_STATES[processState] ?? `unknown (${processState})`)
+        this.publishProperty('remaining_time', remainingTime)
+        this.publishProperty('initial_time',   initialTime)
+        this.publishProperty('remote_start',   remoteStart ? 'ON' : 'OFF')
+        this.publishProperty('run_completed',  isEnd ? 'ON' : 'OFF')
+        this.publishProperty('error',          hasError ? 'ON' : 'OFF')
+        this.publishProperty('error_message',  ERRORS[errorCode] ?? `unknown (0x${errorCode.toString(16)})`)
+
+        // Publish selectors (only if not locked by a recent user edit)
+        if (!this.isSelectorLocked('cycle')) {
+            // If a downloaded SmartCourse is active, show its name instead of the base cycle
+            const cycleName = (downloadedCycleId && DOWNLOADED_CYCLES[downloadedCycleId])
+                ? DOWNLOADED_CYCLES[downloadedCycleId].label
+                : CYCLES[cycle] ?? `unknown (0x${cycle.toString(16)})`
+            this.publishProperty('cycle', cycleName)
+        }
+        this.publishProperty('downloaded_cycle_id',
+            downloadedCycleId ? `0x${downloadedCycleId.toString(16)}` : '-'
+        )
+        if (!this.isSelectorLocked('dry_level')) {
+            this.publishProperty('dry_level',  DRY_LEVELS[this.selectedDryLevel]  ?? `unknown (${this.selectedDryLevel})`)
+        }
+        if (!this.isSelectorLocked('eco_hybrid')) {
+            this.publishProperty('eco_hybrid', ECO_HYBRID[this.selectedEcoHybrid] ?? `unknown (${this.selectedEcoHybrid})`)
+        }
+        if (!this.isSelectorLocked('anti_crease')) {
+            this.publishProperty('anti_crease', antiCrease ? 'ON' : 'OFF')
+        }
+        if (!this.isSelectorLocked('reservation')) {
+            this.publishProperty('reservation', RESERVATION[reservation] ?? 'Off')
+        }
+    }
+
+    // ── Command builder ───────────────────────────────────────────────────────
+
+    private buildStartCommand(): Buffer | null {
+        if (this.selectedCycle === null) {
+            console.warn('[RH90V9] Start ignored: no cycle selected')
+            return null
+        }
+
+        // Enforce per-cycle schema at send time — safety net for raw JSON commands
+        // or any case where selectors get out of sync with the schema.
+        // Also handles downloaded cycles which have their own defaults.
+        const schema = CYCLE_SCHEMA[this.selectedCycle]
+        let dryLevel  = this.selectedDryLevel
+        let ecoHybrid = this.selectedEcoHybrid
+        if (schema) {
+            if (schema.dryLevels.length > 0 && !schema.dryLevels.includes(dryLevel)) {
+                console.warn(`[RH90V9] dry_level ${DRY_LEVELS[dryLevel]} invalid for ${CYCLES[this.selectedCycle]}, using default`)
+                dryLevel = schema.defaultDryLevel
+            }
+            if (!schema.ecoHybrids.includes(ecoHybrid)) {
+                console.warn(`[RH90V9] eco_hybrid ${ECO_HYBRID[ecoHybrid]} invalid for ${CYCLES[this.selectedCycle]}, using default`)
+                ecoHybrid = schema.defaultEcoHybrid
+            }
+        }
+
+        // inner layout (confirmed from captures):
+        // [0-1]  = F0 26 opcode
+        // [2]    = cycle ID
+        // [3]    = dry level
+        // [4]    = eco hybrid
+        // [8]    = reservation hours (0=off, 3-19=delayed end)
+        // [11]   = anti-crease (0x00=off, 0x02=on)
+        // [12]   = operation (0x03=start, 0x01=resume/update)
+        // [14]   = SmartCourse ID (0x00 for base courses)
+        const inner = Buffer.alloc(16, 0)
+        inner[0]  = 0xf0
+        inner[1]  = 0x26
+        inner[2]  = this.selectedCycle
+        inner[3]  = dryLevel
+        inner[4]  = ecoHybrid
+        inner[8]  = this.selectedReservation
+        inner[11] = this.selectedAntiCrease ? 0x02 : 0x00
+        inner[12] = 0x03  // start new cycle
+        return inner
+    }
+
+    // ── HA command handler ────────────────────────────────────────────────────
+
+    setProperty(prop: string, mqttValue: string) {
+        // Safety lock
+        if (prop === 'safety_lock') {
+            this.safetyLockDisabled = mqttValue === SAFETY_LOCK_DISABLED
+            this.publishProperty('safety_lock', mqttValue)
+            return
+        }
+
+        // Power ON — gated behind safety lock
+        // Wire-level confirmed working (aa08f02a010098bb)
+        // Rejected by LG cloud: "Not support dryer_operation_mode: POWER_ON"
+        if (prop === 'power') {
+            if (mqttValue === 'ON') {
+                if (!this.safetyLockDisabled) {
+                    console.warn('[RH90V9] Power on blocked — disable Safety Lock first')
+                    this.publishProperty('power', 'OFF')
+                    return
+                }
+                this.send(Buffer.from('F02A0100', 'hex'))
+            } else if (mqttValue === 'OFF') {
+                // Confirmed: aa09f0240101009cbb
+                this.send(Buffer.from('F024010100', 'hex'))
+            }
+            return
+        }
+
+        // Cycle — also triggers dynamic options update for dry_level and eco_hybrid
+        if (prop === 'cycle') {
+            const id = CYCLE_IDS[mqttValue]
+            if (id !== undefined) {
+                this.selectedCycle = id
+                this.lockSelector('cycle')
+                this.lockSelector('dry_level')
+                this.lockSelector('eco_hybrid')
+                this.publishProperty('cycle', mqttValue)
+                this.updateCycleOptions(id)
+            }
+            return
+        }
+
+        if (prop === 'dry_level') {
+            const id = DRY_LEVEL_IDS[mqttValue]
+            if (id !== undefined) {
+                this.selectedDryLevel = id
+                this.lockSelector('dry_level')
+                this.publishProperty('dry_level', mqttValue)
+            }
+            return
+        }
+
+        if (prop === 'eco_hybrid') {
+            const id = ECO_HYBRID_IDS[mqttValue]
+            if (id !== undefined) {
+                this.selectedEcoHybrid = id
+                this.lockSelector('eco_hybrid')
+                this.publishProperty('eco_hybrid', mqttValue)
+            }
+            return
+        }
+
+        if (prop === 'anti_crease') {
+            this.selectedAntiCrease = mqttValue === 'ON'
+            this.lockSelector('anti_crease')
+            this.publishProperty('anti_crease', mqttValue)
+            return
+        }
+
+        if (prop === 'reservation') {
+            const hours = RESERVATION_IDS[mqttValue]
+            if (hours !== undefined) {
+                this.selectedReservation = hours
+                this.lockSelector('reservation')
+                this.publishProperty('reservation', mqttValue)
+            }
+            return
+        }
+
+        // Pause — confirmed: aa09f02404010099bb
+        if (prop === 'pause') {
+            this.send(Buffer.from('F024040100', 'hex'))
+            return
+        }
+
+        // Start / Resume
+        if (prop === 'start') {
+            const cmd = this.buildStartCommand()
+            if (cmd) this.send(cmd)
+            return
+        }
+    }
+}

--- a/rethink/cloud/devices/RH90V9_WW.ts
+++ b/rethink/cloud/devices/RH90V9_WW.ts
@@ -531,8 +531,9 @@ export default class Device extends AABBDevice {
         ;(this.config.components.dry_level as any).options = dryOptions
         ;(this.config.components.eco_hybrid as any).options = ecoOptions
 
-        this.selectedDryLevel = schema.defaultDryLevel
-        this.selectedEcoHybrid = schema.defaultEcoHybrid
+        // Apply defaults — only if not locked by a recent user edit
+        if (!this.isSelectorLocked('dry_level')) this.selectedDryLevel = schema.defaultDryLevel
+        if (!this.isSelectorLocked('eco_hybrid')) this.selectedEcoHybrid = schema.defaultEcoHybrid
 
         this.publishConfig()
 
@@ -682,7 +683,10 @@ export default class Device extends AABBDevice {
         let dryLevel = this.selectedDryLevel
         let ecoHybrid = this.selectedEcoHybrid
         if (schema) {
-            if (schema.dryLevels.length > 0 && !schema.dryLevels.includes(dryLevel)) {
+            if (schema.dryLevels.length === 0) {
+                // Cycle has no dry level support — always force None
+                dryLevel = 0
+            } else if (!schema.dryLevels.includes(dryLevel)) {
                 console.warn(
                     `[RH90V9] dry_level ${DRY_LEVELS[dryLevel]} invalid for ${CYCLES[this.selectedCycle]}, using default`,
                 )

--- a/rethink/cloud/devices/aabb_device.ts
+++ b/rethink/cloud/devices/aabb_device.ts
@@ -41,4 +41,8 @@ export default class AABBDevice extends HADevice {
         this.publishCache[prop] = value
         this.HA.publishProperty(this.id, prop, value)
     }
+
+    getProperty(prop: string): string | number | undefined {
+        return this.publishCache[prop]
+    }
 }

--- a/rethink/cloud/ha_bridge.ts
+++ b/rethink/cloud/ha_bridge.ts
@@ -5,6 +5,7 @@ import Dev_2REF11EIDA__4 from './devices/2REF11EIDA__4'
 import Dev_2RES1VE61NFA2 from './devices/2RES1VE61NFA2'
 import Dev_2REB1GLVB1__2 from './devices/2REB1GLVB1__2'
 import Dev_2RES1VE600FWC from './devices/2RES1VE600FWC'
+import RH90V9_WW from './devices/RH90V9_WW'
 import Y_V8_Y___W_B32QEUK from './devices/Y_V8_Y___W.B32QEUK'
 import F_V8_Y___W_B_2QEUK from './devices/F_V8_Y___W.B_2QEUK'
 import F_V__F___W_B_1QEUK from './devices/F_V__F___W.B_1QEUK'
@@ -25,6 +26,7 @@ const t1deviceTypes: Record<string, T1Factory> = {
 const t2deviceTypes: Record<string, T2Factory> = {
     RAC_056905_WW,
     WIN_056905_WW,
+    RH90V9_WW,
     ['2REF11EIDA__4']: Dev_2REF11EIDA__4,
     ['2RES1VE61NFA2']: Dev_2RES1VE61NFA2,
     ['2REB1GLVB1__2']: Dev_2REB1GLVB1__2,

--- a/rethink/cloud/thinq2/provisioning.ts
+++ b/rethink/cloud/thinq2/provisioning.ts
@@ -11,6 +11,7 @@ export function routes(config: Config, ca: CA) {
             result: {
                 apiServer: 'https://' + config.hostname + ':' + config.https_port,
                 mqttServer: 'ssl://' + config.hostname + ':' + config.mqtts_port,
+                httpsServer: 'https://' + config.hostname + ':' + config.https_port,
             },
         })
     })

--- a/rethink/tests/cloud/devices/RH90V9_WW.test.ts
+++ b/rethink/tests/cloud/devices/RH90V9_WW.test.ts
@@ -63,14 +63,9 @@ const SAMPLE_DOWNLOADED = buf(
     'AA3830EC001900000000000000000000000000000000000000000000000000001902000000000800000000000000000000000000000000006600A3BB',
 )
 
-// Speed 30 — no dry level, Time eco hybrid
+// Speed 30 — no dry level (Bd[7]=0), Time eco hybrid
 const SAMPLE_SPEED30 = buf(
     'AA3830EC001900000000000000000000000000000000000000000000000000001901000000000900000300000000000000000000000000000000C6BB',
-)
-
-// Towels with stale dry level from previous cycle (Bd[7]=3 but Towels has no dry level)
-const SAMPLE_TOWELS_STALE_DRY = buf(
-    'AA3830EC001900000000000000000000000000000000000000000000000000001901000000000200030300000000000000000000000000000000DABB',
 )
 
 // Expected outgoing command bytes
@@ -95,7 +90,6 @@ describe(MODEL_ID, () => {
         assert.ok(cfg, 'config published')
         const components = cfg!.components as Record<string, Record<string, unknown>>
         for (const c of [
-            'safety_lock',
             'power',
             'remote_start',
             'cycle',
@@ -119,12 +113,15 @@ describe(MODEL_ID, () => {
         }
     })
 
-    test('safety lock starts enabled', () => {
+    test('cycle is a read-only sensor (no command_topic)', () => {
         const { ha } = makeDevice()
-        assert.equal(ha.devices[DEVICE_ID].properties.safety_lock, 'Enabled')
+        const cfg = ha.devices[DEVICE_ID].config!
+        const cycle = (cfg.components as any).cycle
+        assert.equal(cycle.platform, 'sensor')
+        assert.ok(!cycle.command_topic, 'no command_topic on cycle sensor')
     })
 
-    test('cycle selector contains all 15 base courses', () => {
+    test('cycle sensor lists all 15 base courses', () => {
         const { ha } = makeDevice()
         const cfg = ha.devices[DEVICE_ID].config!
         const options = (cfg.components as any).cycle.options as string[]
@@ -228,48 +225,26 @@ describe(MODEL_ID, () => {
         assert.equal(ha.devices[DEVICE_ID].properties.reservation, '4h')
     })
 
-    test('downloaded cycle ID decoded from Bd[20]', () => {
+    test('downloaded cycle ID decoded from Bd[23]', () => {
         const { ha, thinq } = makeDevice()
         thinq.emit('data', SAMPLE_DOWNLOADED)
         const props = ha.devices[DEVICE_ID].properties
         assert.equal(props.downloaded_cycle_id, '0x66 (Gym Clothes)')
-        // Base course (Sports Wear) still shows in cycle selector
+        // Base course (Sports Wear) still shown in cycle sensor
         assert.equal(props.cycle, 'Sports Wear')
     })
 
-    // ── Schema enforcement ────────────────────────────────────────────────────
-
-    test('Speed 30 — dry level forced to None (not supported)', () => {
+    test('Speed 30 — dry level published as None (Bd[7]=0)', () => {
         const { ha, thinq } = makeDevice()
         thinq.emit('data', SAMPLE_SPEED30)
         assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'None')
         assert.equal(ha.devices[DEVICE_ID].properties.eco_hybrid, 'Time')
     })
 
-    test('Towels — stale dry level from previous cycle corrected to None', () => {
+    test('cycle shows None when dryer is off', () => {
         const { ha, thinq } = makeDevice()
-        // Packet has Bd[7]=3 (Cupboard Dry) but Towels has no dry level support
-        thinq.emit('data', SAMPLE_TOWELS_STALE_DRY)
-        assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'None')
-    })
-
-    test('updateCycleOptions — Mixed Fabric shows correct dry level options', () => {
-        const { ha, thinq } = makeDevice()
-        thinq.emit('data', SAMPLE_INITIAL) // Mixed Fabric
-        const cfg = ha.devices[DEVICE_ID].config!
-        const options = (cfg.components as any).dry_level.options as string[]
-        assert.ok(options.includes('Iron Dry'))
-        assert.ok(options.includes('Cupboard Dry'))
-        assert.ok(options.includes('Extra Dry'))
-        assert.ok(!options.includes('None'))
-    })
-
-    test('unknown cycle IDs (0x00, 0x01) are not published to cycle selector', () => {
-        const { ha, thinq } = makeDevice()
-        thinq.emit('data', SAMPLE_OFF) // cycle=0x00
-        // cycle selector should not be updated with unknown values
-        const props = ha.devices[DEVICE_ID].properties
-        assert.ok(!props.cycle || !props.cycle.startsWith('unknown'))
+        thinq.emit('data', SAMPLE_OFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.cycle, 'None')
     })
 
     // ── Commands ──────────────────────────────────────────────────────────────
@@ -290,25 +265,6 @@ describe(MODEL_ID, () => {
         assert.ok(hex(thinq.outbox[0]).includes(WRITE_POWER_OFF))
     })
 
-    test('power ON blocked when safety lock enabled', () => {
-        const { thinq, dev } = makeDevice()
-        thinq.resetRecorder()
-        dev.setProperty('power', 'ON') // safety lock is enabled by default
-        assert.equal(thinq.outbox.length, 0)
-    })
-
-    test('power ON allowed when safety lock disabled', () => {
-        const { thinq, dev } = makeDevice()
-        dev.setProperty(
-            'safety_lock',
-            'Disabled (I accept the safety/fire risk, not recommended, use with caution, see docs for details)',
-        )
-        thinq.resetRecorder()
-        dev.setProperty('power', 'ON')
-        assert.equal(thinq.outbox.length, 1)
-        assert.ok(hex(thinq.outbox[0]).includes(WRITE_POWER_ON))
-    })
-
     test('pause sends confirmed command', () => {
         const { thinq, dev } = makeDevice()
         thinq.resetRecorder()
@@ -317,23 +273,21 @@ describe(MODEL_ID, () => {
         assert.ok(hex(thinq.outbox[0]).includes(WRITE_PAUSE))
     })
 
-    test('start with no cycle selected sends nothing', () => {
+    test('start with no cycle known sends nothing', () => {
         const { thinq, dev } = makeDevice()
         thinq.resetRecorder()
-        dev.setProperty('start', '')
+        dev.setProperty('start', '') // lastBdCycle=0, no cycle known
         assert.equal(thinq.outbox.length, 0)
     })
 
-    test('start after cycle selected sends F0 26 command with correct fields', () => {
+    test('start with JSON payload sends F0 26 command with correct fields', () => {
         const { thinq, dev } = makeDevice()
-        dev.setProperty('cycle', 'Mixed Fabric') // cycle ID 0x06
-        dev.setProperty('dry_level', 'Cupboard Dry') // dry level 3
-        dev.setProperty('eco_hybrid', 'Time') // eco hybrid 3
         thinq.resetRecorder()
-        dev.setProperty('start', '')
+        dev.setProperty(
+            'start',
+            JSON.stringify({ cycle: 'Mixed Fabric', dry_level: 'Cupboard Dry', eco_hybrid: 'Time' }),
+        )
         assert.equal(thinq.outbox.length, 1)
-        // outbox[0] is the raw inner buffer passed to send()
-        // find F0 26 opcode — either raw inner or AABB-wrapped
         const raw = thinq.outbox[0]
         const inner = raw[0] === 0xaa ? raw.subarray(2, raw.length - 2) : raw
         assert.equal(inner[0], 0xf0) // opcode
@@ -344,36 +298,55 @@ describe(MODEL_ID, () => {
         assert.equal(inner[12], 0x03) // start operation
     })
 
-    test('start with reservation sets inner[8]', () => {
+    test('start falls back to last Bd values when payload is empty', () => {
         const { thinq, dev } = makeDevice()
-        dev.setProperty('cycle', 'Mixed Fabric')
-        dev.setProperty('reservation', '4h')
+        thinq.emit('data', SAMPLE_INITIAL) // Mixed Fabric, Cupboard Dry, Time
         thinq.resetRecorder()
-        dev.setProperty('start', '')
+        dev.setProperty('start', '') // no JSON — use Bd fallback
+        assert.equal(thinq.outbox.length, 1)
+        const raw = thinq.outbox[0]
+        const inner = raw[0] === 0xaa ? raw.subarray(2, raw.length - 2) : raw
+        assert.equal(inner[2], 0x06) // Mixed Fabric
+        assert.equal(inner[3], 3) // Cupboard Dry
+        assert.equal(inner[4], 3) // Time
+    })
+
+    test('start with JSON reservation sets inner[8]', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('start', JSON.stringify({ cycle: 'Mixed Fabric', reservation: '4h' }))
         assert.equal(thinq.outbox.length, 1)
         const raw = thinq.outbox[0]
         const inner = raw[0] === 0xaa ? raw.subarray(2, raw.length - 2) : raw
         assert.equal(inner[8], 4) // 4h delayed end
     })
 
-    test('start with anti-crease sets inner[11]', () => {
+    test('start with JSON anti_crease sets inner[11]', () => {
         const { thinq, dev } = makeDevice()
-        dev.setProperty('cycle', 'Mixed Fabric')
-        dev.setProperty('anti_crease', 'ON')
         thinq.resetRecorder()
-        dev.setProperty('start', '')
+        dev.setProperty('start', JSON.stringify({ cycle: 'Mixed Fabric', anti_crease: true }))
         assert.equal(thinq.outbox.length, 1)
         const raw = thinq.outbox[0]
         const inner = raw[0] === 0xaa ? raw.subarray(2, raw.length - 2) : raw
         assert.equal(inner[11], 0x02) // anti-crease on
     })
 
-    test('start enforces schema — Speed 30 corrects invalid dry level', () => {
-        const { thinq, dev } = makeDevice()
-        dev.setProperty('cycle', 'Speed 30') // no dry level support
-        dev.setProperty('dry_level', 'Cupboard Dry') // invalid for Speed 30
+    test('anti_crease switch toggle used as start fallback', () => {
+        const { ha, thinq, dev } = makeDevice()
+        dev.setProperty('anti_crease', 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.anti_crease, 'ON')
         thinq.resetRecorder()
-        dev.setProperty('start', '')
+        dev.setProperty('start', JSON.stringify({ cycle: 'Mixed Fabric' })) // no anti_crease in payload
+        assert.equal(thinq.outbox.length, 1)
+        const raw = thinq.outbox[0]
+        const inner = raw[0] === 0xaa ? raw.subarray(2, raw.length - 2) : raw
+        assert.equal(inner[11], 0x02) // anti-crease from switch state
+    })
+
+    test('start enforces schema — Speed 30 corrects invalid dry level to None', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('start', JSON.stringify({ cycle: 'Speed 30', dry_level: 'Cupboard Dry' })) // invalid for Speed 30
         assert.equal(thinq.outbox.length, 1)
         const raw = thinq.outbox[0]
         const inner = raw[0] === 0xaa ? raw.subarray(2, raw.length - 2) : raw
@@ -385,69 +358,6 @@ describe(MODEL_ID, () => {
         thinq.resetRecorder()
         dev.setProperty('does-not-exist', 'whatever')
         assert.equal(thinq.outbox.length, 0)
-    })
-
-    // ── Selector lock ─────────────────────────────────────────────────────────
-
-    test('selector lock prevents state packet from overwriting user edit', () => {
-        const { ha, thinq, dev } = makeDevice()
-        // Set cycle first (so cycle lock doesn't interfere with dry_level)
-        thinq.emit('data', SAMPLE_INITIAL) // Mixed Fabric — sets cycle, locks it
-        // User then picks Extra Dry — locks dry_level
-        dev.setProperty('dry_level', 'Extra Dry')
-        // Another state packet arrives with Cupboard Dry — should be ignored while locked
-        thinq.emit('data', SAMPLE_INITIAL)
-        assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'Extra Dry')
-    })
-
-    // ── setProperty string parsing ────────────────────────────────────────────
-
-    test('setProperty cycle — string to ID and back', () => {
-        const { ha, thinq, dev } = makeDevice()
-        dev.setProperty('cycle', 'Cotton')
-        assert.equal(ha.devices[DEVICE_ID].properties.cycle, 'Cotton')
-        // Confirm cycle ID was set correctly by starting and checking inner[2]
-        thinq.resetRecorder()
-        dev.setProperty('start', '')
-        const raw = thinq.outbox[0]
-        const inner = raw[0] === 0xaa ? raw.subarray(2, raw.length - 2) : raw
-        assert.equal(inner[2], 0x07) // Cotton = 0x07
-    })
-
-    test('setProperty dry_level — string to ID and back', () => {
-        const { ha, thinq, dev } = makeDevice()
-        dev.setProperty('cycle', 'Mixed Fabric')
-        dev.setProperty('dry_level', 'Iron Dry')
-        assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'Iron Dry')
-        thinq.resetRecorder()
-        dev.setProperty('start', '')
-        const raw = thinq.outbox[0]
-        const inner = raw[0] === 0xaa ? raw.subarray(2, raw.length - 2) : raw
-        assert.equal(inner[3], 1) // Iron Dry = 1
-    })
-
-    test('setProperty eco_hybrid — string to ID and back', () => {
-        const { ha, thinq, dev } = makeDevice()
-        dev.setProperty('cycle', 'Mixed Fabric')
-        dev.setProperty('eco_hybrid', 'Energy')
-        assert.equal(ha.devices[DEVICE_ID].properties.eco_hybrid, 'Energy')
-        thinq.resetRecorder()
-        dev.setProperty('start', '')
-        const raw = thinq.outbox[0]
-        const inner = raw[0] === 0xaa ? raw.subarray(2, raw.length - 2) : raw
-        assert.equal(inner[4], 1) // Energy = 1
-    })
-
-    test('setProperty reservation — string to hours and back', () => {
-        const { ha, thinq, dev } = makeDevice()
-        dev.setProperty('cycle', 'Mixed Fabric')
-        dev.setProperty('reservation', '7h')
-        assert.equal(ha.devices[DEVICE_ID].properties.reservation, '7h')
-        thinq.resetRecorder()
-        dev.setProperty('start', '')
-        const raw = thinq.outbox[0]
-        const inner = raw[0] === 0xaa ? raw.subarray(2, raw.length - 2) : raw
-        assert.equal(inner[8], 7) // 7h
     })
 
     // ── Cycle timing ──────────────────────────────────────────────────────────
@@ -519,30 +429,11 @@ describe(MODEL_ID, () => {
         assert.equal(ha.devices[DEVICE_ID].properties.process_state, 'Dry')
     })
 
-    // ── None states ───────────────────────────────────────────────────────────
-
-    test('cycle shows None when dryer is off', () => {
-        const { ha, thinq } = makeDevice()
-        thinq.emit('data', SAMPLE_OFF)
-        assert.equal(ha.devices[DEVICE_ID].properties.cycle, 'None')
-    })
-
-    test('selecting None from cycle selector is a no-op', () => {
-        const { thinq, dev } = makeDevice()
-        thinq.resetRecorder()
-        dev.setProperty('cycle', 'None')
-        assert.equal(thinq.outbox.length, 0)
-    })
-
     // ── Power on wake sequence ────────────────────────────────────────────────
 
     test('power ON with known downloaded cycle sends F0 25 wake first', (t, done) => {
         const { thinq, dev } = makeDevice()
         thinq.emit('data', SAMPLE_DOWNLOADED) // loads Gym Clothes 0x66 as lastDownloadedCycleId
-        dev.setProperty(
-            'safety_lock',
-            'Disabled (I accept the safety/fire risk, not recommended, use with caution, see docs for details)',
-        )
         thinq.resetRecorder()
         dev.setProperty('power', 'ON')
         // F0 25 sent immediately
@@ -565,10 +456,6 @@ describe(MODEL_ID, () => {
 
     test('power ON with no downloaded cycle sends F0 2A directly', () => {
         const { thinq, dev } = makeDevice()
-        dev.setProperty(
-            'safety_lock',
-            'Disabled (I accept the safety/fire risk, not recommended, use with caution, see docs for details)',
-        )
         thinq.resetRecorder()
         dev.setProperty('power', 'ON')
         assert.equal(thinq.outbox.length, 1)

--- a/rethink/tests/cloud/devices/RH90V9_WW.test.ts
+++ b/rethink/tests/cloud/devices/RH90V9_WW.test.ts
@@ -58,9 +58,9 @@ const SAMPLE_RESERVATION = buf(
     'AA3830EC001900000000000000000000000000000000000000000000000000001901000000000600000000040000000000000000000000000000C4BB',
 )
 
-// Downloaded cycle — Sports Wear base + Gym Clothes SmartCourse (Bd[20]=0x66)
+// Downloaded cycle — Sports Wear base + Gym Clothes SmartCourse (Bd[23]=0x66)
 const SAMPLE_DOWNLOADED = buf(
-    'AA3830EC001900000000000000000000000000000000000000000000000000001902000000000800000000000000000000000000006600000000A3BB',
+    'AA3830EC001900000000000000000000000000000000000000000000000000001902000000000800000000000000000000000000000000006600A3BB',
 )
 
 // Speed 30 — no dry level, Time eco hybrid
@@ -398,6 +398,184 @@ describe(MODEL_ID, () => {
         // Another state packet arrives with Cupboard Dry — should be ignored while locked
         thinq.emit('data', SAMPLE_INITIAL)
         assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'Extra Dry')
+    })
+
+    // ── setProperty string parsing ────────────────────────────────────────────
+
+    test('setProperty cycle — string to ID and back', () => {
+        const { ha, thinq, dev } = makeDevice()
+        dev.setProperty('cycle', 'Cotton')
+        assert.equal(ha.devices[DEVICE_ID].properties.cycle, 'Cotton')
+        // Confirm cycle ID was set correctly by starting and checking inner[2]
+        thinq.resetRecorder()
+        dev.setProperty('start', '')
+        const raw = thinq.outbox[0]
+        const inner = raw[0] === 0xaa ? raw.subarray(2, raw.length - 2) : raw
+        assert.equal(inner[2], 0x07) // Cotton = 0x07
+    })
+
+    test('setProperty dry_level — string to ID and back', () => {
+        const { ha, thinq, dev } = makeDevice()
+        dev.setProperty('cycle', 'Mixed Fabric')
+        dev.setProperty('dry_level', 'Iron Dry')
+        assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'Iron Dry')
+        thinq.resetRecorder()
+        dev.setProperty('start', '')
+        const raw = thinq.outbox[0]
+        const inner = raw[0] === 0xaa ? raw.subarray(2, raw.length - 2) : raw
+        assert.equal(inner[3], 1) // Iron Dry = 1
+    })
+
+    test('setProperty eco_hybrid — string to ID and back', () => {
+        const { ha, thinq, dev } = makeDevice()
+        dev.setProperty('cycle', 'Mixed Fabric')
+        dev.setProperty('eco_hybrid', 'Energy')
+        assert.equal(ha.devices[DEVICE_ID].properties.eco_hybrid, 'Energy')
+        thinq.resetRecorder()
+        dev.setProperty('start', '')
+        const raw = thinq.outbox[0]
+        const inner = raw[0] === 0xaa ? raw.subarray(2, raw.length - 2) : raw
+        assert.equal(inner[4], 1) // Energy = 1
+    })
+
+    test('setProperty reservation — string to hours and back', () => {
+        const { ha, thinq, dev } = makeDevice()
+        dev.setProperty('cycle', 'Mixed Fabric')
+        dev.setProperty('reservation', '7h')
+        assert.equal(ha.devices[DEVICE_ID].properties.reservation, '7h')
+        thinq.resetRecorder()
+        dev.setProperty('start', '')
+        const raw = thinq.outbox[0]
+        const inner = raw[0] === 0xaa ? raw.subarray(2, raw.length - 2) : raw
+        assert.equal(inner[8], 7) // 7h
+    })
+
+    // ── Cycle timing ──────────────────────────────────────────────────────────
+
+    test('cycle_start_time set when state transitions to Running', () => {
+        const { ha, thinq } = makeDevice()
+        const before = Date.now()
+        thinq.emit('data', SAMPLE_RUNNING)
+        const startTime = ha.devices[DEVICE_ID].properties.cycle_start_time
+        assert.ok(startTime && startTime !== '-', 'cycle_start_time published')
+        const parsed = new Date(startTime).getTime()
+        assert.ok(parsed >= before, 'start time is recent')
+    })
+
+    test('cycle_end_time derived from remaining time', () => {
+        const { ha, thinq } = makeDevice()
+        const before = Date.now()
+        thinq.emit('data', SAMPLE_RUNNING) // 48min remaining
+        const endTime = ha.devices[DEVICE_ID].properties.cycle_end_time
+        assert.ok(endTime && endTime !== '-', 'cycle_end_time published')
+        const parsed = new Date(endTime).getTime()
+        const expectedEnd = before + 48 * 60 * 1000
+        assert.ok(Math.abs(parsed - expectedEnd) < 5000, 'end time ≈ now + 48min')
+    })
+
+    test('cycle_duration is non-negative while running', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_RUNNING)
+        const duration = ha.devices[DEVICE_ID].properties.cycle_duration
+        assert.ok(Number(duration) >= 0)
+    })
+
+    test('cycle timing cleared on End state', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_RUNNING)
+        thinq.emit('data', SAMPLE_END)
+        assert.equal(ha.devices[DEVICE_ID].properties.cycle_duration, 0)
+        assert.equal(ha.devices[DEVICE_ID].properties.cycle_end_time, '-')
+    })
+
+    test('cycle timing cleared on Off state', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_RUNNING)
+        thinq.emit('data', SAMPLE_OFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.cycle_duration, 0)
+        assert.equal(ha.devices[DEVICE_ID].properties.cycle_end_time, '-')
+    })
+
+    test('start_time not reset on subsequent Running packets', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_RUNNING)
+        const first = ha.devices[DEVICE_ID].properties.cycle_start_time
+        thinq.emit('data', SAMPLE_RUNNING)
+        const second = ha.devices[DEVICE_ID].properties.cycle_start_time
+        assert.equal(first, second, 'start time unchanged on repeat Running packets')
+    })
+
+    // ── Process state ─────────────────────────────────────────────────────────
+
+    test('process state shows - when dryer is off', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_OFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.process_state, '-')
+    })
+
+    test('process state shows Dry when running', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_RUNNING)
+        assert.equal(ha.devices[DEVICE_ID].properties.process_state, 'Dry')
+    })
+
+    // ── None states ───────────────────────────────────────────────────────────
+
+    test('cycle shows None when dryer is off', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_OFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.cycle, 'None')
+    })
+
+    test('selecting None from cycle selector is a no-op', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('cycle', 'None')
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    // ── Power on wake sequence ────────────────────────────────────────────────
+
+    test('power ON with known downloaded cycle sends F0 25 wake first', (t, done) => {
+        const { thinq, dev } = makeDevice()
+        thinq.emit('data', SAMPLE_DOWNLOADED) // loads Gym Clothes 0x66 as lastDownloadedCycleId
+        dev.setProperty(
+            'safety_lock',
+            'Disabled (I accept the safety/fire risk, not recommended, use with caution, see docs for details)',
+        )
+        thinq.resetRecorder()
+        dev.setProperty('power', 'ON')
+        // F0 25 sent immediately
+        assert.equal(thinq.outbox.length, 1)
+        const raw = thinq.outbox[0]
+        const inner = raw[0] === 0xaa ? raw.subarray(2, raw.length - 2) : raw
+        assert.equal(inner[0], 0xf0)
+        assert.equal(inner[1], 0x25) // wake opcode
+        assert.equal(inner[15], 0x66) // Gym Clothes
+        // F0 2A follows after 500ms
+        setTimeout(() => {
+            assert.equal(thinq.outbox.length, 2)
+            const raw2 = thinq.outbox[1]
+            const inner2 = raw2[0] === 0xaa ? raw2.subarray(2, raw2.length - 2) : raw2
+            assert.equal(inner2[0], 0xf0)
+            assert.equal(inner2[1], 0x2a)
+            done()
+        }, 600)
+    })
+
+    test('power ON with no downloaded cycle sends F0 2A directly', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty(
+            'safety_lock',
+            'Disabled (I accept the safety/fire risk, not recommended, use with caution, see docs for details)',
+        )
+        thinq.resetRecorder()
+        dev.setProperty('power', 'ON')
+        assert.equal(thinq.outbox.length, 1)
+        const raw = thinq.outbox[0]
+        const inner = raw[0] === 0xaa ? raw.subarray(2, raw.length - 2) : raw
+        assert.equal(inner[0], 0xf0)
+        assert.equal(inner[1], 0x2a) // F0 2A directly
     })
 
     // ── Packet filtering ──────────────────────────────────────────────────────

--- a/rethink/tests/cloud/devices/RH90V9_WW.test.ts
+++ b/rethink/tests/cloud/devices/RH90V9_WW.test.ts
@@ -1,0 +1,414 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/RH90V9_WW'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf, hex } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'RH90V9_WW'
+const META: Metadata = { modelId: MODEL_ID, modelName: 'RH90V9_WW', swVersion: '2.10.123' }
+
+// ─── Test packets ──────────────────────────────────────────────────────────────
+// All packets are real AABB state frames built from confirmed wire captures.
+// Inner structure: header(4: 30 EC 00 19) + A block(26) + B block(26)
+// B block: 0x19 marker + Bd[0..24] current state
+
+// Dryer off, no cycle selected
+const SAMPLE_OFF = buf(
+    'AA3830EC001900000000000000000000000000000000000000000000000000001900000000000000000000000000000000000000000000000000D3BB',
+)
+
+// Initial state — Mixed Fabric selected, Cupboard Dry, Time eco hybrid
+const SAMPLE_INITIAL = buf(
+    'AA3830EC001900000000000000000000000000000000000000000000000000001901000000000600030300000000000000000000000000000000C6BB',
+)
+
+// Running — Mixed Fabric, Cupboard Dry, Time, 48min remaining, remote start armed
+const SAMPLE_RUNNING = buf(
+    'AA3830EC001900000000000000000000000000000000000000000000000000001902003000300600030302000000000001000000000000000000A2BB',
+)
+
+// Paused — Mixed Fabric, 30min remaining
+const SAMPLE_PAUSED = buf(
+    'AA3830EC001900000000000000000000000000000000000000000000000000001903001E00000600030300000000000000000000000000000000E6BB',
+)
+
+// End state
+const SAMPLE_END = buf(
+    'AA3830EC001900000000000000000000000000000000000000000000000000001904000000000600000000000000000000000000000000000000C5BB',
+)
+
+// Error state — door open (error code 15 = 0x0F)
+const SAMPLE_ERROR = buf(
+    'AA3830EC00190000000000000000000000000000000000000000000000000000190500000000060F000000000000000000000000000000000000F5BB',
+)
+
+// Anti-crease flag set (Bd[14] bit 0x02)
+const SAMPLE_ANTI_CREASE = buf(
+    'AA3830EC001900000000000000000000000000000000000000000000000000001902000000000600000000000000000200000000000000000000C5BB',
+)
+
+// Remote start armed (Bd[15] bit 0x01)
+const SAMPLE_REMOTE_START = buf(
+    'AA3830EC001900000000000000000000000000000000000000000000000000001901000000000600000000000000000001000000000000000000DBBB',
+)
+
+// Reservation 4h (Bd[10] = 4)
+const SAMPLE_RESERVATION = buf(
+    'AA3830EC001900000000000000000000000000000000000000000000000000001901000000000600000000040000000000000000000000000000C4BB',
+)
+
+// Downloaded cycle — Sports Wear base + Gym Clothes SmartCourse (Bd[20]=0x66)
+const SAMPLE_DOWNLOADED = buf(
+    'AA3830EC001900000000000000000000000000000000000000000000000000001902000000000800000000000000000000000000006600000000A3BB',
+)
+
+// Speed 30 — no dry level, Time eco hybrid
+const SAMPLE_SPEED30 = buf(
+    'AA3830EC001900000000000000000000000000000000000000000000000000001901000000000900000300000000000000000000000000000000C6BB',
+)
+
+// Towels with stale dry level from previous cycle (Bd[7]=3 but Towels has no dry level)
+const SAMPLE_TOWELS_STALE_DRY = buf(
+    'AA3830EC001900000000000000000000000000000000000000000000000000001901000000000200030300000000000000000000000000000000DABB',
+)
+
+// Expected outgoing command bytes
+const WRITE_POLL = 'F0ED1121010000001804131400005A' // F0 ED handshake
+const WRITE_POWER_ON = 'F02A0100' // confirmed: aa08f02a010098bb
+const WRITE_POWER_OFF = 'F024010100' // confirmed: aa09f0240101009cbb
+const WRITE_PAUSE = 'F024040100' // confirmed: aa09f02404010099bb
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    // ── Config ────────────────────────────────────────────────────────────────
+
+    test('config exposes expected components on construction', () => {
+        const { ha } = makeDevice()
+        const cfg = ha.devices[DEVICE_ID].config
+        assert.ok(cfg, 'config published')
+        const components = cfg!.components as Record<string, Record<string, unknown>>
+        for (const c of [
+            'safety_lock',
+            'power',
+            'remote_start',
+            'cycle',
+            'dry_level',
+            'eco_hybrid',
+            'anti_crease',
+            'reservation',
+            'start',
+            'pause',
+            'ping',
+            'run_state',
+            'process_state',
+            'remaining_time',
+            'initial_time',
+            'run_completed',
+            'error',
+            'error_message',
+            'downloaded_cycle_id',
+        ]) {
+            assert.ok(components[c], `component '${c}' present`)
+        }
+    })
+
+    test('safety lock starts enabled', () => {
+        const { ha } = makeDevice()
+        assert.equal(ha.devices[DEVICE_ID].properties.safety_lock, 'Enabled')
+    })
+
+    test('cycle selector contains all 15 base courses', () => {
+        const { ha } = makeDevice()
+        const cfg = ha.devices[DEVICE_ID].config!
+        const options = (cfg.components as any).cycle.options as string[]
+        for (const c of [
+            'Towels',
+            'Duvet',
+            'Easy Care',
+            'Mixed Fabric',
+            'Cotton',
+            'Sports Wear',
+            'Speed 30',
+            'Delicates',
+            'Wool',
+            'Rack Dry',
+            'Warm Air',
+            'Allergy Care',
+            'Condenser Care',
+            'Drum Care',
+            'Eco (Cotton+)',
+        ]) {
+            assert.ok(options.includes(c), `cycle options includes '${c}'`)
+        }
+    })
+
+    // ── State packet decoding ─────────────────────────────────────────────────
+
+    test('off state', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_OFF)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.power, 'OFF')
+        assert.equal(props.run_state, 'Off')
+        assert.equal(props.run_completed, 'OFF')
+        assert.equal(props.error, 'OFF')
+    })
+
+    test('initial state decodes run state, cycle, dry level, eco hybrid', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_INITIAL)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.power, 'ON')
+        assert.equal(props.run_state, 'Initial')
+        assert.equal(props.cycle, 'Mixed Fabric')
+        assert.equal(props.dry_level, 'Cupboard Dry')
+        assert.equal(props.eco_hybrid, 'Time')
+        assert.equal(props.error, 'OFF')
+    })
+
+    test('running state decodes remaining time and remote start', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_RUNNING)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.run_state, 'Running')
+        assert.equal(props.remaining_time, 48) // 0h 48min
+        assert.equal(props.initial_time, 48)
+        assert.equal(props.remote_start, 'ON') // Bd[15] bit 0x01
+        assert.equal(props.process_state, 'Dry')
+    })
+
+    test('paused state', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_PAUSED)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.run_state, 'Paused')
+        assert.equal(props.remaining_time, 30)
+    })
+
+    test('end state sets run_completed', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_END)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.run_state, 'End')
+        assert.equal(props.run_completed, 'ON')
+        assert.equal(props.remaining_time, 0)
+    })
+
+    test('error state decodes error code', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_ERROR)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.run_state, 'Error')
+        assert.equal(props.error, 'ON')
+        assert.equal(props.error_message, 'dE (door open)') // error code 15
+    })
+
+    test('anti-crease flag decoded from Bd[14]', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_ANTI_CREASE)
+        assert.equal(ha.devices[DEVICE_ID].properties.anti_crease, 'ON')
+    })
+
+    test('remote start flag decoded from Bd[15]', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_REMOTE_START)
+        assert.equal(ha.devices[DEVICE_ID].properties.remote_start, 'ON')
+    })
+
+    test('reservation decoded from Bd[10]', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_RESERVATION)
+        assert.equal(ha.devices[DEVICE_ID].properties.reservation, '4h')
+    })
+
+    test('downloaded cycle ID decoded from Bd[20]', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_DOWNLOADED)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.downloaded_cycle_id, '0x66 (Gym Clothes)')
+        // Base course (Sports Wear) still shows in cycle selector
+        assert.equal(props.cycle, 'Sports Wear')
+    })
+
+    // ── Schema enforcement ────────────────────────────────────────────────────
+
+    test('Speed 30 — dry level forced to None (not supported)', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_SPEED30)
+        assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'None')
+        assert.equal(ha.devices[DEVICE_ID].properties.eco_hybrid, 'Time')
+    })
+
+    test('Towels — stale dry level from previous cycle corrected to None', () => {
+        const { ha, thinq } = makeDevice()
+        // Packet has Bd[7]=3 (Cupboard Dry) but Towels has no dry level support
+        thinq.emit('data', SAMPLE_TOWELS_STALE_DRY)
+        assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'None')
+    })
+
+    test('updateCycleOptions — Mixed Fabric shows correct dry level options', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_INITIAL) // Mixed Fabric
+        const cfg = ha.devices[DEVICE_ID].config!
+        const options = (cfg.components as any).dry_level.options as string[]
+        assert.ok(options.includes('Iron Dry'))
+        assert.ok(options.includes('Cupboard Dry'))
+        assert.ok(options.includes('Extra Dry'))
+        assert.ok(!options.includes('None'))
+    })
+
+    test('unknown cycle IDs (0x00, 0x01) are not published to cycle selector', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_OFF) // cycle=0x00
+        // cycle selector should not be updated with unknown values
+        const props = ha.devices[DEVICE_ID].properties
+        assert.ok(!props.cycle || !props.cycle.startsWith('unknown'))
+    })
+
+    // ── Commands ──────────────────────────────────────────────────────────────
+
+    test('ping sends F0 ED handshake', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('ping', '')
+        assert.equal(thinq.outbox.length, 1)
+        assert.ok(hex(thinq.outbox[0]).includes(WRITE_POLL))
+    })
+
+    test('power OFF sends confirmed command', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('power', 'OFF')
+        assert.equal(thinq.outbox.length, 1)
+        assert.ok(hex(thinq.outbox[0]).includes(WRITE_POWER_OFF))
+    })
+
+    test('power ON blocked when safety lock enabled', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('power', 'ON') // safety lock is enabled by default
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('power ON allowed when safety lock disabled', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty(
+            'safety_lock',
+            'Disabled (I accept the safety/fire risk, not recommended, use with caution, see docs for details)',
+        )
+        thinq.resetRecorder()
+        dev.setProperty('power', 'ON')
+        assert.equal(thinq.outbox.length, 1)
+        assert.ok(hex(thinq.outbox[0]).includes(WRITE_POWER_ON))
+    })
+
+    test('pause sends confirmed command', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('pause', '')
+        assert.equal(thinq.outbox.length, 1)
+        assert.ok(hex(thinq.outbox[0]).includes(WRITE_PAUSE))
+    })
+
+    test('start with no cycle selected sends nothing', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('start', '')
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('start after cycle selected sends F0 26 command with correct fields', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('cycle', 'Mixed Fabric') // cycle ID 0x06
+        dev.setProperty('dry_level', 'Cupboard Dry') // dry level 3
+        dev.setProperty('eco_hybrid', 'Time') // eco hybrid 3
+        thinq.resetRecorder()
+        dev.setProperty('start', '')
+        assert.equal(thinq.outbox.length, 1)
+        // outbox[0] is the raw inner buffer passed to send()
+        // find F0 26 opcode — either raw inner or AABB-wrapped
+        const raw = thinq.outbox[0]
+        const inner = raw[0] === 0xaa ? raw.subarray(2, raw.length - 2) : raw
+        assert.equal(inner[0], 0xf0) // opcode
+        assert.equal(inner[1], 0x26)
+        assert.equal(inner[2], 0x06) // Mixed Fabric
+        assert.equal(inner[3], 3) // Cupboard Dry
+        assert.equal(inner[4], 3) // Time
+        assert.equal(inner[12], 0x03) // start operation
+    })
+
+    test('start with reservation sets inner[8]', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('cycle', 'Mixed Fabric')
+        dev.setProperty('reservation', '4h')
+        thinq.resetRecorder()
+        dev.setProperty('start', '')
+        assert.equal(thinq.outbox.length, 1)
+        const raw = thinq.outbox[0]
+        const inner = raw[0] === 0xaa ? raw.subarray(2, raw.length - 2) : raw
+        assert.equal(inner[8], 4) // 4h delayed end
+    })
+
+    test('start with anti-crease sets inner[11]', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('cycle', 'Mixed Fabric')
+        dev.setProperty('anti_crease', 'ON')
+        thinq.resetRecorder()
+        dev.setProperty('start', '')
+        assert.equal(thinq.outbox.length, 1)
+        const raw = thinq.outbox[0]
+        const inner = raw[0] === 0xaa ? raw.subarray(2, raw.length - 2) : raw
+        assert.equal(inner[11], 0x02) // anti-crease on
+    })
+
+    test('start enforces schema — Speed 30 corrects invalid dry level', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('cycle', 'Speed 30') // no dry level support
+        dev.setProperty('dry_level', 'Cupboard Dry') // invalid for Speed 30
+        thinq.resetRecorder()
+        dev.setProperty('start', '')
+        assert.equal(thinq.outbox.length, 1)
+        const raw = thinq.outbox[0]
+        const inner = raw[0] === 0xaa ? raw.subarray(2, raw.length - 2) : raw
+        assert.equal(inner[3], 0) // corrected to None
+    })
+
+    test('unknown property emits no packet', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('does-not-exist', 'whatever')
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    // ── Selector lock ─────────────────────────────────────────────────────────
+
+    test('selector lock prevents state packet from overwriting user edit', () => {
+        const { ha, thinq, dev } = makeDevice()
+        // Set cycle first (so cycle lock doesn't interfere with dry_level)
+        thinq.emit('data', SAMPLE_INITIAL) // Mixed Fabric — sets cycle, locks it
+        // User then picks Extra Dry — locks dry_level
+        dev.setProperty('dry_level', 'Extra Dry')
+        // Another state packet arrives with Cupboard Dry — should be ignored while locked
+        thinq.emit('data', SAMPLE_INITIAL)
+        assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'Extra Dry')
+    })
+
+    // ── Packet filtering ──────────────────────────────────────────────────────
+
+    test('non-state packets are ignored', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_OFF)
+        const before = ha.devices[DEVICE_ID].properties.power
+
+        // Send junk packet
+        thinq.emit('data', buf('AA083000250052BB'))
+        assert.equal(ha.devices[DEVICE_ID].properties.power, before)
+    })
+})


### PR DESCRIPTION
# Add LG RH90V9_WW heat pump dryer device class

Adds a full device class for the LG RH90V9_WW heat pump dryer, reverse engineered from wire captures against the AABB packet protocol.

## Entities

### Controls

- Power switch (OFF always works; ON gated behind Safety Lock)
- 🔒 Safety Lock select — gates Power On and Remote Start per session
- Cycle select — all 15 base courses from modelJson
- Dry level select — dynamic options per cycle schema
- Eco hybrid select — dynamic options per cycle schema
- Anti-crease switch
- Delayed end select (Off, 3h–19h)
- Start button
- Pause button

### Sensors

- Run state, Process state
- Remaining time, Initial time
- Remote start armed (binary sensor)
- Run completed (binary sensor)
- Error state (binary sensor) + Error message
- Downloaded cycle ID (diagnostic)

## Protocol

Full field map confirmed from wire captures and official modelJson:

| Field | Description |
|---|---|
| `Bd[0]` | Run state |
| `Bd[1-2]` | Remaining hours/minutes |
| `Bd[3-4]` | Initial hours/minutes |
| `Bd[5]` | Cycle ID |
| `Bd[6]` | Error code |
| `Bd[7]` | Dry level |
| `Bd[8]` | Eco hybrid |
| `Bd[9]` | Process state |
| `Bd[10]` | Reservation hours (delayed end) |
| `Bd[14]` | Flags: `0x02`=anti-crease |
| `Bd[15]` | Flags: `0x01`=remote start armed |
| `Bd[20]` | Active downloaded/SmartCourse ID |

Start command inner layout (`F0 26` opcode, 16 bytes):

| Byte | Description |
|---|---|
| `[2]` | Cycle ID |
| `[3]` | Dry level |
| `[4]` | Eco hybrid |
| `[8]` | Reservation hours (`0`=off, `3-19`=delayed end) |
| `[11]` | Anti-crease (`0x00`=off, `0x02`=on) |
| `[12]` | Operation (`0x03`=start, `0x01`=resume/update) |
| `[14]` | SmartCourse ID (`0x00` for base courses) |

## Features

**Per-cycle schema** — dry level and eco hybrid options filter dynamically when cycle changes, with defaults applied from modelJson. Covers all 15 base courses.

**Stale value correction** — packet values validated against schema on every state update. Invalid or stale values (e.g. dry level carrying over from a previous cycle) are corrected to schema defaults rather than published to HA.

**Downloaded cycles** — `DOWNLOADED_CYCLES` table maps SmartCourse wire IDs to friendly names and schema defaults. Two IDs confirmed from captures (`GYMCLOTHES=0x66`, `DEODORIZATION=0x6b`), fourteen others commented out awaiting capture. A `downloaded_cycle_id` diagnostic sensor shows the raw hex ID to help users identify new cycles.

**Selector debounce** — 10s lock prevents incoming state packets from overwriting in-progress HA selector edits.

**Safety Lock** — gates Power On (wire-level confirmed working via `F02A0100`, rejected by LG cloud) and Remote Start per session. Resets to locked on every restart.

## Confirmed captures

All field mappings verified against real packet captures from an RH90V9_WW unit running firmware `2.10.123`.