### PR TITLE
Trivial: RAC_056905_WW HA climate.turn_on command fix

### DIFF
--- a/cloud/devices/RAC_056905_WW.ts
+++ b/cloud/devices/RAC_056905_WW.ts
@@ -401,7 +401,6 @@ export default class Device extends TLVDevice {
                     }
                     return modes2clip[val]
                 },
-                write_attach: [0x1f9, 0x1fa],
             })
         }
 
@@ -442,7 +441,6 @@ export default class Device extends TLVDevice {
                     }
                     return modes2clip[val]
                 },
-                write_attach: [0x1f9, 0x1fa],
             })
         }
 

--- a/cloud/devices/RAC_056905_WW.ts
+++ b/cloud/devices/RAC_056905_WW.ts
@@ -295,7 +295,8 @@ export default class Device extends TLVDevice {
             comp: 'climate',
             readable: false,
             write_xform: (val) => (val === 'ON' ? 1 : 0),
-            write_attach: (raw) => (raw ? [0x1f9, 0x1fa] : []),
+            /*  0x1f7 is not necessary for ON but does not seem to hurt either */
+            write_attach: (raw) => (raw ? [0x1f9, 0x1fa, 0x1fe] : []),
             read_xform: (raw) => (raw ? 'ON' : 'OFF'),
             read_callback: (val) => {
                 // update 'mode' instead


### PR DESCRIPTION
Running Home Assistant `climate.turn_on` command on `RAC_056905_WW` climate component wasn't actually turning the device on.

The issue seems to be due to missing temperature tag (`0x1fe`) on the power on command - the device mode + fan speed + temperature tag triple should always go together.

Writing 1 to the power tag (`0x1f7`) alone does not seem to do anything and in fact seems to be ignored by the device.

Add the missing `0x1fe` tag to `write_attach` when turning climate power ON to fix this issue.

Also, opportunistically remove `write_attach [0x1f9, 0x1fa]` from swing modes - there's no real reason why changing swing modes would require attaching device mode and fan speed tags and the IR remote does not seem to send device mode and fan speed with swing setting either.