### PR TITLE
Add support for LG dehumidifier DHUM_056905_WW

### DIFF
--- a/cloud/devices/DHUM_056905_WW.ts
+++ b/cloud/devices/DHUM_056905_WW.ts
@@ -256,7 +256,7 @@ export default class Device extends TLVDevice {
             write_xform: (val) => (val === 'ON' ? 1 : 0),
         })
 
-        this.addTimerField(config, 0x21b, 'off_timer', 'Sleep timer', 'mdi:bed-clock', 8)
+        this.addTimerField(config, 0x21b, 'off_timer', 'Sleep timer', 'mdi:bed-clock', 9)
 
         // Wire bare state_topic/command_topic (expected by humidifier platform) to our 'power' property
         const hum = (config.components as any).humidifier
@@ -274,7 +274,7 @@ export default class Device extends TLVDevice {
             name: desc,
             icon: icon,
             device_class: 'duration',
-            unit_of_measurement: 'min',
+            unit_of_measurement: 'h',
             min: 0,
             max: max,
             step: step,
@@ -283,17 +283,14 @@ export default class Device extends TLVDevice {
         config['components'][name] = comp
 
         /*
-         * Upon setting this field the device starts counting down and
-         * sends the remaining time (seconds); ceil to whole minutes for HA.
+         * Setpoint is hours×60 (minutes) in tlv, same as RAC timers on 0x21b.
+         * While counting down, notifies send remaining time in seconds.
          */
         this.addField(config, {
             id: id,
             name: '',
             comp: name,
-            read_xform: (raw) => {
-                const val = Math.ceil(raw / 60 / step) * step
-                return val > max ? 0 : val
-            },
+            read_xform: (raw) => Math.ceil(raw / 60 / step) * step,
             write_xform: (val) => Math.round(Number(val) * 60),
         })
     }

--- a/cloud/devices/DHUM_056905_WW.ts
+++ b/cloud/devices/DHUM_056905_WW.ts
@@ -93,13 +93,6 @@ export default class Device extends TLVDevice {
                     icon: 'mdi:fan',
                     options: ['low', 'high'],
                 },
-                off_timer: {
-                    platform: 'select',
-                    unique_id: '$deviceid-off_timer',
-                    name: 'Off timer',
-                    icon: 'mdi:timer-off',
-                    options: ['off', '1', '2', '3', '4', '5', '6', '7', '8'],
-                },
                 current_humidity: {
                     platform: 'sensor',
                     unique_id: '$deviceid-current_humidity',
@@ -261,23 +254,7 @@ export default class Device extends TLVDevice {
             write_xform: (val) => (val === 'ON' ? 1 : 0),
         })
 
-        // off timer (0x21b: 0=off; setpoint is minutes×60s; notifies may show seconds remaining e.g. 59→1 min)
-        this.addField(config, {
-            id: 0x21b,
-            name: '',
-            comp: 'off_timer',
-            read_xform: (raw) => {
-                if (!raw) return 'off'
-                const minutes = Math.ceil(raw / 60)
-                return minutes >= 1 && minutes <= 8 ? String(minutes) : 'off'
-            },
-            write_xform: (val) => {
-                if (val === 'off') return 0
-                const minutes = Number(val)
-                if (!Number.isFinite(minutes) || minutes < 1 || minutes > 8) return 0
-                return minutes * 60
-            },
-        })
+        this.addTimerField(config, 0x21b, 'off_timer', 'Sleep timer', 'mdi:bed-clock', 8)
 
         // Wire bare state_topic/command_topic (expected by humidifier platform) to our 'power' property
         const hum = (config.components as any).humidifier
@@ -285,6 +262,38 @@ export default class Device extends TLVDevice {
         hum.command_topic = '$this/humidifier-power/set'
 
         this.setConfig(config)
+    }
+
+    addTimerField(config: DeviceDiscovery, id: number, name: string, desc: string, icon: string, max: number) {
+        const step = 1
+        const comp = {
+            platform: 'number',
+            unique_id: '$deviceid-' + name,
+            name: desc,
+            icon: icon,
+            device_class: 'duration',
+            unit_of_measurement: 'min',
+            min: 0,
+            max: max,
+            step: step,
+            mode: 'slider',
+        } as const
+        config['components'][name] = comp
+
+        /*
+         * Upon setting this field the device starts counting down and
+         * sends the remaining time (seconds); ceil to whole minutes for HA.
+         */
+        this.addField(config, {
+            id: id,
+            name: '',
+            comp: name,
+            read_xform: (raw) => {
+                const val = Math.ceil(raw / 60 / step) * step
+                return val > max ? 0 : val
+            },
+            write_xform: (val) => Math.round(Number(val) * 60),
+        })
     }
 
     private fanSpeedFromClip(raw?: number): string {

--- a/cloud/devices/DHUM_056905_WW.ts
+++ b/cloud/devices/DHUM_056905_WW.ts
@@ -100,6 +100,7 @@ export default class Device extends TLVDevice {
                     device_class: 'humidity',
                     unit_of_measurement: '%',
                     state_class: 'measurement',
+                    state_topic: '$this/humidifier-current_humidity',
                 },
                 bucket_full: {
                     platform: 'binary_sensor',
@@ -199,8 +200,9 @@ export default class Device extends TLVDevice {
         // current humidity (observed on 0x1fd in device state packets, e.g. 0x30=48%)
         this.addField(config, {
             id: 0x1fd,
-            name: '',
-            comp: 'current_humidity',
+            name: 'current_humidity',
+            comp: 'humidifier',
+            state_topic: 'topic',
             writable: false,
         })
 

--- a/cloud/devices/DHUM_056905_WW.ts
+++ b/cloud/devices/DHUM_056905_WW.ts
@@ -9,6 +9,9 @@ import HADevice from './base'
 /** TLV tags present in capability (0xA7/0x01) packets — store state but do not publish as entity values. */
 const CAPS_ONLY_TAGS = new Set([0x2d5, 0x2d6, 0x336, 0x2e5, 0x2e6, 0x2da])
 
+/** Observed on bucket-empty notify when the tank is reinstalled (0x2b1=256, 0x2b2=0). */
+const BUCKET_EMPTIED_EVENT = 256
+
 /** Entering these modes resets fan speed to low (high remains user-selectable). */
 const SILENT_MODES = new Set([2, 19])
 
@@ -47,6 +50,8 @@ export default class Device extends TLVDevice {
     modePrev?: string
     modeClipPrev?: number
     initialValuesReceived = false
+    /** Last bucket-full state published to HA (retained). */
+    bucketFullHaState?: boolean
 
     constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
         super(HA, thinq)
@@ -102,6 +107,16 @@ export default class Device extends TLVDevice {
                     device_class: 'humidity',
                     unit_of_measurement: '%',
                     state_class: 'measurement',
+                },
+                bucket_full: {
+                    platform: 'binary_sensor',
+                    unique_id: '$deviceid-bucket_full',
+                    name: 'Bucket full',
+                    icon: 'mdi:water-alert',
+                    device_class: 'problem',
+                    payload_on: 'ON',
+                    payload_off: 'OFF',
+                    state_topic: '$this/bucket_full-',
                 },
             },
         })
@@ -316,9 +331,30 @@ export default class Device extends TLVDevice {
         this.send([1, 1, 2, 1, 1], this.buildFanSpeedTlvs(fan))
     }
 
+    private publishBucketFullState(full: boolean) {
+        if (this.bucketFullHaState === full) return
+        this.bucketFullHaState = full
+        this.HA.publishProperty(this.id, 'bucket_full-', full ? 'ON' : 'OFF', { retain: true })
+    }
+
     processKeyValue(k: number, v: number) {
         if (this.query_caps_timeout !== undefined && CAPS_ONLY_TAGS.has(k)) {
             this.raw_clip_state[k] = v
+            return
+        }
+        // 0x336 tracks humidity in live packets, not bucket level (was 45–50% during testing).
+        if (k === 0x336) {
+            this.raw_clip_state[k] = v
+            return
+        }
+        if (k === 0x2b1) {
+            this.raw_clip_state[k] = v
+            if (v === BUCKET_EMPTIED_EVENT) this.publishBucketFullState(false)
+            return
+        }
+        if (k === 0x2b2) {
+            this.raw_clip_state[k] = v
+            this.publishBucketFullState(v !== 0)
             return
         }
         super.processKeyValue(k, v)
@@ -337,6 +373,7 @@ export default class Device extends TLVDevice {
                 t === 0x1fd ||
                 t === 0x21b ||
                 t === 0x21e ||
+                t === 0x2b2 ||
                 t === 0x253 ||
                 t === 0x2a2 ||
                 t === 0x360,

--- a/cloud/devices/DHUM_056905_WW.ts
+++ b/cloud/devices/DHUM_056905_WW.ts
@@ -1,0 +1,352 @@
+import TLVDevice from './tlv_device'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { DeviceDiscovery, type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import * as TLV from '@/util/tlv'
+import HADevice from './base'
+
+/** TLV tags present in capability (0xA7/0x01) packets — store state but do not publish as entity values. */
+const CAPS_ONLY_TAGS = new Set([0x2d5, 0x2d6, 0x336, 0x2e5, 0x2e6, 0x2da])
+
+/** Entering these modes resets fan speed to low (high remains user-selectable). */
+const SILENT_MODES = new Set([2, 19])
+
+const HA_MODES = ['Smart', 'Jet', 'Silent', 'Spot', 'Laundry'] as const
+
+const CLIP_TO_HA_MODE: Record<number, string> = {
+    0: 'Smart',
+    1: 'Jet',
+    2: 'Silent',
+    4: 'Spot',
+    5: 'Laundry',
+    17: 'Smart',
+    18: 'Jet',
+    19: 'Silent',
+    20: 'Spot',
+    21: 'Laundry',
+}
+
+const HA_TO_CLIP_MODE: Record<string, number> = {
+    Smart: 17,
+    Jet: 18,
+    Silent: 19,
+    Spot: 20,
+    Laundry: 21,
+}
+
+function normalizeHaMode(val: string): string {
+    return val.charAt(0).toUpperCase() + val.slice(1).toLowerCase()
+}
+
+/**
+ * LG Dehumidifier DHUM_056905_WW (e.g. models using 056905 platform, deviceType 403)
+ */
+export default class Device extends TLVDevice {
+    powerStatePrev?: boolean
+    modePrev?: string
+    modeClipPrev?: number
+    initialValuesReceived = false
+
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        const config: DeviceDiscovery = allowExtendedType({
+            ...HADevice.config(meta, { name: 'LG Dehumidifier' }),
+            components: {
+                humidifier: {
+                    platform: 'humidifier',
+                    unique_id: '$deviceid-humidifier',
+                    name: null,
+                    device_class: 'dehumidifier',
+                    modes: [...HA_MODES],
+                    min_humidity: 30,
+                    max_humidity: 70,
+                },
+                ionizer: {
+                    platform: 'switch',
+                    unique_id: '$deviceid-ionizer',
+                    name: 'Ionizer',
+                    icon: 'mdi:air-filter',
+                },
+                uv_nano: {
+                    platform: 'switch',
+                    unique_id: '$deviceid-uv_nano',
+                    name: 'UVnano',
+                    icon: 'mdi:lightbulb',
+                },
+                bucket_light: {
+                    platform: 'switch',
+                    unique_id: '$deviceid-bucket_light',
+                    name: 'Bucket Light',
+                    icon: 'mdi:lightbulb-on',
+                },
+                // MQTT humidifier platform has no fan_mode support; use a select entity instead.
+                fan_speed: {
+                    platform: 'select',
+                    unique_id: '$deviceid-fan_speed',
+                    name: 'Fan speed',
+                    icon: 'mdi:fan',
+                    options: ['low', 'high'],
+                },
+                off_timer: {
+                    platform: 'select',
+                    unique_id: '$deviceid-off_timer',
+                    name: 'Off timer',
+                    icon: 'mdi:timer-off',
+                    options: ['off', '1', '2', '3', '4', '5', '6', '7', '8'],
+                },
+                current_humidity: {
+                    platform: 'sensor',
+                    unique_id: '$deviceid-current_humidity',
+                    name: 'Current humidity',
+                    device_class: 'humidity',
+                    unit_of_measurement: '%',
+                    state_class: 'measurement',
+                },
+            },
+        })
+
+        // power (0x1f7) - registered as humidifier-power; we wire bare state/command below
+        this.addField(
+            config,
+            {
+                id: 0x1f7,
+                name: 'power',
+                comp: 'humidifier',
+                write_xform: (val) => (val === 'ON' ? 1 : 0),
+                write_attach: (raw) => (raw ? [0x1f9] : []),
+                read_xform: (raw) => (raw ? 'ON' : 'OFF'),
+                read_callback: (val) => {
+                    const powerState = val === 'ON'
+                    if (this.powerStatePrev !== powerState) {
+                        // future hooks
+                    }
+                    this.powerStatePrev = powerState
+                    return true // allow the power state publish
+                },
+            },
+            false,
+        )
+
+        // mode / op mode
+        this.addField(config, {
+            id: 0x1f9,
+            name: 'mode',
+            comp: 'humidifier',
+            read_xform: (raw) => CLIP_TO_HA_MODE[raw] ?? `mode${raw}`,
+            read_callback: () => {
+                const mode = this.raw_clip_state[0x1f9]
+                if (
+                    mode != null &&
+                    SILENT_MODES.has(mode) &&
+                    (this.modeClipPrev == null || !SILENT_MODES.has(this.modeClipPrev))
+                ) {
+                    this.publishFanSpeedState('low')
+                }
+                if (mode != null) this.modeClipPrev = mode
+                return true
+            },
+            write_xform: (val) => {
+                if (val === 'off' || val === undefined) {
+                    this.setProperty('humidifier-power', 'OFF')
+                    return undefined
+                } else {
+                    this.setProperty('humidifier-power', 'ON')
+                }
+                const mode = normalizeHaMode(val)
+                const clip = HA_TO_CLIP_MODE[mode] ?? Number(val)
+                if (mode === 'Silent' && (this.modeClipPrev == null || !SILENT_MODES.has(this.modeClipPrev))) {
+                    this.raw_clip_state[0x1fa] = 2
+                    this.publishFanSpeedState('low')
+                }
+                if (typeof clip === 'number') this.modeClipPrev = clip
+                return clip
+            },
+            write_attach: [0x1f7],
+        })
+
+        this.addField(config, {
+            id: 0x1fa,
+            name: '',
+            comp: 'fan_speed',
+            read_xform: (raw) => {
+                const modes2ha: Record<number, string> = { 2: 'low', 6: 'high' }
+                return modes2ha[raw] ?? raw.toString()
+            },
+            read_callback: (val) => {
+                this.publishFanSpeedState(typeof val === 'string' ? val : String(val))
+                return false
+            },
+            write_xform: (val) => {
+                const modes2clip: Record<string, number> = { low: 2, high: 6 }
+                return modes2clip[val] ?? Number(val)
+            },
+            write_callback: (val) => {
+                if (val !== 2 && val !== 6) return false
+                this.sendFanSpeedTlvs(val)
+                return false
+            },
+        })
+
+        // current humidity (observed on 0x1fd in device state packets, e.g. 0x30=48%)
+        this.addField(config, {
+            id: 0x1fd,
+            name: '',
+            comp: 'current_humidity',
+            writable: false,
+        })
+
+        // target humidity setpoint (0x253 on live A7/0x04 notify packets, e.g. v=35)
+        this.addField(config, {
+            id: 0x253,
+            name: 'target_humidity',
+            comp: 'humidifier',
+            read_xform: (raw) => raw,
+            read_callback: (val) => {
+                const n = typeof val === 'number' ? val : Number(val)
+                return n >= 30 && n <= 70
+            },
+            write_xform: (valStr) => {
+                let val = Number(valStr)
+                if (val < 30) val = 30
+                if (val > 70) val = 70
+                val = Math.round(val)
+                this.raw_clip_state[0x1f7] = 1
+                return val
+            },
+            write_attach: [0x1f7, 0x1f9],
+        })
+
+        // ionizer on/off (0x360 on live notify packets: 0=OFF, 1=ON)
+        this.addField(config, {
+            id: 0x360,
+            name: '',
+            comp: 'ionizer',
+            read_xform: (raw) => (raw ? 'ON' : 'OFF'),
+            write_xform: (val) => (val === 'ON' ? 1 : 0),
+            write_attach: [0x1f7, 0x1f9],
+        })
+
+        // UVnano (0x2a2 on live notify packets: 0=OFF, 1=ON)
+        this.addField(config, {
+            id: 0x2a2,
+            name: '',
+            comp: 'uv_nano',
+            read_xform: (raw) => (raw ? 'ON' : 'OFF'),
+            write_xform: (val) => (val === 'ON' ? 1 : 0),
+            write_attach: [0x1f7, 0x1f9],
+        })
+
+        // bucket light (0x21e on live notify packets: 0=OFF, 1=ON)
+        this.addField(config, {
+            id: 0x21e,
+            name: '',
+            comp: 'bucket_light',
+            read_xform: (raw) => (raw ? 'ON' : 'OFF'),
+            write_xform: (val) => (val === 'ON' ? 1 : 0),
+        })
+
+        // off timer (0x21b: 0=off; setpoint is minutes×60s; notifies may show seconds remaining e.g. 59→1 min)
+        this.addField(config, {
+            id: 0x21b,
+            name: '',
+            comp: 'off_timer',
+            read_xform: (raw) => {
+                if (!raw) return 'off'
+                const minutes = Math.ceil(raw / 60)
+                return minutes >= 1 && minutes <= 8 ? String(minutes) : 'off'
+            },
+            write_xform: (val) => {
+                if (val === 'off') return 0
+                const minutes = Number(val)
+                if (!Number.isFinite(minutes) || minutes < 1 || minutes > 8) return 0
+                return minutes * 60
+            },
+        })
+
+        // Wire bare state_topic/command_topic (expected by humidifier platform) to our 'power' property
+        const hum = (config.components as any).humidifier
+        hum.state_topic = '$this/humidifier-power'
+        hum.command_topic = '$this/humidifier-power/set'
+
+        this.setConfig(config)
+    }
+
+    private fanSpeedFromClip(raw?: number): string {
+        const v = raw ?? this.raw_clip_state[0x1fa]
+        if (v === 6) return 'high'
+        if (v === 2) return 'low'
+        return v != null ? String(v) : 'low'
+    }
+
+    private publishFanSpeedState(override?: string) {
+        const state = override ?? this.fanSpeedFromClip()
+        this.HA.publishProperty(this.id, 'fan_speed-', state)
+    }
+
+    /** Fan speed writes must include per-mode 0x2d7/0x2d8/0x2d9 triplets (see panel notify captures). */
+    private buildFanSpeedTlvs(fan: 2 | 6): TLV.TLV[] {
+        const modeFan = (mode: number, fanSpeed: number) => [
+            { t: 0x2d7, v: mode },
+            { t: 0x2d8, v: 0 },
+            { t: 0x2d9, v: fanSpeed },
+        ]
+        const modes: [number, number][] =
+            fan === 2
+                ? [
+                      [17, 2],
+                      [18, 2],
+                      [20, 2],
+                      [21, 6],
+                      [22, 2],
+                  ]
+                : [
+                      [17, 6],
+                      [18, 6],
+                      [20, 6],
+                      [21, 6],
+                      [22, 6],
+                  ]
+        const tlvs = [{ t: 0x1fa, v: fan }, ...modes.flatMap(([m, f]) => modeFan(m, f))]
+        for (const { t, v } of tlvs) this.raw_clip_state[t] = v
+        return tlvs
+    }
+
+    private sendFanSpeedTlvs(fan: 2 | 6) {
+        this.send([1, 1, 2, 1, 1], this.buildFanSpeedTlvs(fan))
+    }
+
+    processKeyValue(k: number, v: number) {
+        if (this.query_caps_timeout !== undefined && CAPS_ONLY_TAGS.has(k)) {
+            this.raw_clip_state[k] = v
+            return
+        }
+        super.processKeyValue(k, v)
+    }
+
+    isCapsResponse(tlvArray: TLV.TLV[]) {
+        return tlvArray.some(({ t }) => t === 0x2da)
+    }
+
+    isValuesResponse(tlvArray: TLV.TLV[]) {
+        return tlvArray.some(
+            ({ t }) =>
+                t === 0x1f7 ||
+                t === 0x1f9 ||
+                t === 0x1fa ||
+                t === 0x1fd ||
+                t === 0x21b ||
+                t === 0x21e ||
+                t === 0x253 ||
+                t === 0x2a2 ||
+                t === 0x360,
+        )
+    }
+
+    valuesReceived() {
+        if (this.initialValuesReceived) return
+        this.initialValuesReceived = true
+
+        this.thinq.send('setMaskingInfo', 0, { blacklist_tlv: '1200' })
+    }
+}

--- a/cloud/devices/DHUM_056905_WW.ts
+++ b/cloud/devices/DHUM_056905_WW.ts
@@ -1,6 +1,6 @@
 import TLVDevice from './tlv_device'
 import { Device as Thinq2Device } from '../thinq2/device'
-import { DeviceDiscovery, type Connection } from '../homeassistant'
+import { DeviceDiscovery, type Connection, type HumidifierComponent } from '../homeassistant'
 import { type Metadata } from '../thinq'
 import { allowExtendedType } from '@/util/casting'
 import * as TLV from '@/util/tlv'
@@ -89,7 +89,7 @@ export default class Device extends TLVDevice {
 
     constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
         super(HA, thinq)
-        const config: DeviceDiscovery = allowExtendedType({
+        const config: DeviceDiscovery & { components: { humidifier: HumidifierComponent } } = allowExtendedType({
             ...HADevice.config(meta, { name: 'LG Dehumidifier' }),
             components: {
                 humidifier: {
@@ -100,7 +100,7 @@ export default class Device extends TLVDevice {
                     modes: [...HA_MODES],
                     min_humidity: 30,
                     max_humidity: 70,
-                },
+                } satisfies HumidifierComponent,
                 ionizer: {
                     platform: 'switch',
                     unique_id: '$deviceid-ionizer',
@@ -193,9 +193,11 @@ export default class Device extends TLVDevice {
                 if (val === 'off' || val === undefined) {
                     this.setProperty('humidifier-power', 'OFF')
                     return undefined
-                } else {
-                    this.setProperty('humidifier-power', 'ON')
                 }
+
+                // Power on via attached 0x1f7
+                this.raw_clip_state[0x1f7] = 1
+
                 const mode = normalizeHaMode(val)
                 const clip = HA_TO_CLIP_MODE[mode] ?? Number(val)
                 if (mode === 'Silent' && (this.modeClipPrev == null || !SILENT_MODES.has(this.modeClipPrev))) {
@@ -318,8 +320,8 @@ export default class Device extends TLVDevice {
         config['components'][name] = comp
 
         /*
-         * Setpoint is hours×60 (minutes) in tlv, same as RAC timers on 0x21b.
-         * While counting down, notifies send remaining time in seconds.
+         * HA unit is hours; TLV is minutes (hours×60), same as RAC timers on 0x21b.
+         * Countdown notifies also report remaining time in minutes.
          */
         this.addField(config, {
             id: id,

--- a/cloud/devices/DHUM_056905_WW.ts
+++ b/cloud/devices/DHUM_056905_WW.ts
@@ -6,7 +6,11 @@ import { allowExtendedType } from '@/util/casting'
 import * as TLV from '@/util/tlv'
 import HADevice from './base'
 
-/** TLV tags present in capability (0xA7/0x01) packets — store state but do not publish as entity values. */
+/**
+ * TLV tags present in capability (0xA7/0x01) packets — store during the caps query phase
+ * but do not publish as entity values. After caps are received, 0x336 is handled as
+ * current humidity via its field definition.
+ */
 const CAPS_ONLY_TAGS = new Set([0x2d5, 0x2d6, 0x336, 0x2e5, 0x2e6, 0x2da])
 
 /** Observed on bucket-empty notify when the tank is reinstalled (0x2b1=256, 0x2b2=0). */
@@ -37,6 +41,36 @@ const HA_TO_CLIP_MODE: Record<string, number> = {
     Spot: 20,
     Laundry: 21,
 }
+
+/**
+ * Per-mode fan capability table resent with every fan-speed write.
+ *
+ * The panel/device does not treat fan speed as a single global value alone: a write of
+ * 0x1fa must be accompanied by a repeating 3-tuple capability declaration:
+ *   0x2d7 = operating-mode id
+ *   0x2d8 = 0 (always observed)
+ *   0x2d9 = fan speed that mode should run at (2 = low, 6 = high)
+ *
+ * Most modes accept the requested fan speed. Laundry is fixed at high — that is a
+ * property of the mode, not a special-case in the write path. Mode 22 appears in the
+ * on-wire table on observed units but is not exposed in the ThinQ app / HA modes list.
+ *
+ * This is a capability declaration, not device state: it must not be stored in
+ * raw_clip_state (those tags are not globally unique — they repeat once per mode row).
+ */
+type ModeFanCap = {
+    mode: number
+    /** When set, 0x2d9 is always this value; otherwise it follows the requested fan. */
+    fixedFan?: 2 | 6
+}
+
+const MODE_FAN_CAPS: readonly ModeFanCap[] = [
+    { mode: 17 }, // Smart
+    { mode: 18 }, // Jet
+    { mode: 20 }, // Spot
+    { mode: 21, fixedFan: 6 }, // Laundry — high fan only
+    { mode: 22 }, // present on-wire; not exposed in app
+]
 
 function normalizeHaMode(val: string): string {
     return val.charAt(0).toUpperCase() + val.slice(1).toLowerCase()
@@ -197,9 +231,10 @@ export default class Device extends TLVDevice {
             },
         })
 
-        // current humidity (observed on 0x1fd in device state packets, e.g. 0x30=48%)
+        // current humidity: ThinQ maps 0x336 → airState.humidity.current (live packets).
+        // 0x1fd is a different property on this platform family (temperature on RAC/WIN).
         this.addField(config, {
-            id: 0x1fd,
+            id: 0x336,
             name: 'current_humidity',
             comp: 'humidifier',
             state_topic: 'topic',
@@ -307,31 +342,28 @@ export default class Device extends TLVDevice {
         this.HA.publishProperty(this.id, 'fan_speed-', state)
     }
 
-    /** Fan speed writes must include per-mode 0x2d7/0x2d8/0x2d9 triplets (see panel notify captures). */
+    /**
+     * Build the fan-speed write payload: requested speed (0x1fa) plus MODE_FAN_CAPS rows.
+     * Equivalent expanded form for fan=2:
+     *   0x1fa=2,
+     *   modeFan(17, 2), modeFan(18, 2), modeFan(20, 2),
+     *   modeFan(21, 6), // Laundry always high
+     *   modeFan(22, 2)
+     */
     private buildFanSpeedTlvs(fan: 2 | 6): TLV.TLV[] {
-        const modeFan = (mode: number, fanSpeed: number) => [
+        const modeFanRow = (mode: number, fanSpeed: number): TLV.TLV[] => [
             { t: 0x2d7, v: mode },
             { t: 0x2d8, v: 0 },
             { t: 0x2d9, v: fanSpeed },
         ]
-        const modes: [number, number][] =
-            fan === 2
-                ? [
-                      [17, 2],
-                      [18, 2],
-                      [20, 2],
-                      [21, 6],
-                      [22, 2],
-                  ]
-                : [
-                      [17, 6],
-                      [18, 6],
-                      [20, 6],
-                      [21, 6],
-                      [22, 6],
-                  ]
-        const tlvs = [{ t: 0x1fa, v: fan }, ...modes.flatMap(([m, f]) => modeFan(m, f))]
-        for (const { t, v } of tlvs) this.raw_clip_state[t] = v
+
+        const tlvs: TLV.TLV[] = [{ t: 0x1fa, v: fan }]
+        for (const { mode, fixedFan } of MODE_FAN_CAPS) {
+            tlvs.push(...modeFanRow(mode, fixedFan ?? fan))
+        }
+
+        // Only the actual fan setpoint is device state; mode rows are a capability declaration.
+        this.raw_clip_state[0x1fa] = fan
         return tlvs
     }
 
@@ -350,11 +382,8 @@ export default class Device extends TLVDevice {
             this.raw_clip_state[k] = v
             return
         }
-        // 0x336 tracks humidity in live packets, not bucket level (was 45–50% during testing).
-        if (k === 0x336) {
-            this.raw_clip_state[k] = v
-            return
-        }
+        // Mode-fan capability rows (0x2d7/0x2d8/0x2d9) repeat once per mode — not global state.
+        if (k === 0x2d7 || k === 0x2d8 || k === 0x2d9) return
         if (k === 0x2b1) {
             this.raw_clip_state[k] = v
             if (v === BUCKET_EMPTIED_EVENT) this.publishBucketFullState(false)
@@ -378,12 +407,12 @@ export default class Device extends TLVDevice {
                 t === 0x1f7 ||
                 t === 0x1f9 ||
                 t === 0x1fa ||
-                t === 0x1fd ||
                 t === 0x21b ||
                 t === 0x21e ||
                 t === 0x2b2 ||
                 t === 0x253 ||
                 t === 0x2a2 ||
+                t === 0x336 ||
                 t === 0x360,
         )
     }

--- a/cloud/devices/tlv_device.ts
+++ b/cloud/devices/tlv_device.ts
@@ -136,12 +136,13 @@ export default class TLVDevice extends HADevice {
             buf[3] == 0x00 &&
             buf[4] == 0x00 &&
             buf[5] == 0x00 &&
-            buf[6] == 0x87 &&
+            (buf[6] == 0x87 || buf[6] == 0xa7) &&
             buf[7] == 0x02 &&
             (buf[8] == 0x01 || buf[8] == 0x04) &&
             /* && buf[9] is a "sequence" number */ buf[10] == buf.length - 13
         ) {
             // ignore the CRC, we assume that the modem verifies it :/
+            // 0x87 used by RAC/WIN; 0xA7 used by DHUM_056905_WW and similar
             log('status', this.id, 'received TLV packet')
             this.processTLV(TLV.parse(buf.subarray(11, buf.length - 2)))
         }

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -18,6 +18,7 @@ import RV13U6AM8W_D_US_WIFI from './devices/RV13U6AM8W_D_US_WIFI'
 import F3L2CYU__ from './devices/F3L2CYU__'
 import RV13B6BSD_D_US_WIFI from './devices/RV13B6BSD_D_US_WIFI'
 import WTL_FXU_BDV_NA_01 from './devices/WTL_FXU_BDV_NA_01'
+import DHUM_056905_WW from './devices/DHUM_056905_WW'
 import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
 import { type Connection } from './homeassistant'
@@ -55,6 +56,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['F3L2CYU__']: F3L2CYU__, // LG front-load washer
     ['RV13B6BSD_D_US_WIFI']: RV13B6BSD_D_US_WIFI, // LG electric dryer
     WTL_FXU_BDV_NA_01, // LG WashTower
+    DHUM_056905_WW,
 }
 
 class Bridge {

--- a/cloud/homeassistant.ts
+++ b/cloud/homeassistant.ts
@@ -197,3 +197,11 @@ export type ClimateComponent = ComponentInfo & {
     swing_modes?: string[]
     swing_horizontal_modes?: string[]
 }
+
+export type HumidifierComponent = ComponentInfo & {
+    platform: 'humidifier'
+    device_class?: 'dehumidifier' | 'humidifier'
+    modes?: string[]
+    min_humidity?: number
+    max_humidity?: number
+}

--- a/cloud/homeassistant.ts
+++ b/cloud/homeassistant.ts
@@ -204,4 +204,5 @@ export type HumidifierComponent = ComponentInfo & {
     modes?: string[]
     min_humidity?: number
     max_humidity?: number
+    current_humidity_topic?: string
 }

--- a/tests/cloud/devices/DHUM_056905_WW.test.ts
+++ b/tests/cloud/devices/DHUM_056905_WW.test.ts
@@ -74,8 +74,13 @@ describe(MODEL_ID, () => {
         assert.deepEqual(components.humidifier.modes, ['Smart', 'Jet', 'Silent', 'Spot', 'Laundry'])
         assert.ok(components.fan_speed, 'fan_speed select')
         assert.deepEqual(components.fan_speed.options, ['low', 'high'])
-        assert.ok(components.off_timer, 'off_timer select')
-        assert.deepEqual(components.off_timer.options, ['off', '1', '2', '3', '4', '5', '6', '7', '8'])
+        assert.ok(components.off_timer, 'off_timer number')
+        assert.equal(components.off_timer.platform, 'number')
+        assert.equal(components.off_timer.device_class, 'duration')
+        assert.equal(components.off_timer.unit_of_measurement, 'min')
+        assert.equal(components.off_timer.min, 0)
+        assert.equal(components.off_timer.max, 8)
+        assert.equal(components.off_timer.step, 1)
         assert.ok(components.ionizer, 'ionizer switch')
         assert.ok(components.uv_nano, 'uv_nano switch')
         assert.ok(components.bucket_light, 'bucket_light switch')
@@ -191,17 +196,17 @@ describe(MODEL_ID, () => {
         assert.ok(highPkt.includes('B646'), 'per-mode fan high table')
     })
 
-    test('off timer notify and state use tlv 0x21b (minutes 1–8 or off)', (t) => {
+    test('off timer notify and state use tlv 0x21b (minutes 1–8 or 0)', (t) => {
         const { ha, thinq } = buildReadyDevice(t)
 
         thinq.emit('data', buf(OFF_TIMER_1_NOTIFY_HEX))
-        assert.equal(ha.devices[DEVICE_ID]!.properties['off_timer-'], '1')
+        assert.equal(ha.devices[DEVICE_ID]!.properties['off_timer-'], 1)
 
         thinq.emit('data', buf(OFF_TIMER_5_NOTIFY_HEX))
-        assert.equal(ha.devices[DEVICE_ID]!.properties['off_timer-'], '5')
+        assert.equal(ha.devices[DEVICE_ID]!.properties['off_timer-'], 5)
 
         thinq.emit('data', buf(OFF_TIMER_OFF_NOTIFY_HEX))
-        assert.equal(ha.devices[DEVICE_ID]!.properties['off_timer-'], 'off')
+        assert.equal(ha.devices[DEVICE_ID]!.properties['off_timer-'], 0)
     })
 
     test('off timer write encodes minutes as tlv 0x21b', (t) => {
@@ -221,9 +226,9 @@ describe(MODEL_ID, () => {
         assert.ok(pkt.includes('86D03C'), '1 min → 0x21b=60')
 
         thinq.resetRecorder()
-        dev.setProperty('off_timer-', 'off')
+        dev.setProperty('off_timer-', '0')
         pkt = hex(thinq.outbox[thinq.outbox.length - 1])
-        assert.ok(pkt.includes('86C0'), 'off → 0x21b=0')
+        assert.ok(pkt.includes('86C0'), '0 min → 0x21b=0')
     })
 
     test('entering silent mode defaults fan_speed to low; high still allowed', (t) => {

--- a/tests/cloud/devices/DHUM_056905_WW.test.ts
+++ b/tests/cloud/devices/DHUM_056905_WW.test.ts
@@ -89,7 +89,8 @@ describe(MODEL_ID, () => {
         assert.equal(components.current_humidity.platform, 'sensor')
         assert.equal(components.current_humidity.device_class, 'humidity')
         assert.ok('target_humidity_state_topic' in components.humidifier, 'has target humidity topics')
-        assert.ok(!('current_humidity_state_topic' in components.humidifier), 'humidity on separate sensor')
+        assert.equal(components.humidifier.current_humidity_topic, '$this/humidifier-current_humidity')
+        assert.equal(components.current_humidity.state_topic, '$this/humidifier-current_humidity')
     })
 
     test('values packet publishes target humidity from tlv 0x253', (t) => {
@@ -97,7 +98,7 @@ describe(MODEL_ID, () => {
 
         const props = ha.devices[DEVICE_ID]!.properties
         assert.equal(props['humidifier-target_humidity'], 35)
-        assert.equal(props['current_humidity-'], 48)
+        assert.equal(props['humidifier-current_humidity'], 48)
         assert.equal(props['ionizer-'], 'ON')
         assert.equal(props['uv_nano-'], 'OFF')
         assert.equal(props['fan_speed-'], 'low')

--- a/tests/cloud/devices/DHUM_056905_WW.test.ts
+++ b/tests/cloud/devices/DHUM_056905_WW.test.ts
@@ -26,6 +26,11 @@ const OFF_TIMER_1_NOTIFY_HEX = '000004000000A70204ED0386D03BB028'
 const OFF_TIMER_5_NOTIFY_HEX = '000004000000A70204F30486E0012BC8DA'
 const OFF_TIMER_OFF_NOTIFY_HEX = '000004000000A70204EE0286C0AFE8'
 
+// Bucket emptied and reinstalled (panel / LG app "water" clear); 0x2b1=256, 0x2b2=0
+const BUCKET_EMPTIED_NOTIFY_HEX = '000004000000A702046706AC600100AC807407'
+
+const BUCKET_FULL_NOTIFY_HEX = '000004000000A70204EE02AC811E20' // 0x2b2=1
+
 function makeDevice() {
     const ha = new MockHAConnection()
     const thinq = new MockThinq2Device(DEVICE_ID, META)
@@ -74,6 +79,8 @@ describe(MODEL_ID, () => {
         assert.ok(components.ionizer, 'ionizer switch')
         assert.ok(components.uv_nano, 'uv_nano switch')
         assert.ok(components.bucket_light, 'bucket_light switch')
+        assert.equal(components.bucket_full.device_class, 'problem')
+        assert.equal(components.bucket_full.state_topic, '$this/bucket_full-')
         assert.equal(components.current_humidity.platform, 'sensor')
         assert.equal(components.current_humidity.device_class, 'humidity')
         assert.ok('target_humidity_state_topic' in components.humidifier, 'has target humidity topics')
@@ -106,6 +113,22 @@ describe(MODEL_ID, () => {
 
         thinq.emit('data', buf(IONIZER_OFF_NOTIFY_HEX))
         assert.equal(ha.devices[DEVICE_ID]!.properties['ionizer-'], 'OFF')
+    })
+
+    test('bucket full uses 0x2b2 steady state; 0x2b1=256 clears; 0x336 ignored', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        dev.processKeyValue(0x2b2, 1)
+        assert.equal(ha.devices[DEVICE_ID]!.properties['bucket_full-'], 'ON')
+
+        dev.processKeyValue(0x336, 50)
+        assert.equal(ha.devices[DEVICE_ID]!.properties['bucket_full-'], 'ON', 'humidity tag must not toggle bucket')
+
+        thinq.emit('data', buf(BUCKET_EMPTIED_NOTIFY_HEX))
+        assert.equal(ha.devices[DEVICE_ID]!.properties['bucket_full-'], 'OFF')
+
+        thinq.emit('data', buf(BUCKET_FULL_NOTIFY_HEX))
+        assert.equal(ha.devices[DEVICE_ID]!.properties['bucket_full-'], 'ON')
     })
 
     test('bucket light on/off notify uses tlv 0x21e', (t) => {

--- a/tests/cloud/devices/DHUM_056905_WW.test.ts
+++ b/tests/cloud/devices/DHUM_056905_WW.test.ts
@@ -22,9 +22,10 @@ const UV_OFF_NOTIFY_HEX = '000004000000A702044A08A8808C90388CD041E991'
 const BUCKET_LIGHT_ON_NOTIFY_HEX = '000004000000A702048C0287817086'
 const BUCKET_LIGHT_OFF_NOTIFY_HEX = '000004000000A702048A028780473E'
 
-const OFF_TIMER_1_NOTIFY_HEX = '000004000000A70204ED0386D03BB028'
-const OFF_TIMER_5_NOTIFY_HEX = '000004000000A70204F30486E0012BC8DA'
-const OFF_TIMER_OFF_NOTIFY_HEX = '000004000000A70204EE0286C0AFE8'
+// Sleep timer (0x21b) countdown notifies: remaining seconds in tlv
+const SLEEP_TIMER_59S_NOTIFY_HEX = '000004000000A70204ED0386D03BB028' // ~1 h displayed
+const SLEEP_TIMER_299S_NOTIFY_HEX = '000004000000A70204F30486E0012BC8DA' // ~5 h displayed
+const SLEEP_TIMER_OFF_NOTIFY_HEX = '000004000000A70204EE0286C0AFE8'
 
 // Bucket emptied and reinstalled (panel / LG app "water" clear); 0x2b1=256, 0x2b2=0
 const BUCKET_EMPTIED_NOTIFY_HEX = '000004000000A702046706AC600100AC807407'
@@ -74,12 +75,14 @@ describe(MODEL_ID, () => {
         assert.deepEqual(components.humidifier.modes, ['Smart', 'Jet', 'Silent', 'Spot', 'Laundry'])
         assert.ok(components.fan_speed, 'fan_speed select')
         assert.deepEqual(components.fan_speed.options, ['low', 'high'])
-        assert.ok(components.off_timer, 'off_timer number')
+        assert.ok(components.off_timer, 'sleep timer number')
+        assert.equal(components.off_timer.name, 'Sleep timer')
         assert.equal(components.off_timer.platform, 'number')
         assert.equal(components.off_timer.device_class, 'duration')
-        assert.equal(components.off_timer.unit_of_measurement, 'min')
+        assert.equal(components.off_timer.unit_of_measurement, 'h')
+        assert.equal(components.off_timer.mode, 'slider')
         assert.equal(components.off_timer.min, 0)
-        assert.equal(components.off_timer.max, 8)
+        assert.equal(components.off_timer.max, 9)
         assert.equal(components.off_timer.step, 1)
         assert.ok(components.ionizer, 'ionizer switch')
         assert.ok(components.uv_nano, 'uv_nano switch')
@@ -197,39 +200,53 @@ describe(MODEL_ID, () => {
         assert.ok(highPkt.includes('B646'), 'per-mode fan high table')
     })
 
-    test('off timer notify and state use tlv 0x21b (minutes 1–8 or 0)', (t) => {
+    test('sleep timer countdown notify uses tlv 0x21b seconds', (t) => {
         const { ha, thinq } = buildReadyDevice(t)
 
-        thinq.emit('data', buf(OFF_TIMER_1_NOTIFY_HEX))
+        thinq.emit('data', buf(SLEEP_TIMER_59S_NOTIFY_HEX))
         assert.equal(ha.devices[DEVICE_ID]!.properties['off_timer-'], 1)
 
-        thinq.emit('data', buf(OFF_TIMER_5_NOTIFY_HEX))
+        thinq.emit('data', buf(SLEEP_TIMER_299S_NOTIFY_HEX))
         assert.equal(ha.devices[DEVICE_ID]!.properties['off_timer-'], 5)
 
-        thinq.emit('data', buf(OFF_TIMER_OFF_NOTIFY_HEX))
+        thinq.emit('data', buf(SLEEP_TIMER_OFF_NOTIFY_HEX))
         assert.equal(ha.devices[DEVICE_ID]!.properties['off_timer-'], 0)
     })
 
-    test('off timer write encodes minutes as tlv 0x21b', (t) => {
+    test('sleep timer setpoint read uses minutes in tlv 0x21b', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+
+        dev.processKeyValue(0x21b, 540)
+        assert.equal(ha.devices[DEVICE_ID]!.properties['off_timer-'], 9)
+
+        dev.processKeyValue(0x21b, 180)
+        assert.equal(ha.devices[DEVICE_ID]!.properties['off_timer-'], 3)
+    })
+
+    test('sleep timer write encodes whole hours as minutes in tlv 0x21b', (t) => {
         const { thinq, dev } = buildReadyDevice(t)
 
-        dev.setProperty('off_timer-', '5')
+        dev.setProperty('off_timer-', '9')
         let pkt = hex(thinq.outbox[thinq.outbox.length - 1])
-        assert.ok(pkt.includes('86E0012C'), '5 min → 0x21b=300')
+        assert.ok(pkt.includes('86E0021C'), '9 h → 0x21b=540')
+
+        dev.setProperty('off_timer-', '5')
+        pkt = hex(thinq.outbox[thinq.outbox.length - 1])
+        assert.ok(pkt.includes('86E0012C'), '5 h → 0x21b=300')
 
         dev.setProperty('off_timer-', '2')
         pkt = hex(thinq.outbox[thinq.outbox.length - 1])
-        assert.ok(pkt.includes('86D078'), '2 min → 0x21b=120')
+        assert.ok(pkt.includes('86D078'), '2 h → 0x21b=120')
 
         thinq.resetRecorder()
         dev.setProperty('off_timer-', '1')
         pkt = hex(thinq.outbox[thinq.outbox.length - 1])
-        assert.ok(pkt.includes('86D03C'), '1 min → 0x21b=60')
+        assert.ok(pkt.includes('86D03C'), '1 h → 0x21b=60')
 
         thinq.resetRecorder()
         dev.setProperty('off_timer-', '0')
         pkt = hex(thinq.outbox[thinq.outbox.length - 1])
-        assert.ok(pkt.includes('86C0'), '0 min → 0x21b=0')
+        assert.ok(pkt.includes('86C0'), '0 h → 0x21b=0')
     })
 
     test('entering silent mode defaults fan_speed to low; high still allowed', (t) => {

--- a/tests/cloud/devices/DHUM_056905_WW.test.ts
+++ b/tests/cloud/devices/DHUM_056905_WW.test.ts
@@ -1,0 +1,220 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/DHUM_056905_WW'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf, hex } from '@/tests/helpers/mocks'
+import { enableMockTimers, tickMockTimers } from '@/tests/helpers/timers'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'DHUM_056905_WW'
+const META: Metadata = { modelId: MODEL_ID, modelName: 'TEST DHUM', swVersion: '9439' }
+
+const CAPS_RESPONSE_HEX = '000004000000A70201000AB6A00A7CB541B5A004023220'
+
+const QUERY_RESPONSE_HEX = '00000400000087020400117DC17E50117E827F503094D023D801A8803F5E'
+
+// Live notify when ionizer turned off on device panel
+const IONIZER_OFF_NOTIFY_HEX = '000004000000A702043F02D80085A3'
+
+const UV_ON_NOTIFY_HEX = '000004000000A702044B02A88184D7'
+const UV_OFF_NOTIFY_HEX = '000004000000A702044A08A8808C90388CD041E991'
+
+const BUCKET_LIGHT_ON_NOTIFY_HEX = '000004000000A702048C0287817086'
+const BUCKET_LIGHT_OFF_NOTIFY_HEX = '000004000000A702048A028780473E'
+
+const OFF_TIMER_1_NOTIFY_HEX = '000004000000A70204ED0386D03BB028'
+const OFF_TIMER_5_NOTIFY_HEX = '000004000000A70204F30486E0012BC8DA'
+const OFF_TIMER_OFF_NOTIFY_HEX = '000004000000A70204EE0286C0AFE8'
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    ha.on('setProperty', (id: string, prop: string, value: string) => {
+        dev.setProperty(prop, value)
+    })
+    return { ha, thinq, dev }
+}
+
+function buildReadyDevice(t: import('node:test').TestContext) {
+    enableMockTimers(t)
+    const { ha, thinq, dev } = makeDevice()
+
+    thinq.resetRecorder()
+
+    thinq.emit('data', buf(CAPS_RESPONSE_HEX))
+    thinq.emit('data', buf(QUERY_RESPONSE_HEX))
+    tickMockTimers(t, 6000)
+
+    thinq.resetRecorder()
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('caps and values responses triggers humidifier config publish', (t) => {
+        enableMockTimers(t)
+        const { ha, thinq } = makeDevice()
+        thinq.resetRecorder()
+
+        thinq.emit('data', buf(CAPS_RESPONSE_HEX))
+        thinq.emit('data', buf(QUERY_RESPONSE_HEX))
+
+        tickMockTimers(t, 6000)
+        const device = ha.devices[DEVICE_ID]
+        assert.ok(device, 'HA configuration published')
+
+        const components = device.config!.components as Record<string, Record<string, unknown>>
+        assert.ok(components.humidifier, 'humidifier component')
+        assert.equal(components.humidifier.device_class, 'dehumidifier')
+        assert.deepEqual(components.humidifier.modes, ['Smart', 'Jet', 'Silent', 'Spot', 'Laundry'])
+        assert.ok(components.fan_speed, 'fan_speed select')
+        assert.deepEqual(components.fan_speed.options, ['low', 'high'])
+        assert.ok(components.off_timer, 'off_timer select')
+        assert.deepEqual(components.off_timer.options, ['off', '1', '2', '3', '4', '5', '6', '7', '8'])
+        assert.ok(components.ionizer, 'ionizer switch')
+        assert.ok(components.uv_nano, 'uv_nano switch')
+        assert.ok(components.bucket_light, 'bucket_light switch')
+        assert.equal(components.current_humidity.platform, 'sensor')
+        assert.equal(components.current_humidity.device_class, 'humidity')
+        assert.ok('target_humidity_state_topic' in components.humidifier, 'has target humidity topics')
+        assert.ok(!('current_humidity_state_topic' in components.humidifier), 'humidity on separate sensor')
+    })
+
+    test('values packet publishes target humidity from tlv 0x253', (t) => {
+        const { ha } = buildReadyDevice(t)
+
+        const props = ha.devices[DEVICE_ID]!.properties
+        assert.equal(props['humidifier-target_humidity'], 35)
+        assert.equal(props['current_humidity-'], 48)
+        assert.equal(props['ionizer-'], 'ON')
+        assert.equal(props['uv_nano-'], 'OFF')
+        assert.equal(props['fan_speed-'], 'low')
+    })
+
+    test('uv on/off notify uses tlv 0x2a2', (t) => {
+        const { ha, thinq } = buildReadyDevice(t)
+
+        thinq.emit('data', buf(UV_ON_NOTIFY_HEX))
+        assert.equal(ha.devices[DEVICE_ID]!.properties['uv_nano-'], 'ON')
+
+        thinq.emit('data', buf(UV_OFF_NOTIFY_HEX))
+        assert.equal(ha.devices[DEVICE_ID]!.properties['uv_nano-'], 'OFF')
+    })
+
+    test('ionizer off notify uses tlv 0x360', (t) => {
+        const { ha, thinq } = buildReadyDevice(t)
+
+        thinq.emit('data', buf(IONIZER_OFF_NOTIFY_HEX))
+        assert.equal(ha.devices[DEVICE_ID]!.properties['ionizer-'], 'OFF')
+    })
+
+    test('bucket light on/off notify uses tlv 0x21e', (t) => {
+        const { ha, thinq } = buildReadyDevice(t)
+
+        thinq.emit('data', buf(BUCKET_LIGHT_ON_NOTIFY_HEX))
+        assert.equal(ha.devices[DEVICE_ID]!.properties['bucket_light-'], 'ON')
+
+        thinq.emit('data', buf(BUCKET_LIGHT_OFF_NOTIFY_HEX))
+        assert.equal(ha.devices[DEVICE_ID]!.properties['bucket_light-'], 'OFF')
+    })
+
+    test('target humidity write uses tlv 0x253', (t) => {
+        const { thinq, dev } = buildReadyDevice(t)
+
+        dev.setProperty('humidifier-target_humidity', '45')
+        const pkt = hex(thinq.outbox[thinq.outbox.length - 1])
+        assert.ok(pkt.includes('94D02D'), 'target humidity 45 encoded as tlv 0x253')
+    })
+
+    test('ionizer toggle write uses tlv 0x360', (t) => {
+        const { thinq, dev } = buildReadyDevice(t)
+
+        dev.setProperty('ionizer-', 'ON')
+        const pkt = hex(thinq.outbox[thinq.outbox.length - 1])
+        assert.ok(pkt.includes('D801'), 'ionizer tlv 0x360=1 present')
+        assert.ok(pkt.includes('7DC1'), 'power+mode attached to ionizer write')
+    })
+
+    test('uv_nano toggle write uses tlv 0x2a2', (t) => {
+        const { thinq, dev } = buildReadyDevice(t)
+
+        dev.setProperty('uv_nano-', 'ON')
+        const pkt = hex(thinq.outbox[thinq.outbox.length - 1])
+        assert.ok(pkt.includes('A881'), 'uv_nano tlv 0x2a2=1 present')
+        assert.ok(pkt.includes('7DC1'), 'power+mode attached to uv write')
+    })
+
+    test('bucket light write uses tlv 0x21e only', (t) => {
+        const { thinq, dev } = buildReadyDevice(t)
+
+        dev.setProperty('bucket_light-', 'ON')
+        const pkt = hex(thinq.outbox[thinq.outbox.length - 1])
+        assert.ok(pkt.includes('8781'), 'bucket light tlv 0x21e=1')
+        assert.ok(!pkt.includes('7DC1'), 'panel-style write has no power/mode attach')
+    })
+
+    test('fan_speed write sends per-mode tlv table like device panel', (t) => {
+        const { thinq, dev } = buildReadyDevice(t)
+
+        dev.setProperty('fan_speed-', 'low')
+        const lowPkt = hex(thinq.outbox[thinq.outbox.length - 1])
+        assert.ok(lowPkt.includes('7E82'), 'fan low 0x1fa=2')
+        assert.ok(lowPkt.includes('B642'), 'per-mode fan low table')
+
+        thinq.resetRecorder()
+        dev.setProperty('fan_speed-', 'high')
+        const highPkt = hex(thinq.outbox[thinq.outbox.length - 1])
+        assert.ok(highPkt.includes('7E86'), 'fan high 0x1fa=6')
+        assert.ok(highPkt.includes('B646'), 'per-mode fan high table')
+    })
+
+    test('off timer notify and state use tlv 0x21b (minutes 1–8 or off)', (t) => {
+        const { ha, thinq } = buildReadyDevice(t)
+
+        thinq.emit('data', buf(OFF_TIMER_1_NOTIFY_HEX))
+        assert.equal(ha.devices[DEVICE_ID]!.properties['off_timer-'], '1')
+
+        thinq.emit('data', buf(OFF_TIMER_5_NOTIFY_HEX))
+        assert.equal(ha.devices[DEVICE_ID]!.properties['off_timer-'], '5')
+
+        thinq.emit('data', buf(OFF_TIMER_OFF_NOTIFY_HEX))
+        assert.equal(ha.devices[DEVICE_ID]!.properties['off_timer-'], 'off')
+    })
+
+    test('off timer write encodes minutes as tlv 0x21b', (t) => {
+        const { thinq, dev } = buildReadyDevice(t)
+
+        dev.setProperty('off_timer-', '5')
+        let pkt = hex(thinq.outbox[thinq.outbox.length - 1])
+        assert.ok(pkt.includes('86E0012C'), '5 min → 0x21b=300')
+
+        dev.setProperty('off_timer-', '2')
+        pkt = hex(thinq.outbox[thinq.outbox.length - 1])
+        assert.ok(pkt.includes('86D078'), '2 min → 0x21b=120')
+
+        thinq.resetRecorder()
+        dev.setProperty('off_timer-', '1')
+        pkt = hex(thinq.outbox[thinq.outbox.length - 1])
+        assert.ok(pkt.includes('86D03C'), '1 min → 0x21b=60')
+
+        thinq.resetRecorder()
+        dev.setProperty('off_timer-', 'off')
+        pkt = hex(thinq.outbox[thinq.outbox.length - 1])
+        assert.ok(pkt.includes('86C0'), 'off → 0x21b=0')
+    })
+
+    test('entering silent mode defaults fan_speed to low; high still allowed', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        dev.modeClipPrev = 17 // was smart
+        dev.processKeyValue(0x1f9, 19) // silent
+        assert.equal(ha.devices[DEVICE_ID]!.properties['fan_speed-'], 'low')
+
+        dev.processKeyValue(0x1fa, 6)
+        assert.equal(ha.devices[DEVICE_ID]!.properties['fan_speed-'], 'high')
+
+        thinq.resetRecorder()
+        dev.setProperty('fan_speed-', 'high')
+        assert.ok(thinq.outbox.length >= 1, 'high fan write allowed in silent mode')
+    })
+})

--- a/tests/cloud/devices/DHUM_056905_WW.test.ts
+++ b/tests/cloud/devices/DHUM_056905_WW.test.ts
@@ -55,9 +55,9 @@ const UV_OFF_NOTIFY_HEX = '000004000000A702044A08A8808C90388CD041E991'
 const BUCKET_LIGHT_ON_NOTIFY_HEX = '000004000000A702048C0287817086'
 const BUCKET_LIGHT_OFF_NOTIFY_HEX = '000004000000A702048A028780473E'
 
-// Sleep timer (0x21b) countdown notifies: remaining seconds in tlv
-const SLEEP_TIMER_59S_NOTIFY_HEX = '000004000000A70204ED0386D03BB028' // ~1 h displayed
-const SLEEP_TIMER_299S_NOTIFY_HEX = '000004000000A70204F30486E0012BC8DA' // ~5 h displayed
+// Sleep timer (0x21b) countdown notifies: remaining minutes in tlv (same unit as setpoint)
+const SLEEP_TIMER_59M_NOTIFY_HEX = '000004000000A70204ED0386D03BB028' // 59 min → ~1 h displayed
+const SLEEP_TIMER_299M_NOTIFY_HEX = '000004000000A70204F30486E0012BC8DA' // 299 min → ~5 h displayed
 const SLEEP_TIMER_OFF_NOTIFY_HEX = '000004000000A70204EE0286C0AFE8'
 
 // Bucket emptied and reinstalled (panel / LG app "water" clear); 0x2b1=256, 0x2b2=0
@@ -264,13 +264,13 @@ describe(MODEL_ID, () => {
         assert.equal(dev.raw_clip_state[0x2d9], undefined)
     })
 
-    test('sleep timer countdown notify uses tlv 0x21b seconds', (t) => {
+    test('sleep timer countdown notify uses tlv 0x21b minutes', (t) => {
         const { ha, thinq } = buildReadyDevice(t)
 
-        thinq.emit('data', buf(SLEEP_TIMER_59S_NOTIFY_HEX))
+        thinq.emit('data', buf(SLEEP_TIMER_59M_NOTIFY_HEX))
         assert.equal(ha.devices[DEVICE_ID]!.properties['off_timer-'], 1)
 
-        thinq.emit('data', buf(SLEEP_TIMER_299S_NOTIFY_HEX))
+        thinq.emit('data', buf(SLEEP_TIMER_299M_NOTIFY_HEX))
         assert.equal(ha.devices[DEVICE_ID]!.properties['off_timer-'], 5)
 
         thinq.emit('data', buf(SLEEP_TIMER_OFF_NOTIFY_HEX))

--- a/tests/cloud/devices/DHUM_056905_WW.test.ts
+++ b/tests/cloud/devices/DHUM_056905_WW.test.ts
@@ -4,6 +4,7 @@ import DUT from '@/cloud/devices/DHUM_056905_WW'
 import type { Metadata } from '@/cloud/thinq'
 import { MockHAConnection, MockThinq2Device, buf, hex } from '@/tests/helpers/mocks'
 import { enableMockTimers, tickMockTimers } from '@/tests/helpers/timers'
+import * as TLV from '@/util/tlv'
 
 const DEVICE_ID = 'test-id'
 const MODEL_ID = 'DHUM_056905_WW'
@@ -12,6 +13,38 @@ const META: Metadata = { modelId: MODEL_ID, modelName: 'TEST DHUM', swVersion: '
 const CAPS_RESPONSE_HEX = '000004000000A70201000AB6A00A7CB541B5A004023220'
 
 const QUERY_RESPONSE_HEX = '00000400000087020400117DC17E50117E827F503094D023D801A8803F5E'
+
+/** Live notify: current humidity 0x336 = 48%. */
+const CURRENT_HUMIDITY_48_NOTIFY_HEX = (() => {
+    const tlv = TLV.build([{ t: 0x336, v: 48 }])
+    const body = [0x04, 0x00, 0x00, 0x00, 0xa7, 0x02, 0x04, 0x00, tlv.length, ...tlv]
+    // CRC not verified by processData; pad 2 bytes
+    return Buffer.from([0x00, 0x00, ...body, 0x00, 0x00])
+        .toString('hex')
+        .toUpperCase()
+})()
+
+function parseSentTlvs(packet: Buffer): TLV.TLV[] {
+    // Same framing as TLVDevice.processData: TLV payload at offset 11, CRC last 2 bytes
+    return TLV.parse(packet.subarray(11, packet.length - 2)).map(({ t, v }) => ({ t, v }))
+}
+
+/** Expected MODE_FAN_CAPS expansion for a requested fan speed. */
+function expectedFanSpeedTlvs(fan: 2 | 6): TLV.TLV[] {
+    const row = (mode: number, fanSpeed: number): TLV.TLV[] => [
+        { t: 0x2d7, v: mode },
+        { t: 0x2d8, v: 0 },
+        { t: 0x2d9, v: fanSpeed },
+    ]
+    return [
+        { t: 0x1fa, v: fan },
+        ...row(17, fan), // Smart
+        ...row(18, fan), // Jet
+        ...row(20, fan), // Spot
+        ...row(21, 6), // Laundry — always high
+        ...row(22, fan), // on-wire-only mode
+    ]
+}
 
 // Live notify when ionizer turned off on device panel
 const IONIZER_OFF_NOTIFY_HEX = '000004000000A702043F02D80085A3'
@@ -101,10 +134,19 @@ describe(MODEL_ID, () => {
 
         const props = ha.devices[DEVICE_ID]!.properties
         assert.equal(props['humidifier-target_humidity'], 35)
-        assert.equal(props['humidifier-current_humidity'], 48)
         assert.equal(props['ionizer-'], 'ON')
         assert.equal(props['uv_nano-'], 'OFF')
         assert.equal(props['fan_speed-'], 'low')
+    })
+
+    test('current humidity publishes from tlv 0x336 (airState.humidity.current)', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        thinq.emit('data', buf(CURRENT_HUMIDITY_48_NOTIFY_HEX))
+        assert.equal(ha.devices[DEVICE_ID]!.properties['humidifier-current_humidity'], 48)
+
+        dev.processKeyValue(0x336, 52)
+        assert.equal(ha.devices[DEVICE_ID]!.properties['humidifier-current_humidity'], 52)
     })
 
     test('uv on/off notify uses tlv 0x2a2', (t) => {
@@ -124,7 +166,7 @@ describe(MODEL_ID, () => {
         assert.equal(ha.devices[DEVICE_ID]!.properties['ionizer-'], 'OFF')
     })
 
-    test('bucket full uses 0x2b2 steady state; 0x2b1=256 clears; 0x336 ignored', (t) => {
+    test('bucket full uses 0x2b2 steady state; 0x2b1=256 clears; humidity does not affect bucket', (t) => {
         const { ha, thinq, dev } = buildReadyDevice(t)
 
         dev.processKeyValue(0x2b2, 1)
@@ -132,6 +174,7 @@ describe(MODEL_ID, () => {
 
         dev.processKeyValue(0x336, 50)
         assert.equal(ha.devices[DEVICE_ID]!.properties['bucket_full-'], 'ON', 'humidity tag must not toggle bucket')
+        assert.equal(ha.devices[DEVICE_ID]!.properties['humidifier-current_humidity'], 50)
 
         thinq.emit('data', buf(BUCKET_EMPTIED_NOTIFY_HEX))
         assert.equal(ha.devices[DEVICE_ID]!.properties['bucket_full-'], 'OFF')
@@ -185,19 +228,40 @@ describe(MODEL_ID, () => {
         assert.ok(!pkt.includes('7DC1'), 'panel-style write has no power/mode attach')
     })
 
-    test('fan_speed write sends per-mode tlv table like device panel', (t) => {
+    test('fan_speed write sends MODE_FAN_CAPS table; laundry fixed high; caps not in raw state', (t) => {
         const { thinq, dev } = buildReadyDevice(t)
 
+        // --- low: modes take fan=2 except Laundry (21) which stays 6 ---
         dev.setProperty('fan_speed-', 'low')
-        const lowPkt = hex(thinq.outbox[thinq.outbox.length - 1])
-        assert.ok(lowPkt.includes('7E82'), 'fan low 0x1fa=2')
-        assert.ok(lowPkt.includes('B642'), 'per-mode fan low table')
+        assert.equal(thinq.outbox.length, 1, 'one fan-speed write packet')
+        const lowTlvs = parseSentTlvs(thinq.outbox[0])
+        assert.deepEqual(lowTlvs, expectedFanSpeedTlvs(2))
 
+        // Capability tags are not global state (would clobber to last row only if stored).
+        assert.equal(dev.raw_clip_state[0x1fa], 2, 'fan setpoint stored')
+        assert.equal(dev.raw_clip_state[0x2d7], undefined, 'mode id not stored as state')
+        assert.equal(dev.raw_clip_state[0x2d8], undefined, 'mode-fan padding not stored as state')
+        assert.equal(dev.raw_clip_state[0x2d9], undefined, 'per-mode fan not stored as state')
+
+        // Laundry row must be high even when requested fan is low
+        const laundryLow = lowTlvs.findIndex((x, i) => x.t === 0x2d7 && x.v === 21 && lowTlvs[i + 2]?.t === 0x2d9)
+        assert.ok(laundryLow >= 0, 'Laundry mode row present')
+        assert.equal(lowTlvs[laundryLow + 2].v, 6, 'Laundry fan always high')
+
+        // --- high: every mode row uses fan=6 ---
         thinq.resetRecorder()
         dev.setProperty('fan_speed-', 'high')
-        const highPkt = hex(thinq.outbox[thinq.outbox.length - 1])
-        assert.ok(highPkt.includes('7E86'), 'fan high 0x1fa=6')
-        assert.ok(highPkt.includes('B646'), 'per-mode fan high table')
+        const highTlvs = parseSentTlvs(thinq.outbox[0])
+        assert.deepEqual(highTlvs, expectedFanSpeedTlvs(6))
+        assert.equal(dev.raw_clip_state[0x1fa], 6)
+        assert.equal(dev.raw_clip_state[0x2d7], undefined)
+
+        // Inbound capability table on notify must also not pollute raw_clip_state
+        dev.processKeyValue(0x2d7, 17)
+        dev.processKeyValue(0x2d8, 0)
+        dev.processKeyValue(0x2d9, 2)
+        assert.equal(dev.raw_clip_state[0x2d7], undefined)
+        assert.equal(dev.raw_clip_state[0x2d9], undefined)
     })
 
     test('sleep timer countdown notify uses tlv 0x21b seconds', (t) => {


### PR DESCRIPTION
MQTT discovery and TLV control for the 056905 clip platform (0xA7/0x87).

Supported features:
- Power and operating modes: smart, jet, silent, spot, laundry
- Current and target humidity (30–70%)
- Fan speed (low/high) via select
- Ionizer, UVnano, and bucket light switches (not available on official integration)
- Off timer: off or 1–8 minutes

Includes capability-packet handling, unit tests from panel captures, and bridge registration.

Note: I can only be certain of compatibility with this exact model of dehumidifier: MD19GQGE0 (other models in this family have slightly different capabilities and controls exposed).