### PR TITLE
feat: add RAC_0B0001_WW as alias for RAC_056905_WW

### DIFF
--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -27,6 +27,7 @@ const t1deviceTypes: Record<string, T1Factory> = {
 const t2deviceTypes: Record<string, T2Factory> = {
     POT_056905_WW,
     RAC_056905_WW,
+    ['RAC_0B0001_WW']: RAC_056905_WW, // European variant (deviceType 401, RTK_RTL8720cm), same TLV handler
     WIN_056905_WW,
     ['2REF11EIDA__4']: Dev_2REF11EIDA__4,
     ['2RES1VE61NFA2']: Dev_2RES1VE61NFA2,


### PR DESCRIPTION
`RAC_0B0001_WW` is a European variant of the DualCool wall-mount unit (`deviceType: 401`, `RTK_RTL8720cm`, `protocolVer: 4.9`, reports `countryCode: DE`, deployed in Italy). It uses the same TLV packet format as `RAC_056905_WW` and the existing handler works without modification.

Confirmed across five units (models EZ09CSNCSJ1, EZ12CSUCA31, EZ12CSNNCSJ1). All climate entities (power, mode, target temp, fan speed, swing) work correctly in Home Assistant.

The device connects, sends `preDeploy`, completes provisioning, then streams `device_packet` telemetry continuously:

```
incoming clip/provisioning/devices/<uuid>  cmd: preDeploy  kind: RAC_0B0001_WW
incoming lime/devices/<uuid>               cmd: completeProvisioning
incoming clip/message/devices/<uuid>       cmd: completeProvisioning_ack
incoming clip/message/devices/<uuid>       cmd: device_packet  data: "000004000000870204A204..."
incoming clip/message/devices/<uuid>       cmd: device_packet  data: "000004000000870204F304..."
```

Without this alias, rethink logs `thinq2 device type RAC_0B0001_WW unknown` and no HA entities are created.

**Change:** one-line alias in `t2deviceTypes` map — no new handler needed.