### PR TITLE
Support enrolling newer RTL8720cm/CLIP firmware (protocolVer 4.9): publicKey whitespace fix + generic device fallback

### DIFF
--- a/cloud/devices/generic.ts
+++ b/cloud/devices/generic.ts
@@ -1,0 +1,67 @@
+import HADevice from './base'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import log from '@/util/logging'
+
+// Generic "loose capture" device class. Used as the fallback when a connecting device's
+// modelId has no specific class in ha_bridge's registry. Goal: let onboarding COMPLETE for
+// ANY device (so it stops timing out at "connecting to wifi" and shows up in HA) and stream
+// every raw packet to a diagnostic sensor, so the protocol can be reverse-engineered and the
+// device later reassigned ("binned") to a model-specific class.
+//
+// Deliberately protocol-agnostic: it hooks the raw thinq2 'data' events (no AA..BB / TLV
+// assumption) and never throws out of the handler, to keep the device session stable.
+export default class GenericDevice extends HADevice {
+    publishCache: Record<string, string | number> = {}
+
+    constructor(
+        HA: Connection,
+        readonly thinq: Thinq2Device,
+        readonly meta: Metadata,
+    ) {
+        super(HA, thinq.id)
+        this.thinq.on('data', (buf) => this.onData(buf))
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: meta.modelName || meta.modelId || 'LG device (generic)' }),
+                components: {
+                    raw: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-raw',
+                        state_topic: '$this/raw',
+                        name: 'Raw packet',
+                        icon: 'mdi:code-braces',
+                        entity_category: 'diagnostic',
+                    },
+                    last_seen: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-last-seen',
+                        state_topic: '$this/last_seen',
+                        name: 'Last packet at',
+                        icon: 'mdi:clock-outline',
+                        entity_category: 'diagnostic',
+                    },
+                },
+            }),
+        )
+    }
+
+    onData(buf: Buffer) {
+        try {
+            const hex = buf.toString('hex')
+            log('status', this.id, 'generic raw packet:', hex)
+            this.pub('raw', hex.slice(0, 255)) // HA sensor state caps at 255 chars
+            this.pub('last_seen', new Date().toISOString())
+        } catch (err) {
+            log('status', this.id, 'generic onData error', String(err))
+        }
+    }
+
+    pub(prop: string, value: string | number) {
+        if (this.publishCache[prop] === value) return
+        this.publishCache[prop] = value
+        this.HA.publishProperty(this.id, prop, value)
+    }
+}

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -10,6 +10,7 @@ import Y_V8_Y___W_B32QEUK from './devices/Y_V8_Y___W.B32QEUK'
 import F_V8_Y___W_B_2QEUK from './devices/F_V8_Y___W.B_2QEUK'
 import F_V__F___W_B_1QEUK from './devices/F_V__F___W.B_1QEUK'
 import F_VB_F___W_B_2QEUK from './devices/F_VB_F___W.B_2QEUK'
+import GenericDevice from './devices/generic'
 import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
 import { type Connection } from './homeassistant'
@@ -64,6 +65,15 @@ class Bridge {
         } else if (thinqdev.platform === 'thinq2') {
             const devclass = t2deviceTypes[meta.modelId]
             if (devclass) hadevice = new devclass(this.HA, thinqdev, meta)
+            else {
+                // Loose-capture fallback: a thinq2 device with no specific class still enrolls via a
+                // generic raw-capture class instead of being dropped. This (a) completes onboarding so
+                // the device stays connected, and (b) streams its raw packet hex to a diagnostic HA
+                // sensor — turning an unsupported model into one you can observe and reverse-engineer
+                // a real class from, rather than a silent dead end.
+                console.warn(`thinq2 device type ${meta.modelId} unknown — enrolling with generic raw class`)
+                hadevice = new GenericDevice(this.HA, thinqdev as T2Device, meta)
+            }
         }
 
         if (!hadevice) {

--- a/docs/enrolling-newer-firmware.md
+++ b/docs/enrolling-newer-firmware.md
@@ -1,0 +1,73 @@
+# Enrolling newer ThinQ2 firmware (RTL8720cm "CLIP", protocolVer 4.9)
+
+Notes from bringing up a current-gen LG appliance — an **`BDH_D30007_US` dryer** (DeviceType 202,
+RTK_RTL8720cm Wi-Fi/"CLIP" module, `protocolVer 4.9`, sw 2.11.263) — fully local on rethink. It now
+completes SoftAP → `/route` → cert → MQTT clip, enrolls, and streams telemetry with no LG cloud
+contact. A couple of things differ from older firmware; this documents them so the next person with
+a newer module doesn't repeat the rabbit holes.
+
+## 1. The setup `publicKey` must have no in-band whitespace  *(fixed in this branch)*
+
+`rethink-setup`'s hardcoded `publicKey` was a tab-indented template literal, so every base64 line
+carried a leading `\t` inside the PEM. Older firmware strips it; the RTL8720cm CLIP parser is strict.
+
+With the indentation, `getDeviceInfo` comes back as:
+```
+encrypt_val: ''
+extra: 'POWER_ON|...|encryptRes:ffff'   # the device's RSA-encrypt step failed
+```
+The device then can't build a cert request, reboots onto Wi-Fi, polls `/route` a few times, sends a
+clean `close_notify`, and gives up — which looks like a `/route` problem but is really the setup key.
+
+With a clean PEM (base64 at column 0, same key bytes):
+```
+extra: 'POWER_ON|...|encryptRes:0'
+encrypt_val: 'frkUhxnfo4kzwExk1zF2...'   # non-empty
+```
+…and it proceeds straight through `/route` → `GET /route/certificate` → `POST /device/:id/certificate`
+→ MQTT. See the `rethink-setup: strip whitespace from the setup publicKey` commit.
+
+## 2. Unknown models now loosely enroll instead of being dropped  *(added in this branch)*
+
+Previously an unknown `modelId` was dropped (`ha_bridge` logged `device type ... unknown` and
+returned). A new appliance could provision perfectly and still never appear in HA, get no answer from
+the cloud side, and leave you with no captured data to build a class from. A generic raw-capture
+fallback now enrolls any unknown thinq2 device and republishes its raw packet hex to a diagnostic HA
+sensor, so adding real support becomes a decode exercise against live data. See the
+`ha_bridge: generic raw-capture fallback` commit + `cloud/devices/generic.ts`.
+
+## 3. Legacy TLS profile (modern Node / OpenSSL 3)  *(not changed here — see issues #17/#18)*
+
+This firmware is TLS-1.2-only and prefers legacy ECDHE-CBC-SHA suites. On Node ≥ 20 / OpenSSL 3 the
+server defaults are too strict and the handshake fails. A relaxed profile is needed:
+`minVersion/maxVersion: 'TLSv1.2'`, the legacy ciphers at `@SECLEVEL=0`, and
+`SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION | SSL_OP_LEGACY_SERVER_CONNECT` on the HTTPS and MQTTS
+servers. This is already tracked in issues #17/#18; left out of this PR to keep it focused, but
+required to reproduce the flow on a current Node.
+
+## 4. Post-provision: power-cycle the appliance once
+
+After `releaseDev` the device reboots itself, but on this firmware it then sits in "connecting…",
+streams monitoring for a few minutes, and publishes `clip/provisioning/.../undeploy` (we see
+`req_timesync` with `rssi:-100` = a reboot) — a re-registration loop that never settles. A **hard
+power-cycle of the appliance after provisioning** makes it come up clean and hold a stable connection
+(verified across a full ~50-minute dryer cycle: one MQTT connection, 0 undeploys, ~960 telemetry
+packets). The firmware's own soft-reset appears insufficient where a cold boot is not. Whether a
+cloud/setup-triggerable clean reset exists (a reboot opcode after `releaseDev`, or an AABB reboot
+command over MQTT) is an open question.
+
+## Things that were NOT the problem (so nobody chases them)
+
+- **The fake OTP / shared `publicKey`.** Fine for the local flow: rethink signs the CSR without
+  verifying the `ciphertext`, and the `publicKey` is a fixed value (a real cloud-issued key is
+  byte-identical to the one in the repo). A self-generated `base64(uuid)` OTP also works.
+- **The minimal `/route` body.** Upstream returns `ssl://<config.hostname>:<port>`, which the rethink
+  CA cert covers, so the broker TLS validates fine. (Returning a real per-region AWS mqtt host would
+  break it — the device validates the broker cert against that SNI and rejects it `bad_certificate`.)
+- **`svcphase`.** Our working setup ran `svcphase: 'OP'` rather than the repo's debug-UART `'QA'`; we
+  could not isolate whether OP is *required* for this firmware, so we left the default alone here.
+  Flagging in case it matters for other newer modules.
+
+## Device under test
+`BDH_D30007_US`, did `fe8b2ea0-…-3034dbd055fe`. Full packet captures + decrypted MQTT clip transcripts
+available (SoftAP setup, `/route`, cert, `deploy`/`completeProvisioning`/`_ack`, telemetry).


### PR DESCRIPTION
## Before you read

I wasn't sure how to introduce this into the project, because in order to enroll the machine, I had to broaden some assumptions built into the code that rethink has now - for instance, greedy device enroll vs selective, QA mode in headers, geo regions, crypto pairing, cert storage tics, etc. It's also not finished - I had to cycle the power on the dryer after enrollment was finished to put it in the active state, because I don't know what command to send back to issue a reset. Anyway, it's here for reference, not necessarily to pull in.

## What & why

Brings up a current-gen LG appliance — an **`BDH_D30007_US` dryer** (DeviceType 202, RTK_RTL8720cm
"CLIP" module, `protocolVer 4.9`, sw 2.11.263) — fully local on rethink. It now completes SoftAP →
`/route` → cert → MQTT clip, enrolls, and streams telemetry with **zero LG cloud contact** (verified
across a full ~50-minute dryer cycle: one MQTT connection, 0 undeploys, ~960 telemetry packets).

Two focused code changes + a docs page. Each commit is self-explaining.

## 1. `rethink-setup`: strip whitespace from the setup `publicKey` (the real blocker)

The hardcoded setup `publicKey` is a tab-indented template literal, so every base64 line carries a
leading TAB *inside* the PEM. Older firmware tolerates this; the RTL8720cm CLIP parser is strict —
with the indentation, `getDeviceInfo`'s RSA-encrypt step fails:

```
encrypt_val: ''
extra: 'POWER_ON|...|encryptRes:ffff'
```

…so the device can't build a cert request and loops on `/route` forever — which looks like a `/route`
bug but isn't. A clean PEM (same key bytes, base64 at column 0) → `encryptRes:0`, a valid
`encrypt_val`, and it proceeds straight through `/route/certificate` → cert → MQTT.

## 2. `ha_bridge`: generic raw-capture fallback for unknown device types

Today an unknown `modelId` is dropped (`device type ... unknown` → return), so a brand-new appliance
can provision perfectly and still never enroll — and you get no captured data to build a class from.
The fallback enrolls any unknown thinq2 device via a minimal class that completes onboarding (so it
stays connected) and republishes raw packet hex to a diagnostic HA sensor. Adding real support then
becomes a decode exercise against live data instead of guesswork.

## 3. `docs/enrolling-newer-firmware.md`

Ties it together and documents the findings that don't need code here: the legacy-TLS profile (your
issues #17/#18), the post-provision power-cycle this firmware needs to settle, and the things that
were NOT the problem (fake OTP, shared `publicKey`, minimal `/route` body, `svcphase`) so nobody
re-chases them.

## Deliberately excluded / honest caveats

- No changes to the OTP, the `/route` body, or TLS defaults here — kept focused. The OTP and the
  minimal `/route` body work as-is for this firmware; the legacy-TLS profile is your #17/#18.
- Our working setup also ran `svcphase: 'OP'` (vs the debug-UART `'QA'` default). We could not
  isolate whether OP is *required* for this firmware, so we left your default alone — flagging in
  case it matters for other newer modules.
- The post-provision power-cycle is documented as a manual step; whether a clean software-triggerable
  reset exists is an open question.

## What I'd value your input on

- Does "strict PEM parser on newer CLIP firmware" match your experience with other modules, or is it
  specific to RTL8720cm?
- Is there a cloud- or setup-triggerable clean reset that would avoid the manual power-cycle?
- Preferred shape for the generic fallback — always-on, or behind an opt-in flag?

I can share full packet captures + decrypted MQTT clip transcripts (SoftAP setup, `/route`, cert,
`deploy`/`completeProvisioning`/`_ack`, telemetry). Device did `fe8b2ea0-…-3034dbd055fe`.

---

This was obviously drafted with Claude code and my edits and steering. Further work I won't continue to disclose that, assume it is co-written or just me replying like a caveman or something.
