### PR TITLE
Add ThinQ2 device handler for LG F4X7511TWS washer (VCDWL2QEUK)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The following appliances are currently supported in rethink:
     - 👍 F2J7HG1W, Washing Machine - mostly working,
     - 🫤 F4WV709P1E, Front-Loading Washing Machine - preliminary support
     - 🫤 TW4V9RW9W - preliminary support
+    - 🫤 F4X7511TWS (VCDWL2QEUK), Front-Load Washing Machine - preliminary support
 
 The supported appliances can be used "out of the box" with HomeAssistant or another compatible MQTT consumer.  
 Appliances not listed above can still be used with the bridge mode, but they will not be translated to MQTT. Contributions are welcome!

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following appliances are currently supported in rethink:
     - 👍 F2J7HG1W, Washing Machine - mostly working,
     - 🫤 F4WV709P1E, Front-Loading Washing Machine - preliminary support
     - 🫤 TW4V9RW9W - preliminary support
-    - 🫤 F4X7511TWS (VCDWL2QEUK), Front-Load Washing Machine - preliminary support
+    - 👍 F4X7511TWS (VCDWL2QEUK), Front-Load Washing Machine - mostly working
 
 The supported appliances can be used "out of the box" with HomeAssistant or another compatible MQTT consumer.  
 Appliances not listed above can still be used with the bridge mode, but they will not be translated to MQTT. Contributions are welcome!

--- a/cloud/devices/VCDWL2QEUK.ts
+++ b/cloud/devices/VCDWL2QEUK.ts
@@ -22,20 +22,21 @@ const CONFIG_FRAME_TYPE = 0x88
 const STATUS_RECORD_OFF = 78 // record B (current state) start within the inner body
 const STATUS_RECORD_LEN = 63
 const STATUS_FRAME_LEN = 142 // 15B header + 63B recA + 63B recB + 1B trailer
-// rec[0] of record B = the wash-intensity (soil) level while running; 0x00 when standby/spin-only.
-// So rec[0] doubles as the running-vs-standby discriminator (any non-zero soil level = running). RE'd
-// by stepping the soil level on a fixed course and diffing record B (each level confirmed twice).
+// rec[0] of record B = the wash-intensity (soil) level while washing; 0x00 during the rinse/spin/end
+// phases, the spin-only program, and standby (there is no wash intensity then). RE'd by stepping the soil
+// level on a fixed course and diffing record B (each level confirmed twice). Power/off is keyed on the
+// status byte rec[20], not on this soil lead (see the power-derivation note below).
 const SOIL_BY_LEVEL: Record<number, string> = { 1: 'Light', 3: 'Medium', 5: 'Heavy' }
 const DOOR_FRAME_TYPE = 0x41
 const DOOR_OFFSET = 18 // buf[18] in the 0x41 snapshot: 0x02 = closed, 0x01 = open
 const DOOR_CLOSED = 0x02
 const DOOR_OPEN = 0x01
 
-// Power is derived from the status frame's record B: a running record (leads with a non-zero soil
-// level, see SOIL_BY_LEVEL) → ON; a standby record (leads 0x00 with a zero status byte) → OFF. The
-// standby signature was seen on three live power-offs (all from standby; the standby record is a frozen
-// copy of the last selected program). It is distinct from spin-only, which is also 0x00-led but carries
-// a non-zero status byte in rec[20].
+// Power/off: a record with BOTH a zero soil lead (rec[0]) AND a zero status byte (rec[20]) is LG POWEROFF
+// → OFF (seen on three live power-offs; the two are coincident on every off frame in the captures). Any
+// non-zero status is a running frame → ON: the wash phase (soil-led) and the rinse/spin/end phases +
+// spin-only program (0x00-soil-led but non-zero status) all share the same record-B offsets. The AND
+// (rather than status-alone) guards against a hypothetical soil-led frame with a transient zero status.
 const RECORD_B_STANDBY = 0x00
 
 // Settings (temp/spin/course) are read from the status frame's record B — laid out 03 [TEMP] 0e [SPIN]
@@ -50,7 +51,7 @@ const STATUS_COURSE: Record<number, string> = {
     0x2e: 'Cotton',
     0x54: 'Towels',
     0x4b: 'Quick 14',
-    0x4e: 'Spin only', // only reachable once 0x00-led spin-only frames are decoded (currently ignored)
+    0x4e: 'Spin only', // a 0x00-soil-led program; decoded like the rinse/spin phases (same record-B offsets)
     0x55: 'Drum Clean',
     // RE'd 2026-06-30 by pushing each program from the LG app and reading rec[4] (cross-checked against
     // the rec[19] repeat). English names for the DK programs this unit offers.
@@ -71,8 +72,8 @@ const STATUS_COURSE: Record<number, string> = {
     0x07: 'Baby Steam Care',
     0x73: 'Down Jacket',
     0x88: 'Microplastic Care',
-    0x37: 'Rinse + Spin', // pure rinse+spin: its record B is 0x00-led (no wash phase, like spin-only),
-    // so it currently won't surface — kept for correctness if a 0x03-led frame ever carries it.
+    0x37: 'Rinse + Spin', // pure rinse+spin program: 0x00-soil-led (no wash phase, like spin-only), decoded
+    // via the running path since its status byte is non-zero.
 }
 
 // Rinse (skyl) level — record B rec[26], a clean 0..5 index, RE'd by stepping the rinse option on a
@@ -93,11 +94,15 @@ const SKYL_BY_INDEX: Record<number, string> = {
 const STATUS: Record<number, string> = {
     0x01: 'Detecting',
     0x02: 'Paused',
+    0x03: 'Detecting', // early detection sub-step (cloud state DETECTING)
     0x0b: 'Washing',
     0x0c: 'Rinsing',
     0x0e: 'Spinning',
     0x10: 'End',
-    0x29: 'DrumClean',
+    0x25: 'Detecting', // clothing-recognition sub-step (cloud state CLOTHING_RECOGNITION)
+    0x26: 'Washing', // detergent-input sub-step (cloud state DETERGENT_INPUT)
+    0x27: 'Rinsing', // softener-input sub-step (cloud state SOFTENER_INPUT)
+    0x29: 'Drum Clean',
 }
 
 // EzDispense auto-dosing — also in status-frame record B. The two reservoir enable flags and their
@@ -118,6 +123,24 @@ const OPT_PREWASH = 0x40 // forvask
 const OPT_TURBOWASH = 0x20
 const OPT_BYTE_B = 34 // rec[34]: steam bit
 const OPT_STEAM = 0x10 // damp
+
+// Child-lock + remote-start flags — record B rec[36]. These are toggled on the physical panel (not the
+// LG app), and each toggle emits a 0x92; RE'd by flipping each on/off (three cycles) and correlating
+// record B against the LG cloud's own childLock/remoteStart fields. Validated both in standby and mid-run
+// (rec[36] held its position across a running frame). rec[36] also carries a 0x02 standby-indicator bit
+// (set at rest, clears during a run) which is independent of these two flags, so test each bit directly.
+const FLAGS_BYTE = 36
+const FLAG_CHILD_LOCK = 0x20
+const FLAG_REMOTE_START = 0x10
+
+// "Washes since drum clean" counter — record B rec[27]. A single byte (rec[28] is a constant, not a high
+// byte). RE'd on a full AI-wash: it read 1 throughout the run and stepped to 2 at status = End, matching
+// the LG cloud's TCLCount field (1 → 2) exactly — NOT a lifetime cycle count (this unit exposes no
+// lifetime counter; the byte read 32 before a drum-clean and reset to 1 after, i.e. it's the tub-clean
+// reminder counter). Present at the same offset in the standby record, so it also reads correctly at
+// rest. Published as a plain sensor with NO state_class — it resets at each drum-clean, so total_increasing
+// would wrongly accumulate across the reset.
+const TUB_CLEAN_OFFSET = 27
 
 export default class Device extends AABBDevice {
     constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
@@ -273,6 +296,32 @@ export default class Device extends AABBDevice {
                         name: 'Steam',
                         icon: 'mdi:weather-fog',
                     },
+                    child_lock: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-child_lock',
+                        state_topic: '$this/child_lock',
+                        name: 'Child lock',
+                        icon: 'mdi:lock', // NOT device_class 'lock' — that class is inverted (on = unlocked)
+                        entity_category: 'diagnostic',
+                    },
+                    remote_start: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-remote_start',
+                        state_topic: '$this/remote_start',
+                        name: 'Remote start',
+                        icon: 'mdi:cellphone-wireless',
+                        entity_category: 'diagnostic',
+                    },
+                    tub_clean_count: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-tub_clean_count',
+                        state_topic: '$this/tub_clean_count',
+                        name: 'Washes since drum clean',
+                        icon: 'mdi:washing-machine-alert',
+                        // No state_class: this counter RESETS to a low value at each drum-clean;
+                        // total_increasing would wrongly accumulate across the reset. Raw value is what we want.
+                        entity_category: 'diagnostic',
+                    },
                 },
             }),
         )
@@ -318,24 +367,29 @@ export default class Device extends AABBDevice {
         if (buf.length !== STATUS_FRAME_LEN) return // expected 142B; reject header/layout drift
         const rec = buf.subarray(STATUS_RECORD_OFF, STATUS_RECORD_OFF + STATUS_RECORD_LEN)
 
-        // Standby/off: record B leads with 0x00 and carries a zero status byte (rec[20]). Distinct from
-        // spin-only (0x00-led but rec[20] != 0). Zero the countdown so HA doesn't keep a stale remaining
-        // time alongside power=OFF. temp/spin/course intentionally retain their last-selected values (the
-        // standby record is a frozen copy of the last program); energy is left as-is (total_increasing).
+        // Powered off / standby: BOTH the soil lead (rec[0]) AND the status byte (rec[20]) are 0 (LG
+        // POWEROFF) — coincident on every off frame in the captures. A rinse / spin / end phase and the
+        // spin-only program are 0x00-soil-led but carry a NON-zero status, so they fall through to the
+        // running decode below. Requiring both to be zero (vs status alone) avoids flipping OFF on a
+        // hypothetical soil-led frame with a transient zero status. Zero the countdown so HA doesn't keep
+        // a stale remaining time alongside power=OFF; temp/spin/course retain their last values (the
+        // standby record is a frozen copy of the last program); energy is left as-is.
         if (rec[0] === RECORD_B_STANDBY && rec[20] === 0x00) {
             this.publishProperty('power', 'OFF')
             this.publishProperty('status', 'Off')
             this.publishProperty('remaining_time', 0)
             this.publishProperty('initial_time', 0)
+            // child-lock / remote-start / cycle-count still apply while powered off (same offsets in the
+            // standby record) — publish them so HA reflects the panel state and count at rest.
+            this.publishPersistent(rec)
             return
         }
-        // A running record B leads with a non-zero soil level (rec[0]). Only the 0x00-led layouts reach
-        // here — standby was handled above, so a 0x00 lead is spin-only (0x00 + status != 0), whose record
-        // uses different offsets; ignore it rather than read every field at the wrong place. (Earlier this
-        // tested rec[0] === 0x03, but 0x03 is only the *medium* soil level — that rejected light/heavy
-        // washes; the discriminator is "leads non-zero", not "leads 0x03".)
-        if (rec[0] === RECORD_B_STANDBY) return
-
+        // A running frame. Record B uses the SAME offsets whether it leads with a soil level (wash phase)
+        // or 0x00 (rinse / spin / end phases + the spin-only program): the remaining-time countdown at
+        // rec[13] was cross-checked against the LG cloud's remainTimeMinute at several rinse points, and
+        // initial/spin/course/energy stay consistent across every phase boundary of a full captured cycle.
+        // During the non-wash phases soil (rec[0]) and temp (rec[1]) are simply 0 → decode to 'unknown',
+        // which is correct (no wash intensity / no active heat then).
         this.publishProperty('power', 'ON')
         this.publishProperty('status', STATUS[rec[20]] ?? 'Running')
         this.publishProperty('soil', SOIL_BY_LEVEL[rec[0]] ?? 'unknown')
@@ -355,6 +409,17 @@ export default class Device extends AABBDevice {
         this.publishProperty('prewash', (rec[OPT_BYTE_A] & OPT_PREWASH) !== 0 ? 'ON' : 'OFF')
         this.publishProperty('turbowash', (rec[OPT_BYTE_A] & OPT_TURBOWASH) !== 0 ? 'ON' : 'OFF')
         this.publishProperty('steam', (rec[OPT_BYTE_B] & OPT_STEAM) !== 0 ? 'ON' : 'OFF')
-        // not yet located (declared entities intentionally omitted rather than published wrong): cycle_count, error.
+        this.publishPersistent(rec)
+        // not yet located (declared entities intentionally omitted rather than published wrong): error.
+    }
+
+    // Fields that live at stable record-B offsets and persist across power states: child-lock /
+    // remote-start bits (rec[36]) and the tub-clean wash counter (rec[27] — washes since the last drum
+    // clean, NOT a lifetime count; see the TUB_CLEAN_OFFSET note). Published from both the running and
+    // standby paths (record B uses the same offsets in every frame type, including spin-only).
+    private publishPersistent(rec: Buffer) {
+        this.publishProperty('child_lock', (rec[FLAGS_BYTE] & FLAG_CHILD_LOCK) !== 0 ? 'ON' : 'OFF')
+        this.publishProperty('remote_start', (rec[FLAGS_BYTE] & FLAG_REMOTE_START) !== 0 ? 'ON' : 'OFF')
+        this.publishProperty('tub_clean_count', rec[TUB_CLEAN_OFFSET])
     }
 }

--- a/cloud/devices/VCDWL2QEUK.ts
+++ b/cloud/devices/VCDWL2QEUK.ts
@@ -1,0 +1,360 @@
+import HADevice from './base'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import AABBDevice from './aabb_device'
+
+// LG F4X7511TWS front-load washer — matched on modelId "VCDWL2QEUK". Unlike the 80-byte
+// single-frame F-class washers, this model emits several AABB frame types, discriminated by inner[3]
+// (buf = the AABB body, AA+len and checksum+BB already stripped; buf[0]==0x20 on every frame):
+//   0x88  config frame  — selected program/options; sent at cycle start / setting-change only.
+//   0x92  status frame  — two back-to-back 63-byte records (LG "old state, then new state"); we read
+//                         record B = buf[78:141] (current; leads with the soil level, or 0x00 in standby).
+//                         cf. the dual-record 0xEC washer in PR #77, which reads the *first* record — this
+//                         model uses the second.
+//   0x41  door snapshot — carries the current door state; emitted on every door transition / at ready.
+// Offsets were reverse-engineered against the LG app and validated in HA; see the PR description for the
+// per-offset capture evidence.
+
+const STATUS_FRAME_TYPE = 0x92
+const CONFIG_FRAME_TYPE = 0x88
+const STATUS_RECORD_OFF = 78 // record B (current state) start within the inner body
+const STATUS_RECORD_LEN = 63
+const STATUS_FRAME_LEN = 142 // 15B header + 63B recA + 63B recB + 1B trailer
+// rec[0] of record B = the wash-intensity (soil) level while running; 0x00 when standby/spin-only.
+// So rec[0] doubles as the running-vs-standby discriminator (any non-zero soil level = running). RE'd
+// by stepping the soil level on a fixed course and diffing record B (each level confirmed twice).
+const SOIL_BY_LEVEL: Record<number, string> = { 1: 'Light', 3: 'Medium', 5: 'Heavy' }
+const DOOR_FRAME_TYPE = 0x41
+const DOOR_OFFSET = 18 // buf[18] in the 0x41 snapshot: 0x02 = closed, 0x01 = open
+const DOOR_CLOSED = 0x02
+const DOOR_OPEN = 0x01
+
+// Power is derived from the status frame's record B: a running record (leads with a non-zero soil
+// level, see SOIL_BY_LEVEL) → ON; a standby record (leads 0x00 with a zero status byte) → OFF. The
+// standby signature was seen on three live power-offs (all from standby; the standby record is a frozen
+// copy of the last selected program). It is distinct from spin-only, which is also 0x00-led but carries
+// a non-zero status byte in rec[20].
+const RECORD_B_STANDBY = 0x00
+
+// Settings (temp/spin/course) are read from the status frame's record B — laid out 03 [TEMP] 0e [SPIN]
+// [COURSE]… — not from the sparse 0x88 config frame (which fires only at cycle start and is routinely
+// missed). These status-frame encodings are distinct from the 0x88 indices, RE'd by diffing record B
+// across LG-app "send to machine" pushes one setting at a time. Anything unmapped emits 'unknown'.
+// idx 0 = cold wash (no fixed target temperature) → intentionally left unmapped so HA shows None, not 0°C.
+const STATUS_TEMP_BY_INDEX: Record<number, number> = { 1: 20, 2: 30, 3: 40, 5: 60, 6: 95 } // idx 4 (50 °C) not offered on this model
+const STATUS_SPIN_BY_INDEX: Record<number, number> = { 0: 0, 1: 400, 4: 800, 6: 1000, 8: 1200, 9: 1400 } // full RPM set (no 600 on this model)
+const STATUS_COURSE: Record<number, string> = {
+    0x72: 'AI Wash',
+    0x2e: 'Cotton',
+    0x54: 'Towels',
+    0x4b: 'Quick 14',
+    0x4e: 'Spin only', // only reachable once 0x00-led spin-only frames are decoded (currently ignored)
+    0x55: 'Drum Clean',
+    // RE'd 2026-06-30 by pushing each program from the LG app and reading rec[4] (cross-checked against
+    // the rec[19] repeat). English names for the DK programs this unit offers.
+    0x13: 'Eco 40-60',
+    0x7a: 'TurboWash 39',
+    0x2b: 'Mixed',
+    0x16: 'Delicate',
+    0x1d: 'Easy Care',
+    0x5e: 'Hand/Wool',
+    0x4f: 'Activewear',
+    0x04: 'Allergy Care',
+    0x1b: 'Duvet',
+    0x11: 'Cold Wash',
+    0x81: 'Bedding',
+    0xa9: 'Cuffs & Collars',
+    0x6a: 'Rainy Days',
+    0x42: 'Silent Wash',
+    0x07: 'Baby Steam Care',
+    0x73: 'Down Jacket',
+    0x88: 'Microplastic Care',
+    0x37: 'Rinse + Spin', // pure rinse+spin: its record B is 0x00-led (no wash phase, like spin-only),
+    // so it currently won't surface — kept for correctness if a 0x03-led frame ever carries it.
+}
+
+// Rinse (skyl) level — record B rec[26], a clean 0..5 index, RE'd by stepping the rinse option on a
+// fixed course and time-aligning each frame to its label (the "+pause" variants hold water after rinse).
+const SKYL_OFFSET = 26
+const SKYL_BY_INDEX: Record<number, string> = {
+    0: 'None',
+    1: 'Normal',
+    2: 'Rinse +',
+    3: 'Rinse ++',
+    4: 'Rinse + Hold',
+    5: 'Rinse+ + Hold',
+}
+
+// status from record[20] — a course-dependent "step" id (NOT the F-class STATES indices). Maintenance
+// courses use their own ids (Drum Clean = 0x29); anything unmapped falls back to 'Running' (free-text
+// status, so HA never rejects it).
+const STATUS: Record<number, string> = {
+    0x01: 'Detecting',
+    0x02: 'Paused',
+    0x0b: 'Washing',
+    0x0c: 'Rinsing',
+    0x0e: 'Spinning',
+    0x10: 'End',
+    0x29: 'DrumClean',
+}
+
+// EzDispense auto-dosing — also in status-frame record B. The two reservoir enable flags and their
+// per-wash default doses, RE'd by toggling each dispenser and stepping its dose in the LG app one
+// setting at a time and diffing record B (every captured mL value decoded to an exact byte).
+// Corroborated on the real drum-clean frame (both enabled, 45/30 mL), so the offsets hold in a running
+// cycle, not just at setting-change. Doses go 9–120 mL in 3 mL steps; the byte is the literal mL value.
+const DISP_DETERGENT_EN = 29 // rec[29]: 0x02 = detergent dispenser on, 0x00 = off
+const DISP_SOFTENER_EN = 30 // rec[30]: 0x02 = softener dispenser on, 0x00 = off
+const DISP_DETERGENT_ML = 31 // rec[31]: detergent default dose, direct mL byte
+const DISP_SOFTENER_ML = 32 // rec[32]: softener default dose, direct mL byte
+const DISP_ON = 0x02
+
+// Program option toggles — a bitfield pair in record B, RE'd by flipping one option at a time (each
+// isolated so only its bit moved) and diffing record B; each verified on and off twice.
+const OPT_BYTE_A = 33 // rec[33]: pre-wash + TurboWash bits
+const OPT_PREWASH = 0x40 // forvask
+const OPT_TURBOWASH = 0x20
+const OPT_BYTE_B = 34 // rec[34]: steam bit
+const OPT_STEAM = 0x10 // damp
+
+export default class Device extends AABBDevice {
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        // Declare only the entities this decoder actually populates (no inherited/zombie entities).
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: 'LG Washer' }),
+                components: {
+                    power: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-power',
+                        state_topic: '$this/power',
+                        name: 'Power',
+                        icon: 'mdi:washing-machine',
+                        device_class: 'running',
+                    },
+                    status: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-status',
+                        state_topic: '$this/status',
+                        name: 'Status',
+                        icon: 'mdi:state-machine',
+                        // free-text (NOT device_class:enum): the step codes are course-dependent and we
+                        // emit a 'Running' fallback, both of which an enum constraint would reject.
+                    },
+                    course: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-course',
+                        state_topic: '$this/course',
+                        name: 'Course',
+                        icon: 'mdi:pin-outline',
+                    },
+                    temp: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-temp',
+                        state_topic: '$this/temp',
+                        name: 'Temperature',
+                        device_class: 'temperature',
+                        unit_of_measurement: '°C',
+                        suggested_display_precision: 0,
+                        value_template: "{{ value if value | is_number else 'None' }}",
+                    },
+                    spin: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-spin',
+                        state_topic: '$this/spin',
+                        name: 'Spin',
+                        icon: 'mdi:autorenew',
+                        unit_of_measurement: 'RPM',
+                        value_template: "{{ value if value | is_number else 'None' }}",
+                    },
+                    energy: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-energy',
+                        state_topic: '$this/energy',
+                        name: 'Energy',
+                        icon: 'mdi:lightning-bolt',
+                        device_class: 'energy',
+                        state_class: 'total_increasing',
+                        unit_of_measurement: 'Wh',
+                    },
+                    initial_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-initial_time',
+                        state_topic: '$this/initial_time',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        name: 'Initial time',
+                    },
+                    remaining_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-remaining_time',
+                        state_topic: '$this/remaining_time',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        name: 'Remaining time',
+                    },
+                    door: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-door',
+                        state_topic: '$this/door',
+                        name: 'Door',
+                        device_class: 'door', // payload ON = open, OFF = closed
+                    },
+                    detergent_dispenser: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-detergent_dispenser',
+                        state_topic: '$this/detergent_dispenser',
+                        name: 'Detergent dispenser',
+                        icon: 'mdi:cup-water',
+                    },
+                    softener_dispenser: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-softener_dispenser',
+                        state_topic: '$this/softener_dispenser',
+                        name: 'Softener dispenser',
+                        icon: 'mdi:cup-water',
+                    },
+                    detergent_dose: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-detergent_dose',
+                        state_topic: '$this/detergent_dose',
+                        name: 'Detergent dose',
+                        icon: 'mdi:cup',
+                        device_class: 'volume',
+                        unit_of_measurement: 'mL',
+                        state_class: 'measurement',
+                    },
+                    softener_dose: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-softener_dose',
+                        state_topic: '$this/softener_dose',
+                        name: 'Softener dose',
+                        icon: 'mdi:cup',
+                        device_class: 'volume',
+                        unit_of_measurement: 'mL',
+                        state_class: 'measurement',
+                    },
+                    soil: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-soil',
+                        state_topic: '$this/soil',
+                        name: 'Soil level',
+                        icon: 'mdi:liquid-spot',
+                        // free-text (like course/status): a 'unknown' fallback for unmapped levels.
+                    },
+                    rinse: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-rinse',
+                        state_topic: '$this/rinse',
+                        name: 'Rinse',
+                        icon: 'mdi:water-sync',
+                    },
+                    prewash: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-prewash',
+                        state_topic: '$this/prewash',
+                        name: 'Pre-wash',
+                        icon: 'mdi:water-plus',
+                    },
+                    turbowash: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-turbowash',
+                        state_topic: '$this/turbowash',
+                        name: 'TurboWash',
+                        icon: 'mdi:rotate-right',
+                    },
+                    steam: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-steam',
+                        state_topic: '$this/steam',
+                        name: 'Steam',
+                        icon: 'mdi:weather-fog',
+                    },
+                },
+            }),
+        )
+    }
+
+    processAABB(buf: Buffer) {
+        if (buf[0] !== 0x20 || buf.length < 6) return // < 6 skips the 3-byte heartbeat (need buf[3])
+        if (buf[3] === CONFIG_FRAME_TYPE) return this.processConfig(buf)
+        if (buf[3] === STATUS_FRAME_TYPE) return this.processStatus(buf)
+        if (buf[3] === DOOR_FRAME_TYPE) return this.processDoor(buf)
+        // other frame types (0x53 mid-cycle, 0xA0 end snapshot, 0x16/0x4d idle) are not yet decoded.
+    }
+
+    // 0x41 — door/ready snapshot. Door state is at buf[18]: 0x02 = closed, 0x01 = open (0x05 =
+    // uninitialised at power-on, before the first door event — held, not published). Polarity confirmed
+    // against a labelled open/close capture. The 0x41 frame is only emitted while powered on, so the
+    // entity retains its last value during off/idle periods.
+    private processDoor(buf: Buffer) {
+        if (buf.length <= DOOR_OFFSET) return
+        const v = buf[DOOR_OFFSET]
+        if (v === DOOR_OPEN) this.publishProperty('door', 'ON')
+        else if (v === DOOR_CLOSED) this.publishProperty('door', 'OFF')
+        // any other value (e.g. 0x05 power-on init) leaves the last published state in place
+    }
+
+    // 0x88 — fires at cycle start / setting-change. Settings are read from the status frame (see
+    // processStatus), so this frame only serves as an early power-ON signal before the first 0x92.
+    private processConfig(_buf: Buffer) {
+        this.publishProperty('power', 'ON')
+    }
+
+    // 0x92 — runtime status (current-state record B, laid out [SOIL] [TEMP] 0e [SPIN] [COURSE]…):
+    //   rec[0]  = soil level (also the running discriminator), rec[1] = temp idx, rec[3] = spin idx,
+    //   rec[4]  = course code (status-frame encodings; see the SOIL_BY_LEVEL / STATUS_*_BY_INDEX /
+    //            STATUS_COURSE tables — distinct from the 0x88 indices),
+    //   rec[20] = status code, rec[13] = remaining min, rec[15] = initial min,
+    //   rec[16:18] = energy (big-endian Wh, same shape as the F-class buf[71]*256+buf[72]; confirmed
+    //            against the app's per-cycle "Energiforbrug" — 41 Wh cold, 880 Wh @60° — high byte proven),
+    //   rec[26] = rinse (skyl) level 0..5 (see SKYL_BY_INDEX),
+    //   rec[29:33] = EzDispense (detergent/softener enable + dose mL; see the DISP_* offsets above),
+    //   rec[33] = pre-wash/TurboWash bits, rec[34] = steam bit (see the OPT_* masks above).
+    private processStatus(buf: Buffer) {
+        if (buf.length !== STATUS_FRAME_LEN) return // expected 142B; reject header/layout drift
+        const rec = buf.subarray(STATUS_RECORD_OFF, STATUS_RECORD_OFF + STATUS_RECORD_LEN)
+
+        // Standby/off: record B leads with 0x00 and carries a zero status byte (rec[20]). Distinct from
+        // spin-only (0x00-led but rec[20] != 0). Zero the countdown so HA doesn't keep a stale remaining
+        // time alongside power=OFF. temp/spin/course intentionally retain their last-selected values (the
+        // standby record is a frozen copy of the last program); energy is left as-is (total_increasing).
+        if (rec[0] === RECORD_B_STANDBY && rec[20] === 0x00) {
+            this.publishProperty('power', 'OFF')
+            this.publishProperty('status', 'Off')
+            this.publishProperty('remaining_time', 0)
+            this.publishProperty('initial_time', 0)
+            return
+        }
+        // A running record B leads with a non-zero soil level (rec[0]). Only the 0x00-led layouts reach
+        // here — standby was handled above, so a 0x00 lead is spin-only (0x00 + status != 0), whose record
+        // uses different offsets; ignore it rather than read every field at the wrong place. (Earlier this
+        // tested rec[0] === 0x03, but 0x03 is only the *medium* soil level — that rejected light/heavy
+        // washes; the discriminator is "leads non-zero", not "leads 0x03".)
+        if (rec[0] === RECORD_B_STANDBY) return
+
+        this.publishProperty('power', 'ON')
+        this.publishProperty('status', STATUS[rec[20]] ?? 'Running')
+        this.publishProperty('soil', SOIL_BY_LEVEL[rec[0]] ?? 'unknown')
+        this.publishProperty('rinse', SKYL_BY_INDEX[rec[SKYL_OFFSET]] ?? 'unknown')
+        this.publishProperty('temp', STATUS_TEMP_BY_INDEX[rec[1]] ?? 'unknown')
+        this.publishProperty('spin', STATUS_SPIN_BY_INDEX[rec[3]] ?? 'unknown')
+        this.publishProperty('course', STATUS_COURSE[rec[4]] ?? 'unknown')
+        this.publishProperty('remaining_time', rec[13])
+        this.publishProperty('initial_time', rec[15])
+        this.publishProperty('energy', rec[16] * 256 + rec[17])
+        // EzDispense reservoirs: enable flags (0x02 on / else off) + default dose in mL (literal byte).
+        this.publishProperty('detergent_dispenser', rec[DISP_DETERGENT_EN] === DISP_ON ? 'ON' : 'OFF')
+        this.publishProperty('softener_dispenser', rec[DISP_SOFTENER_EN] === DISP_ON ? 'ON' : 'OFF')
+        this.publishProperty('detergent_dose', rec[DISP_DETERGENT_ML])
+        this.publishProperty('softener_dose', rec[DISP_SOFTENER_ML])
+        // Program option toggles (bitfields): pre-wash + TurboWash in rec[33], steam in rec[34].
+        this.publishProperty('prewash', (rec[OPT_BYTE_A] & OPT_PREWASH) !== 0 ? 'ON' : 'OFF')
+        this.publishProperty('turbowash', (rec[OPT_BYTE_A] & OPT_TURBOWASH) !== 0 ? 'ON' : 'OFF')
+        this.publishProperty('steam', (rec[OPT_BYTE_B] & OPT_STEAM) !== 0 ? 'ON' : 'OFF')
+        // not yet located (declared entities intentionally omitted rather than published wrong): cycle_count, error.
+    }
+}

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -11,6 +11,7 @@ import Y_V8_Y___W_B32QEUK from './devices/Y_V8_Y___W.B32QEUK'
 import F_V8_Y___W_B_2QEUK from './devices/F_V8_Y___W.B_2QEUK'
 import F_V__F___W_B_1QEUK from './devices/F_V__F___W.B_1QEUK'
 import F_VB_F___W_B_2QEUK from './devices/F_VB_F___W.B_2QEUK'
+import VCDWL2QEUK from './devices/VCDWL2QEUK'
 import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
 import { type Connection } from './homeassistant'
@@ -38,6 +39,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['Y_V8_Y___W.B32QEUK']: Y_V8_Y___W_B32QEUK,
     ['F_V8_Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK,
     ['F_V__Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK, // NOTE: we reuse F_V8_Y___W_B_2QEUK as the models appear to be compatible
+    ['VCDWL2QEUK']: VCDWL2QEUK, // LG F4X7511TWS front-load washer (matched on modelId VCDWL2QEUK)
     ['F_V__F___W.B_1QEUK']: F_V__F___W_B_1QEUK,
     ['F_VB_F___W.B_2QEUK']: F_VB_F___W_B_2QEUK, // LG CV74J7S2QA washer/dryer combo
 }

--- a/tests/cloud/devices/VCDWL2QEUK.test.ts
+++ b/tests/cloud/devices/VCDWL2QEUK.test.ts
@@ -1,0 +1,397 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/VCDWL2QEUK'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'VCDWL2QEUK'
+const META: Metadata = { modelId: MODEL_ID, modelName: 'VCDWL2QEUK', swVersion: '0.0.0' }
+
+// All fixtures are REAL frames captured live from the appliance (or, for WASHING/END, the real
+// drum-clean frame with record B replaced by a captured/edited wash record). The AA + length and
+// checksum + BB envelope bytes are not validated on input, so synthetic ones (aa00…00bb) parse
+// identically to the originals.
+
+// 0x88 config — Quick 14, 20 °C, 400 rpm.
+const CFG_COLD = buf(
+    'aa00200a00880000d300020103004d010e0102010020001e0b0000008603c6000e000e00000c020201010200014000000c00000202022d2d1e001f2b47001c630063010700030008000800080008000800020000000000000000000201050025564344574c325145554b000000000000000000000102c712ea140b070000000000000000006400bb',
+)
+// 0x92 status — Drum Clean cycle start (status step 0x29, remaining=initial=72 min).
+const DRUM = buf(
+    'aaff200a0092000196000100ec00800003050e005500000000000000004800480040005529010000000001200202022d1e0000001000041800000000000004000000000000000000000000000000000003050e005500000000000000004800480000005529010009000001200202022d1e000000100104180000000000000400000000000000000000000000000000e163bb',
+)
+// 0x92 status — Quick 14 Washing phase (status 0x0b, remaining=initial=14 min).
+const WASHING = buf(
+    'aa00200a0092000196000100ec00800003050e005500000000000000004800480040005529010000000001200202022d1e0000001000041800000000000004000000000000000000000000000000000003010e014b00000000000000000e000e0000004b0b0100090000011f0202022d1e200000100104180000000000000400000000000000000000000000000000e100bb',
+)
+// 0x92 status — End (status 0x10, remaining 0).
+const END = buf(
+    'aa00200a0092000196000100ec00800003050e005500000000000000004800480040005529010000000001200202022d1e0000001000041800000000000004000000000000000000000000000000000003010e014b000000000000000000000e0000004b100100090000011f0202022d1e200000100104180000000000000400000000000000000000000000000000e100bb',
+)
+// 0x92 standby — powered OFF. REAL frame from a live power-off capture (2026-06-30); record B leads
+// 0x00 with a 0x00 status byte. All three captured power-offs produced this signature.
+const OFF = buf(
+    'aa00200a0092000cbc000100ec00800003020e097200000000000000003b003b0000007201000000000001010200002d1e000000020004180000000000000400000000000000000000000000000000000000000c7200000000000000003b003b0000007200010009000001010200002d1e0000000000041800000000000004000000000000000000000000000000005800bb',
+)
+// 0x41 door/ready snapshots — REAL captured frames (2026-06-29 labelled door capture). Door state is
+// inner[18]: 0x02 = closed, 0x01 = open (polarity confirmed by aligning the labelled open/close events
+// with frame timestamps). These two differ only in that byte (plus seq + checksum).
+const DOOR_CLOSED_F = buf(
+    'aaff200a0041000c76000201030006100e0102100201050025564344574c325145554b000000000000000000000102ce12ea140b07000000000000000000c10ebb',
+)
+const DOOR_OPEN_F = buf(
+    'aaff200a0041000c77000201030006100e0102100101050025564344574c325145554b000000000000000000000102ce12ea140b07000000000000000000063dbb',
+)
+
+// 0x92 status frames for spin + EzDispense mapping — REAL captured frames (2026-06-30 labelled LG-app
+// "send to machine" pushes). Record B carries the selected spin (rec[3]) and the EzDispense reservoir
+// enable flags (rec[29]/rec[30]) plus default doses (rec[31]/rec[32], literal mL). Each was diffed
+// against the labelled push it followed; the offsets also read sane on the real DRUM frame above.
+const SPIN1000 = buf(
+    'aa00200a0092000d3f000100ec00800003020e097200000000000000003b003b0000007201000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000000003020e067200000000000000003800380000007201000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000004600bb',
+) // record B spin idx 6 -> 1000 rpm
+const SPIN1200 = buf(
+    'aa00200a0092000d45000100ec00800003020e067200000000000000003800380000007201000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000000003020e087200000000000000003800380000007201000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000009000bb',
+) // record B spin idx 8 -> 1200 rpm
+const DET_ON = buf(
+    'aa00200a0092000d4a000100ec00800003020e087200000000000000003800380000007201000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000000003020e087200000000000000003800380000007201000000000001010202002d1e0000000200041800000000000004000000000000000000000000000000000b00bb',
+) // record B detergent dispenser on (rec[29]=0x02), softener off
+const SOFT_ON = buf(
+    'aa00200a0092000d57000100ec00800003020e087200000000000000003800380000007201000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000000003020e087200000000000000003800380000007201000000000001010200022d1e0000000200041800000000000004000000000000000000000000000000005c00bb',
+) // record B softener dispenser on (rec[30]=0x02), detergent off
+const DET_DOSE120 = buf(
+    'aa00200a0092000d72000100ec00800003020e08720000000000000000380038000000720100000000000101020000091e0000000200041800000000000004000000000000000000000000000000000003020e08720000000000000000380038000000720100000000000101020000781e0000000200041800000000000004000000000000000000000000000000005000bb',
+) // record B detergent dose 120 mL (rec[31]=0x78), softener 30
+const SOFT_DOSE120 = buf(
+    'aa00200a0092000d63000100ec00800003020e087200000000000000003800380000007201000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000000003020e087200000000000000003800380000007201000000000001010200002d780000000200041800000000000004000000000000000000000000000000007800bb',
+) // record B softener dose 120 mL (rec[32]=0x78), detergent 45
+
+// 0x92 status frames for soil / option / course mapping — REAL captured frames (2026-06-30). Soil is
+// record B rec[0] (also the running discriminator): light 0x01 / medium 0x03 / heavy 0x05, RE'd by
+// stepping the soil level on a fixed course. SOIL_TUNG (rec[0]=0x05) and SOIL_LET (rec[0]=0x01) lock in
+// that non-medium washes still decode (a prior rec[0]===0x03 sentinel rejected them).
+const SOIL_LET = buf(
+    'aa00200a0092000e00000100ec00800003010e047300000000000000009400940000007301000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000000001010e047300000000000000008600860000007301000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000003400bb',
+) // record B rec[0]=0x01 (Light), course Down Jacket 0x73
+const SOIL_MED = buf(
+    'aa00200a0092000e02000100ec00800001010e047300000000000000008600860000007301000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000000003010e047300000000000000009400940000007301000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000008800bb',
+) // record B rec[0]=0x03 (Medium)
+const SOIL_TUNG = buf(
+    'aa00200a0092000e04000100ec00800003010e047300000000000000009400940000007301000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000000005010e04730000000000000000b200b20000007301000000000001010200002d1e000000020004180000000000000400000000000000000000000000000000f700bb',
+) // record B rec[0]=0x05 (Heavy)
+// Program option toggles — record B rec[33] (pre-wash 0x40 / TurboWash 0x20) and rec[34] (steam 0x10),
+// each isolated so only its bit moved vs an all-off baseline.
+const STEAM_ON = buf(
+    'aa00200a0092000e0c000100ec00800003050e097200000000000000005b005b0000007201000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000000003050e097200000000000000006e006e0000007201000000000001010200002d1e0010000200041800000000000004000000000000000000000000000000005600bb',
+) // record B rec[34]=0x10 (steam on)
+const TURBOWASH_ON = buf(
+    'aa00200a0092000e12000100ec00800003030e092e0000000000000000ef00ef0000002e01000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000000003030e062e0000000000000000c400c40000002e01000000000001010200002d1e2000000200041800000000000004000000000000000000000000000000007d00bb',
+) // record B rec[33]=0x20 (TurboWash on), course Cotton 0x2e
+const FORVASK_ON = buf(
+    'aa00200a0092000e1b000100ec00800003030e062e0000000000000000dd00dd0000002e01000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000000003030e062e0000000000000000ee00ee0000002e01000000000001010200002d1e400000020004180000000000000400000000000000000000000000000000b600bb',
+) // record B rec[33]=0x40 (pre-wash on)
+// New course codes (rec[4]), REAL captured frames.
+const ECO = buf(
+    'aa00200a0092000db7000100ec00800005030e092e00000000000000010101010000002e01000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000000003030e09130000000000000000dc00dc0000001301000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000008e00bb',
+) // record B course 0x13 (Eco 40-60)
+const DELIKAT = buf(
+    'aa00200a0092000ddd000100ec00800003030e062b00000000000000005100510000002b01000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000000003010e041600000000000000002d002d0000001601000009000001010200002d1e0000000200041800000000000004000000000000000000000000000000004200bb',
+) // record B course 0x16 (Delicate)
+// Rinse (skyl) level — record B rec[26] (0..5), REAL captured frames (selected by rec[26] value so the
+// fixtures don't depend on capture-label timing).
+const SKYL_NONE = buf(
+    'aa00200a0092000e4f000100ec00800003030e092e0000000000000000ef00ef0000002e01000000000001010200002d1e00000002000418000000000000040000000000000000000000000000000000030300092e0000000000000000d100d10000002e01000000000000010200002d1e0000000200041800000000000004000000000000000000000000000000008c00bb',
+) // record B rec[26]=0 (None)
+const SKYL_PLUS = buf(
+    'aa00200a0092000e55000100ec008000030300092e0000000000000000d100d10000002e01000000000000010200002d1e0000000200041800000000000004000000000000000000000000000000000003030f092e0000000000000000fe00fe0000002e01000000000002010200002d1e000000020004180000000000000400000000000000000000000000000000fc00bb',
+) // record B rec[26]=2 (Rinse +)
+const SKYL_HOLD = buf(
+    'aa00200a0092000e5f000100ec008000030310092e00000000000000010d010d0000002e01000000000003010200002d1e00000002000418000000000000040000000000000000000000000000000000030312092e0000000000000000ef00ef0000002e01000000000004010200002d1e0000000200041800000000000004000000000000000000000000000000000900bb',
+) // record B rec[26]=4 (Rinse + Hold)
+const MIKROPLAST = buf(
+    'aa00200a0092000e6e000100ec00800003030e092e0000000000000000ef00ef0000002e01000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000000003030e068800000000000000007000700000008801000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000004200bb',
+) // record B course 0x88 (Microplastic Care)
+
+// Return a copy of an AA..BB frame with one INNER byte patched (inner[i] = full[2 + i]).
+function patchInner(frame: Buffer, innerIndex: number, value: number): Buffer {
+    const f = Buffer.from(frame)
+    f[2 + innerIndex] = value
+    return f
+}
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('config exposes a lean component set (no inherited zombie entities)', () => {
+        const { ha } = makeDevice()
+        const cfg = ha.devices[DEVICE_ID].config
+        assert.ok(cfg, 'config published')
+        const components = cfg!.components as Record<string, Record<string, unknown>>
+        // implemented entities present
+        for (const c of [
+            'power',
+            'status',
+            'course',
+            'temp',
+            'spin',
+            'energy',
+            'initial_time',
+            'remaining_time',
+            'door',
+        ]) {
+            assert.ok(components[c], `component ${c} present`)
+        }
+        // power is a read-only binary_sensor (no untested command), status is free-text (no enum)
+        assert.equal(components.power.platform, 'binary_sensor')
+        assert.equal(components.power.device_class, 'running')
+        assert.equal(components.status.device_class, undefined, 'status has no enum constraint')
+        assert.equal(components.status.options, undefined)
+        // door is a read-only binary_sensor (device_class door: payload ON=open, OFF=closed)
+        assert.equal(components.door.platform, 'binary_sensor')
+        assert.equal(components.door.device_class, 'door')
+        // not-yet-implemented fields are NOT declared (would be stuck-unknown zombies in HA)
+        for (const c of ['error', 'error_message', 'cycles', 'remote_start', 'door_lock', 'start', 'pause']) {
+            assert.equal(components[c], undefined, `zombie component ${c} absent`)
+        }
+    })
+
+    test('0x88 config frame marks power ON (settings now sourced from the status frame)', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', CFG_COLD)
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
+    })
+
+    test('0x92 status decodes course, temp, spin from record B', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', WASHING) // record B: temp idx 1 (20°C), spin idx 1 (400), course 0x4b (Quick 14)
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.course, 'Quick 14')
+        assert.equal(p.temp, 20)
+        assert.equal(p.spin, 400)
+    })
+
+    test('0x92 status (Washing) decodes status, remaining, initial, power', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', WASHING)
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.power, 'ON')
+        assert.equal(p.status, 'Washing')
+        assert.equal(p.remaining_time, 14)
+        assert.equal(p.initial_time, 14)
+        assert.ok((p.remaining_time as number) <= (p.initial_time as number), 'remaining <= initial')
+    })
+
+    test('0x92 status (Drum Clean) maps step 0x29 to DrumClean, remaining/initial = 72', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', DRUM)
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.status, 'DrumClean')
+        assert.equal(p.course, 'Drum Clean') // course code 0x55
+        assert.equal(p.remaining_time, 72)
+        assert.equal(p.initial_time, 72)
+    })
+
+    test('0x92 status (End) decodes status=End, remaining=0', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', END)
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.status, 'End')
+        assert.equal(p.remaining_time, 0)
+        assert.equal(p.initial_time, 14) // initial stays at the selected duration when remaining hits 0
+    })
+
+    test('0x92 energy decodes as big-endian Wh (rec[16] high, rec[17] low)', () => {
+        const { ha, thinq } = makeDevice()
+        // rec[17] is inner[95]; ground truth: the cold Quick-14 reported 41 Wh with rec[16]=0.
+        thinq.emit('data', patchInner(WASHING, 95, 41))
+        assert.equal(ha.devices[DEVICE_ID].properties.energy, 41)
+        // exercise the high byte: rec[16]=inner[94]=1, rec[17]=inner[95]=16 -> 256+16
+        const f = patchInner(WASHING, 94, 1)
+        f[2 + 95] = 16
+        thinq.emit('data', f)
+        assert.equal(ha.devices[DEVICE_ID].properties.energy, 272)
+    })
+
+    test('unconfirmed status-frame enum indices fall back to unknown (never a wrong number)', () => {
+        const { ha, thinq } = makeDevice()
+        // record B starts at inner[78]; rec[1]=temp inner[79], rec[3]=spin inner[81], rec[4]=course inner[82]
+        thinq.emit('data', patchInner(WASHING, 79, 0xff))
+        assert.equal(ha.devices[DEVICE_ID].properties.temp, 'unknown')
+        thinq.emit('data', patchInner(WASHING, 81, 0xff))
+        assert.equal(ha.devices[DEVICE_ID].properties.spin, 'unknown')
+        thinq.emit('data', patchInner(WASHING, 82, 0xff))
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'unknown')
+    })
+
+    test('soil level decodes from rec[0]; light/heavy washes still decode (sentinel is "non-zero lead")', () => {
+        const { ha, thinq } = makeDevice()
+        // Regression: a prior rec[0]===0x03 sentinel rejected any non-medium soil. rec[0] is the soil
+        // level (0x01 light / 0x03 medium / 0x05 heavy); all three must decode as running, not be dropped.
+        thinq.emit('data', SOIL_LET)
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.soil, 'Light')
+        thinq.emit('data', SOIL_MED)
+        assert.equal(ha.devices[DEVICE_ID].properties.soil, 'Medium')
+        thinq.emit('data', SOIL_TUNG)
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.soil, 'Heavy')
+    })
+
+    test('0x92 frame of unexpected length is ignored', () => {
+        const { ha, thinq } = makeDevice()
+        const before = ha.devices[DEVICE_ID].properties.status
+        thinq.emit('data', buf('aa00200a0092000196000100ec0080000300bb')) // 0x92 type, too short
+        assert.equal(ha.devices[DEVICE_ID].properties.status, before)
+    })
+
+    test('0x92 standby frame (record B leads 0x00 with status 0x00) decodes power OFF', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', WASHING) // running first (remaining_time -> 14)
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.remaining_time, 14)
+        thinq.emit('data', OFF) // then powered off
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Off')
+        // the countdown is cleared so HA doesn't show a stale remaining time while OFF
+        assert.equal(ha.devices[DEVICE_ID].properties.remaining_time, 0)
+        assert.equal(ha.devices[DEVICE_ID].properties.initial_time, 0)
+    })
+
+    test('spin-only frame (record B leads 0x00 but status != 0) is NOT mistaken for OFF', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', WASHING) // power ON
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
+        // REAL spin-only frame: record B leads 0x00 (like standby) but rec[20]=0x01 (active). The OFF rule
+        // must rely on rec[20]==0x00, so this is ignored, NOT read as OFF — guards against a future
+        // simplification to `rec[0]==0x00 -> OFF` that would flip power off mid-spin.
+        const SPINONLY = buf(
+            'aa00200a0092000c1a000100ec00800003020e097200000000000000003b003b0000007201000000000001010200002d1e00000002000418000000000000040000000000000000000000000000000000000000014e00000000000000000800080000004e01000009000000010200002d1e0000000200041800000000000004000000000000000000000000000000006e00bb',
+        )
+        thinq.emit('data', SPINONLY)
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON', 'spin-only must not be read as OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Washing', 'ignored frame leaves prior status')
+    })
+
+    test('0x41 door snapshot decodes open/closed from buf[18]', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', DOOR_CLOSED_F)
+        assert.equal(ha.devices[DEVICE_ID].properties.door, 'OFF')
+        thinq.emit('data', DOOR_OPEN_F)
+        assert.equal(ha.devices[DEVICE_ID].properties.door, 'ON')
+        thinq.emit('data', DOOR_CLOSED_F)
+        assert.equal(ha.devices[DEVICE_ID].properties.door, 'OFF')
+    })
+
+    test('0x41 with an uninitialised door byte (0x05 at power-on) holds the last state', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', DOOR_OPEN_F)
+        assert.equal(ha.devices[DEVICE_ID].properties.door, 'ON')
+        thinq.emit('data', patchInner(DOOR_OPEN_F, 18, 0x05)) // neither open nor closed -> no publish
+        assert.equal(ha.devices[DEVICE_ID].properties.door, 'ON', 'last state held, not overwritten')
+    })
+
+    test('0x92 status maps spin index 6 -> 1000 rpm and 8 -> 1200 rpm', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SPIN1000)
+        assert.equal(ha.devices[DEVICE_ID].properties.spin, 1000)
+        thinq.emit('data', SPIN1200)
+        assert.equal(ha.devices[DEVICE_ID].properties.spin, 1200)
+    })
+
+    test('config exposes the EzDispense entities (2 enable binary_sensors + 2 dose sensors)', () => {
+        const { ha } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        for (const c of ['detergent_dispenser', 'softener_dispenser', 'detergent_dose', 'softener_dose']) {
+            assert.ok(components[c], `component ${c} present`)
+        }
+        assert.equal(components.detergent_dispenser.platform, 'binary_sensor')
+        assert.equal(components.softener_dispenser.platform, 'binary_sensor')
+        assert.equal(components.detergent_dose.platform, 'sensor')
+        assert.equal(components.detergent_dose.unit_of_measurement, 'mL')
+        assert.equal(components.softener_dose.unit_of_measurement, 'mL')
+    })
+
+    test('0x92 record B decodes EzDispense enable flags (detergent and softener independently)', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', DET_ON)
+        assert.equal(ha.devices[DEVICE_ID].properties.detergent_dispenser, 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.softener_dispenser, 'OFF')
+        thinq.emit('data', SOFT_ON)
+        assert.equal(ha.devices[DEVICE_ID].properties.detergent_dispenser, 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties.softener_dispenser, 'ON')
+    })
+
+    test('0x92 record B decodes EzDispense doses as literal mL (detergent rec[31], softener rec[32])', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', DET_DOSE120)
+        assert.equal(ha.devices[DEVICE_ID].properties.detergent_dose, 120)
+        assert.equal(ha.devices[DEVICE_ID].properties.softener_dose, 30)
+        thinq.emit('data', SOFT_DOSE120)
+        assert.equal(ha.devices[DEVICE_ID].properties.softener_dose, 120)
+        assert.equal(ha.devices[DEVICE_ID].properties.detergent_dose, 45)
+    })
+
+    test('0x92 decodes newly-mapped course codes (rec[4])', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', ECO)
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'Eco 40-60')
+        thinq.emit('data', DELIKAT)
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'Delicate')
+        thinq.emit('data', MIKROPLAST)
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'Microplastic Care')
+    })
+
+    test('0x92 decodes rinse (skyl) level from rec[26]', () => {
+        const { ha, thinq } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        assert.equal(components.rinse.platform, 'sensor')
+        thinq.emit('data', SKYL_NONE)
+        assert.equal(ha.devices[DEVICE_ID].properties.rinse, 'None')
+        thinq.emit('data', SKYL_PLUS)
+        assert.equal(ha.devices[DEVICE_ID].properties.rinse, 'Rinse +')
+        thinq.emit('data', SKYL_HOLD)
+        assert.equal(ha.devices[DEVICE_ID].properties.rinse, 'Rinse + Hold')
+    })
+
+    test('config exposes the soil + option entities', () => {
+        const { ha } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        assert.equal(components.soil.platform, 'sensor')
+        for (const c of ['prewash', 'turbowash', 'steam']) {
+            assert.ok(components[c], `component ${c} present`)
+            assert.equal(components[c].platform, 'binary_sensor')
+        }
+    })
+
+    test('0x92 record B decodes option bitflags (pre-wash rec[33]&0x40, TurboWash rec[33]&0x20, steam rec[34]&0x10)', () => {
+        const { ha, thinq } = makeDevice()
+        // baseline: all options off (SOIL_MED has rec[33]=rec[34]=0x00)
+        thinq.emit('data', SOIL_MED)
+        assert.equal(ha.devices[DEVICE_ID].properties.prewash, 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties.turbowash, 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties.steam, 'OFF')
+        thinq.emit('data', FORVASK_ON)
+        assert.equal(ha.devices[DEVICE_ID].properties.prewash, 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.turbowash, 'OFF')
+        thinq.emit('data', TURBOWASH_ON)
+        assert.equal(ha.devices[DEVICE_ID].properties.turbowash, 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.prewash, 'OFF')
+        thinq.emit('data', STEAM_ON)
+        assert.equal(ha.devices[DEVICE_ID].properties.steam, 'ON')
+    })
+
+    test('unknown frame type and non-envelope frames are ignored', () => {
+        const { ha, thinq } = makeDevice()
+        const before = ha.devices[DEVICE_ID].properties.power
+        thinq.emit('data', buf('aa00200a005a0001020304050600bb')) // 0x5A course-list
+        thinq.emit('data', buf('aa0720e90a91bb')) // 3-byte heartbeat
+        thinq.emit('data', buf('001122')) // not an AA..BB envelope
+        assert.equal(ha.devices[DEVICE_ID].properties.power, before)
+    })
+})

--- a/tests/cloud/devices/VCDWL2QEUK.test.ts
+++ b/tests/cloud/devices/VCDWL2QEUK.test.ts
@@ -113,6 +113,49 @@ const MIKROPLAST = buf(
     'aa00200a0092000e6e000100ec00800003030e092e0000000000000000ef00ef0000002e01000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000000003030e068800000000000000007000700000008801000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000004200bb',
 ) // record B course 0x88 (Microplastic Care)
 
+// Child-lock / remote-start flags — record B rec[36]. REAL captured frames (2026-07-01): each toggled on
+// the physical panel while capturing, and correlated against the LG cloud's childLock/remoteStart fields.
+// rec[36] base carries a 0x02 standby-indicator bit (set at rest, clears in a run) independent of these.
+const CHILD_LOCK_ON = buf(
+    'aa00200a0092000ec5000100ec00800003030e097200000000000000003b003b0000007201000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000000003030e097200000000000000003b003b0000007201000000000001010200002d1e00000022000418000000000000040000000000000000000000000000000082' +
+        '00bb',
+) // record B rec[36]=0x22 -> child lock on, remote start off
+const REMOTE_START_ON = buf(
+    'aa00200a0092000ecc000100ec00800003030e097200000000000000003b003b0000007201000000000001010200002d1e0000000200041800000000000004000000000000000000000000000000000003030e097200000000000000003b003b0000007201000000000001010200002d1e00000012000418000000000000040000000000000000000000000000000087' +
+        '00bb',
+) // record B rec[36]=0x12 -> remote start on, child lock off
+// Mid-cycle (status 0x0b Washing) with BOTH flags set — proves rec[36] holds its offset in a running frame.
+const RUN_CHILD_REMOTE = buf(
+    'aa00200a009200100b000100ec00800003030e097200000000000000002b003b010800720b260006000001010202022d1e0000001001061800000000000004000000000000000000000000000000000003030e097200000000000000002b003b010900720b260006000001010202022d1e0000003001061800000000000004000000000000000000000000000000009b' +
+        '00bb',
+) // record B rec[36]=0x30 -> child lock + remote start both on
+
+// Cycle-count end frame — REAL last standby-off frame of the AI-wash capture (2026-07-01): record B
+// leads 0x00 with a 0x00 status byte (powered off) and rec[27] = 2, the incremented lifetime count that
+// matched the LG cloud's own value at cycle end.
+const CYCLE_END = buf(
+    'aa00200a0092001101000100ec0080000000000c72000000000000000000003b01590072100e0009000001020202022d1e000000000006180000000000000400000000000000000000000000000000000000000c72000000000000000000003b0159007200100009000001020202022d1e0000000000061800000000000004000000000000000000000000000000007e' +
+        '00bb',
+) // record B rec[0]=0x00/rec[20]=0x00 (standby off), rec[27]=2 (cycle count)
+
+// Back-half phase frames — REAL captured frames (2026-07-01 AI wash). Record B leads soil=0x00 during
+// rinse/spin/end but uses the SAME offsets as the wash phase (remaining=rec[13], spin=rec[3], course=
+// rec[4], status=rec[20]) — verified against the LG cloud. These must decode as running, not be dropped.
+const RINSE = buf(
+    'aa00200a009200102d000100ec00800003030e0972000000000000000021003b011a00720b260006000001010202022d1e0000001001061800000000000004000000000000000000000000000000000000000e0972000000000000000020003b011c00720c0b0006000001010202022d1e00000010010418000000000000040000000000000000000000000000000092' +
+        '00bb',
+) // record B: status 0x0c Rinsing, remaining 32, spin idx 9 (1400), course 0x72 (AI Wash)
+const SPINNING = buf(
+    'aa00200a00920010a3000100ec00800000000e097200000000000000000d003b013400720c270006000001010202022d1e00000010010618000000000000040000000000000000000000000000000000000000097200000000000000000c003b013500720e0c0006000001010202022d1e000000100104180000000000000400000000000000000000000000000000b8' +
+        '00bb',
+) // record B: status 0x0e Spinning, remaining 12
+// Spin-only PROGRAM — REAL frame (2026-06-29). Also 0x00-soil-led; decodes with the same offsets (this
+// disproves the earlier "spin-only uses a shifted layout" note).
+const SPIN_ONLY = buf(
+    'aa00200a0092000c1a000100ec00800003020e097200000000000000003b003b0000007201000000000001010200002d1e00000002000418000000000000040000000000000000000000000000000000000000014e00000000000000000800080000004e01000009000000010200002d1e0000000200041800000000000004000000000000000000000000000000006e' +
+        '00bb',
+) // record B: status 0x01, course 0x4e (Spin only), spin idx 1 (400), remaining 8
+
 // Return a copy of an AA..BB frame with one INNER byte patched (inner[i] = full[2 + i]).
 function patchInner(frame: Buffer, innerIndex: number, value: number): Buffer {
     const f = Buffer.from(frame)
@@ -144,6 +187,9 @@ describe(MODEL_ID, () => {
             'initial_time',
             'remaining_time',
             'door',
+            'child_lock',
+            'remote_start',
+            'tub_clean_count',
         ]) {
             assert.ok(components[c], `component ${c} present`)
         }
@@ -156,7 +202,7 @@ describe(MODEL_ID, () => {
         assert.equal(components.door.platform, 'binary_sensor')
         assert.equal(components.door.device_class, 'door')
         // not-yet-implemented fields are NOT declared (would be stuck-unknown zombies in HA)
-        for (const c of ['error', 'error_message', 'cycles', 'remote_start', 'door_lock', 'start', 'pause']) {
+        for (const c of ['error', 'error_message', 'door_lock', 'start', 'pause']) {
             assert.equal(components[c], undefined, `zombie component ${c} absent`)
         }
     })
@@ -187,11 +233,11 @@ describe(MODEL_ID, () => {
         assert.ok((p.remaining_time as number) <= (p.initial_time as number), 'remaining <= initial')
     })
 
-    test('0x92 status (Drum Clean) maps step 0x29 to DrumClean, remaining/initial = 72', () => {
+    test('0x92 status (Drum Clean) maps step 0x29 to Drum Clean, remaining/initial = 72', () => {
         const { ha, thinq } = makeDevice()
         thinq.emit('data', DRUM)
         const p = ha.devices[DEVICE_ID].properties
-        assert.equal(p.status, 'DrumClean')
+        assert.equal(p.status, 'Drum Clean')
         assert.equal(p.course, 'Drum Clean') // course code 0x55
         assert.equal(p.remaining_time, 72)
         assert.equal(p.initial_time, 72)
@@ -263,19 +309,27 @@ describe(MODEL_ID, () => {
         assert.equal(ha.devices[DEVICE_ID].properties.initial_time, 0)
     })
 
-    test('spin-only frame (record B leads 0x00 but status != 0) is NOT mistaken for OFF', () => {
+    test('OFF needs BOTH soil==0 and status==0 — a soil-led frame with a zero status stays running', () => {
         const { ha, thinq } = makeDevice()
-        thinq.emit('data', WASHING) // power ON
-        assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
+        const p = ha.devices[DEVICE_ID].properties
+        // soil-led (rec[0]=0x03) but status byte 0 → must NOT flip OFF (guards the AND discriminator; with
+        // a status-alone check this would wrongly power off and zero the countdown mid-cycle).
+        thinq.emit('data', patchInner(WASHING, 98, 0x00)) // inner[98] = rec[20]
+        assert.equal(p.power, 'ON')
+        assert.equal(p.status, 'Running') // 0x00 unmapped -> free-text fallback, not 'Off'
+        // and the true standby frame (soil==0 AND status==0) IS off
+        thinq.emit('data', OFF)
+        assert.equal(p.power, 'OFF')
+        assert.equal(p.status, 'Off')
+    })
+
+    test('a 0x00-soil-led frame with status != 0 is powered ON, never OFF (rec[20] is the discriminator)', () => {
+        const { ha, thinq } = makeDevice()
         // REAL spin-only frame: record B leads 0x00 (like standby) but rec[20]=0x01 (active). The OFF rule
-        // must rely on rec[20]==0x00, so this is ignored, NOT read as OFF — guards against a future
-        // simplification to `rec[0]==0x00 -> OFF` that would flip power off mid-spin.
-        const SPINONLY = buf(
-            'aa00200a0092000c1a000100ec00800003020e097200000000000000003b003b0000007201000000000001010200002d1e00000002000418000000000000040000000000000000000000000000000000000000014e00000000000000000800080000004e01000009000000010200002d1e0000000200041800000000000004000000000000000000000000000000006e00bb',
-        )
-        thinq.emit('data', SPINONLY)
+        // keys on rec[20]==0x00, so this decodes as running — NOT read as OFF, and NOT dropped.
+        thinq.emit('data', SPIN_ONLY)
         assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON', 'spin-only must not be read as OFF')
-        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Washing', 'ignored frame leaves prior status')
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Detecting') // rec[20]=0x01
     })
 
     test('0x41 door snapshot decodes open/closed from buf[18]', () => {
@@ -384,6 +438,76 @@ describe(MODEL_ID, () => {
         assert.equal(ha.devices[DEVICE_ID].properties.prewash, 'OFF')
         thinq.emit('data', STEAM_ON)
         assert.equal(ha.devices[DEVICE_ID].properties.steam, 'ON')
+    })
+
+    test('0x92 record B decodes child_lock (rec[36]&0x20) and remote_start (rec[36]&0x10)', () => {
+        const { ha, thinq } = makeDevice()
+        const p = ha.devices[DEVICE_ID].properties
+        thinq.emit('data', CHILD_LOCK_ON) // rec[36]=0x22
+        assert.equal(p.child_lock, 'ON')
+        assert.equal(p.remote_start, 'OFF')
+        thinq.emit('data', REMOTE_START_ON) // rec[36]=0x12
+        assert.equal(p.child_lock, 'OFF')
+        assert.equal(p.remote_start, 'ON')
+        thinq.emit('data', RUN_CHILD_REMOTE) // rec[36]=0x30, mid-cycle (status Washing)
+        assert.equal(p.status, 'Washing', 'still a running frame')
+        assert.equal(p.child_lock, 'ON')
+        assert.equal(p.remote_start, 'ON')
+    })
+
+    test('flags publish in standby too (rec[36] read before the OFF short-circuit)', () => {
+        const { ha, thinq } = makeDevice()
+        // prime both flags ON from a running frame, then a real standby OFF frame (rec[36]=0x00) must clear them
+        thinq.emit('data', RUN_CHILD_REMOTE)
+        thinq.emit('data', OFF)
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.power, 'OFF')
+        assert.equal(p.child_lock, 'OFF')
+        assert.equal(p.remote_start, 'OFF')
+    })
+
+    test('0x92 record B decodes tub_clean_count / washes-since-drum-clean (rec[27]) in both run and standby', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', RUN_CHILD_REMOTE) // mid-cycle, count not yet incremented
+        assert.equal(ha.devices[DEVICE_ID].properties.tub_clean_count, 1)
+        thinq.emit('data', CYCLE_END) // powered off at cycle end, count stepped to 2 (matches cloud TCLCount)
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties.tub_clean_count, 2)
+    })
+
+    test('0x00-soil-led back-half phases decode as running (rinse/spin/end + spin-only)', () => {
+        const { ha, thinq } = makeDevice()
+        const p = ha.devices[DEVICE_ID].properties
+        thinq.emit('data', RINSE)
+        assert.equal(p.power, 'ON')
+        assert.equal(p.status, 'Rinsing')
+        assert.equal(p.remaining_time, 32)
+        assert.equal(p.spin, 1400) // spin target still readable during rinse
+        assert.equal(p.course, 'AI Wash')
+        thinq.emit('data', SPINNING)
+        assert.equal(p.power, 'ON')
+        assert.equal(p.status, 'Spinning')
+        assert.equal(p.remaining_time, 12)
+        // spin-only program is a distinct 0x00-led frame — must decode, not read as OFF
+        thinq.emit('data', SPIN_ONLY)
+        assert.equal(p.power, 'ON')
+        assert.equal(p.course, 'Spin only')
+        assert.equal(p.spin, 400)
+        assert.equal(p.remaining_time, 8)
+    })
+
+    test('sub-step status codes map to their phase (0x03/0x25 Detecting, 0x26 Washing, 0x27 Rinsing)', () => {
+        const { ha, thinq } = makeDevice()
+        const p = ha.devices[DEVICE_ID].properties
+        for (const [code, phase] of [
+            [0x03, 'Detecting'],
+            [0x25, 'Detecting'],
+            [0x26, 'Washing'],
+            [0x27, 'Rinsing'],
+        ] as const) {
+            thinq.emit('data', patchInner(WASHING, 98, code)) // inner[98] = record B rec[20] (status)
+            assert.equal(p.status, phase, `status 0x${code.toString(16)} -> ${phase}`)
+        }
     })
 
     test('unknown frame type and non-envelope frames are ignored', () => {


### PR DESCRIPTION
Adds support for the LG F4X7511TWS front-load washer (internal model `VCDWL2QEUK`, ThinQ2). Unlike the single-frame F-class washers, this model emits several AA/BB frame types, so it gets its own handler.

## What this adds

A device handler (`cloud/devices/VCDWL2QEUK.ts`) parsing the AA/BB-framed packets to expose:

| Entity | Type | Source |
|---|---|---|
| Power | binary_sensor (`running`) | frame-derived (see below) |
| Status | sensor | `0x92` record B, step code `rec[20]` |
| Soil level | sensor | `0x92` record B `rec[0]` |
| Course | sensor | `0x92` record B `rec[4]` |
| Temperature | sensor (°C) | `0x92` record B `rec[1]` |
| Spin | sensor (RPM) | `0x92` record B `rec[3]` |
| Rinse | sensor | `0x92` record B `rec[26]` |
| Energy | sensor (Wh, `total_increasing`) | `0x92` record B `rec[16:17]` big-endian |
| Initial time | sensor (duration) | `0x92` record B `rec[15]` |
| Remaining time | sensor (duration) | `0x92` record B `rec[13]` |
| Detergent / Softener dispenser | binary_sensor | `0x92` record B `rec[29]` / `rec[30]` (EzDispense) |
| Detergent / Softener dose | sensor (mL) | `0x92` record B `rec[31]` / `rec[32]` |
| Pre-wash / TurboWash / Steam | binary_sensor | `0x92` record B `rec[33]` / `rec[34]` bitflags |
| Child lock / Remote start | binary_sensor (diagnostic) | `0x92` record B `rec[36]` bits `0x20` / `0x10` |
| Washes since drum clean | sensor (diagnostic) | `0x92` record B `rec[27]` (LG `TCLCount`) |
| Door | binary_sensor (`door`) | `0x41` snapshot `buf[18]` |

## How it works

Frame types are discriminated by `inner[3]`:

- `0x88` config — sent at cycle start / setting change; used only as an early power-ON signal.
- `0x92` status — carries two back-to-back 63-byte records; the current state is record B (`buf[78:141]`). cf. #77's dual-record `0xEC` washer, which uses the *first* record — this model uses the second (verified against the live app countdown).
- `0x41` door snapshot — door state at `buf[18]` (`0x02` = closed, `0x01` = open).

Record B uses the **same offsets in every phase** of a cycle. During the wash phase it leads with the soil level (light/medium/heavy); during the rinse/spin/end phases and the spin-only / rinse+spin programs it leads with `0x00` (no wash intensity) but still carries a non-zero status byte. Power is frame-derived (no timers): a record with **both** a zero soil lead and a zero status byte is standby → OFF; any non-zero status is a running frame → ON. Settings (soil, course, temp, spin, rinse, the EzDispense doses, the program-option toggles, the child-lock/remote-start flags and the tub-clean counter) are read from the periodic status frame rather than the sparse `0x88` config frame, which is routinely missed.

## Design notes (intentional differences from the F-class washers)

This handler follows the leaner, read-only shape of #77 (the other dual-record washer) rather than the command-capable F-class handlers:

- **Read-only.** All entities are sensors — this model's control/command frames haven't been reverse-engineered, so there's no writable power `switch`, `start`/`pause`, or `start()` init query (no untested commands are sent to the appliance).
- **`status`, `course`, `soil` and `rinse` are plain sensors, not `device_class: enum`.** The codes are model-specific and the handler emits an `unknown`/`Running` fallback; HA rejects values outside an enum's fixed `options`, so free-text sensors are used.
- **`child_lock` uses an icon, not `device_class: lock`** — HA's `lock` binary_sensor class is inverted (`on` = unlocked), which would flip the meaning. `child_lock` and `remote_start` are physical-panel flags and are marked `entity_category: diagnostic`.
- **`door` is the physical open/closed contact** (`device_class: door`, from the `0x41` snapshot). A separate door-lock state isn't exposed — it doesn't map to a clean bit on this model, and is essentially "running and not paused", which `status` already conveys.
- **`Washes since drum clean`** is the LG `TCLCount` (a tub-clean reminder counter that resets at each drum clean); it's a plain sensor with **no `state_class`**, since `total_increasing` would wrongly accumulate across the reset. This model doesn't expose a lifetime cycle count.
- **Lean entity set.** Only decoded fields are exposed; `error` and the raw control state are omitted rather than published as a stuck `unknown`.

## Known limitations

- `error` isn't located yet — that entity is intentionally omitted rather than published as a stuck `unknown`.
- A few cloud-reported fields aren't mapped to wire bytes yet (door-lock, load/weight detection, EzDispense empty/refill state); each has only a single time-confounded transition per cycle, so they'd need targeted captures.
- The power-OFF signature is validated for standby-off after a normal program; off-states after other program families haven't been captured yet.
- The `0x41` door snapshot is only emitted while powered on, so the door entity retains its last value during standby.

Marked as mostly-working in the README.

## How this was built

This handler was primarily written by Claude (Opus 4.8, via Claude Code) and tested thoroughly against real frames captured from a live machine: power on/off, the full run of status phases (detecting → wash → rinse → spin → end), soil, course/temp/spin, rinse, energy, the EzDispense dispensers and doses, the program-option toggles, the child-lock and remote-start flags, the tub-clean counter, and the door were each validated on hardware as well as in unit tests. Field offsets were cross-checked against the LG cloud's own decode of the same frames. I've also cross-checked the existing device PRs to line this up with the project's structure and conventions as closely as possible. Happy to revise anything that doesn't fit.
