### PR TITLE
fix: make management UI path-independent for reverse proxy compatibility

### DIFF
--- a/html/monitor.js
+++ b/html/monitor.js
@@ -4,7 +4,6 @@ let ws
 let reconnectTimer
 
 const baseUrl = new URL(window.location)
-baseUrl.pathname = '/'
 baseUrl.search = ''
 baseUrl.hash = ''
 

--- a/html/panel.js
+++ b/html/panel.js
@@ -27,7 +27,6 @@ get('status_bridge_text').innerText = 'Unknown'
 const devices = {}
 
 const baseUrl = new URL(window.location)
-baseUrl.pathname = '/'
 baseUrl.search = ''
 baseUrl.hash = ''
 
@@ -136,7 +135,7 @@ class DeviceEntry {
         }
 
         td = document.createElement('td')
-        td.innerHTML = `<a class="btn waves-effect waves-light" href="/monitor?id=${this.id}"><i class="material-icons">troubleshoot</i></a>`
+        td.innerHTML = `<a class="btn waves-effect waves-light" href="monitor?id=${this.id}"><i class="material-icons">troubleshoot</i></a>`
         children.push(td)
 
         this.row.replaceChildren(...children)


### PR DESCRIPTION
The management UI hardcodes `baseUrl.pathname = '/'` in both `panel.js` and `monitor.js`. This resets the URL path to root, which breaks the UI when served behind a reverse proxy that prefixes requests with a subpath (e.g. Home Assistant's ingress proxy, which serves the UI under `/api/hassio_ingress/<token>/`).

With the hardcoded pathname, all `fetch()` API calls and `WebSocket` connections resolve against the root of the proxy host rather than the ingress subpath, producing 404s and failed WebSocket upgrades.

Additionally, `panel.js` links to the monitor page with an absolute path (`/monitor?id=...`), which similarly bypasses the proxy prefix.

**Changes:**

- `html/panel.js`: remove `baseUrl.pathname = '/'` — `URL` already inherits the correct pathname from `window.location`
- `html/monitor.js`: same
- `html/panel.js`: change `href="/monitor?id=..."` to relative `href="monitor?id=..."` so the monitor link stays under the proxy prefix

Direct access (no proxy) is unaffected: `window.location.pathname` is `/` in that case, so behaviour is identical.

**Tested on:** Home Assistant OS (HAOS) ingress proxy, five LG AC units (RAC_0B0001_WW). UI loads correctly, WebSocket connection established, device monitor functional.