### PR TITLE
WIN_056905_WW: validate LW1022FVSM through unified RAC

### DIFF
--- a/cloud/devices/RAC_056905_WW.ts
+++ b/cloud/devices/RAC_056905_WW.ts
@@ -251,14 +251,6 @@ export default class Device extends TLVDevice {
         return this.meta.modelId === 'WIN_056905_WW'
     }
 
-    supportsVerticalSwingMode() {
-        return !!(this.raw_clip_state[0x2cd] & 0x4)
-    }
-
-    supportsHorizontalSwingMode() {
-        return !!(this.raw_clip_state[0x2cd] & 0x8)
-    }
-
     supportsWinEnergySaverMode() {
         return this.isWinFamily() && !!(this.raw_clip_state[0x2c1] & (1 << 8))
     }
@@ -278,7 +270,7 @@ export default class Device extends TLVDevice {
         if (modeCaps & (1 << 1)) modes.push('dry')
         if (modeCaps & (1 << 2)) modes.push('fan_only')
         if (modeCaps & (1 << 4)) modes.push('heat')
-        if (!this.isWinFamily() && modeCaps & (1 << 6)) modes.push('auto')
+        if (modeCaps & (1 << 6)) modes.push('auto')
 
         return modes.length > 1 ? modes : undefined
     }
@@ -298,11 +290,7 @@ export default class Device extends TLVDevice {
 
     modeWriteAttach() {
         if (!this.isWinFamily()) return [0x1fa, 0x1fe]
-
-        const attach = [0x1f7, 0x1fa, 0x1fe]
-        if (this.supportsVerticalSwingMode()) attach.push(0x321)
-        if (this.supportsHorizontalSwingMode()) attach.push(0x322)
-        return attach
+        return [0x1f7, 0x1fa, 0x1fe]
     }
 
     setModeRaw(rawMode: number) {
@@ -478,29 +466,17 @@ export default class Device extends TLVDevice {
         })
 
         if (this.raw_clip_state[0x2cd] & 4) {
-            config['components']['climate']['swing_modes'] = this.isWinFamily()
-                ? ['on', 'off']
-                : ['1', '2', '3', '4', '5', '6', 'on', 'off']
+            config['components']['climate']['swing_modes'] = ['1', '2', '3', '4', '5', '6', 'on', 'off']
             this.addField(config, {
                 id: 0x321,
                 name: 'swing_mode',
                 comp: 'climate',
                 read_xform: (raw) => {
-                    if (this.isWinFamily()) {
-                        const modes2ha: Record<string, string> = { '0': 'off', '100': 'on' }
-                        return modes2ha[raw]
-                    }
-
                     const modes2ha = ['off', '1', '2', '3', '4', '5', '6']
                     modes2ha[100] = 'on'
                     return modes2ha[raw]
                 },
                 write_xform: (val) => {
-                    if (this.isWinFamily()) {
-                        const modes2clip: Record<string, number> = { off: 0, on: 100 }
-                        return modes2clip[val]
-                    }
-
                     const modes2clip: Record<string, number> = {
                         off: 0,
                         '1': 1,
@@ -517,19 +493,22 @@ export default class Device extends TLVDevice {
         }
 
         if (this.raw_clip_state[0x2cd] & 8) {
-            config['components']['climate']['swing_horizontal_modes'] = this.isWinFamily()
-                ? ['on', 'off']
-                : ['1', '2', '3', '4', '5', '1-3', '3-5', 'on', 'off']
+            config['components']['climate']['swing_horizontal_modes'] = [
+                '1',
+                '2',
+                '3',
+                '4',
+                '5',
+                '1-3',
+                '3-5',
+                'on',
+                'off',
+            ]
             this.addField(config, {
                 id: 0x322,
                 name: 'swing_horizontal_mode',
                 comp: 'climate',
                 read_xform: (raw) => {
-                    if (this.isWinFamily()) {
-                        const modes2ha: Record<string, string> = { '0': 'off', '100': 'on' }
-                        return modes2ha[raw]
-                    }
-
                     const modes2ha = ['off', '1', '2', '3', '4', '5']
                     modes2ha[13] = '1-3'
                     modes2ha[35] = '3-5'
@@ -537,11 +516,6 @@ export default class Device extends TLVDevice {
                     return modes2ha[raw]
                 },
                 write_xform: (val) => {
-                    if (this.isWinFamily()) {
-                        const modes2clip: Record<string, number> = { off: 0, on: 100 }
-                        return modes2clip[val]
-                    }
-
                     const modes2clip: Record<string, number> = {
                         off: 0,
                         '1': 1,
@@ -887,7 +861,11 @@ export default class Device extends TLVDevice {
             name: '',
             comp: name,
             read_xform: (raw) => Math.ceil(raw / 60 / step) * step,
-            write_xform: (val) => Math.round(Number(val) * 60),
+            write_xform: (val) => {
+                const hours = Number(val)
+                const steppedHours = hours === 0 ? 0 : Math.ceil(hours / step) * step
+                return Math.round(steppedHours * 60)
+            },
         })
     }
 

--- a/cloud/devices/RAC_056905_WW.ts
+++ b/cloud/devices/RAC_056905_WW.ts
@@ -290,6 +290,7 @@ export default class Device extends TLVDevice {
 
     modeWriteAttach() {
         if (!this.isWinFamily()) return [0x1fa, 0x1fe]
+        // LW1022FVSM live A/B: the tested off-to-on fan-only write needs 0x1f7=1; already-on writes tolerate it.
         return [0x1f7, 0x1fa, 0x1fe]
     }
 
@@ -355,7 +356,7 @@ export default class Device extends TLVDevice {
             comp: 'climate',
             readable: false,
             write_xform: (val) => (val === 'ON' ? 1 : 0),
-            /*  0x1f7 is not necessary for ON but does not seem to hurt either */
+            /* Direct power ON uses the generic RAC attach behavior; WIN-family mode writes add 0x1f7 separately. */
             write_attach: (raw) => (raw ? [0x1f9, 0x1fa, 0x1fe] : []),
             read_xform: (raw) => (raw ? 'ON' : 'OFF'),
             read_callback: (val) => {

--- a/cloud/devices/RAC_056905_WW.ts
+++ b/cloud/devices/RAC_056905_WW.ts
@@ -247,6 +247,80 @@ export default class Device extends TLVDevice {
         return this.raw_clip_state[0x1f9]
     }
 
+    isWinFamily() {
+        return this.meta.modelId === 'WIN_056905_WW'
+    }
+
+    supportsVerticalSwingMode() {
+        return !!(this.raw_clip_state[0x2cd] & 0x4)
+    }
+
+    supportsHorizontalSwingMode() {
+        return !!(this.raw_clip_state[0x2cd] & 0x8)
+    }
+
+    supportsWinEnergySaverMode() {
+        return this.isWinFamily() && !!(this.raw_clip_state[0x2c1] & (1 << 8))
+    }
+
+    supportsSleepTimer() {
+        const timerCaps = this.raw_clip_state[0x2d3]
+        if (timerCaps == null) return false
+        return !!(timerCaps & 0x1 || (this.isWinFamily() && timerCaps & 0x10))
+    }
+
+    getClimateModes() {
+        const modeCaps = this.raw_clip_state[0x2c1]
+        if (modeCaps == null) return undefined
+
+        const modes = ['off']
+        if (modeCaps & (1 << 0)) modes.push('cool')
+        if (modeCaps & (1 << 1)) modes.push('dry')
+        if (modeCaps & (1 << 2)) modes.push('fan_only')
+        if (modeCaps & (1 << 4)) modes.push('heat')
+        if (!this.isWinFamily() && modeCaps & (1 << 6)) modes.push('auto')
+
+        return modes.length > 1 ? modes : undefined
+    }
+
+    getFanModes() {
+        if (!this.isWinFamily()) return ['auto', 'very low', 'low', 'medium', 'high', 'very high']
+
+        const fanCaps = this.raw_clip_state[0x2f5]
+        if (fanCaps == null) return ['low', 'medium', 'high']
+
+        const fanModes: string[] = []
+        if (fanCaps & 0x1) fanModes.push('low')
+        if (fanCaps & 0x2) fanModes.push('medium')
+        if (fanCaps & 0x4) fanModes.push('high')
+        return fanModes.length > 0 ? fanModes : ['low', 'medium', 'high']
+    }
+
+    modeWriteAttach() {
+        if (!this.isWinFamily()) return [0x1fa, 0x1fe]
+
+        const attach = [0x1f7, 0x1fa, 0x1fe]
+        if (this.supportsVerticalSwingMode()) attach.push(0x321)
+        if (this.supportsHorizontalSwingMode()) attach.push(0x322)
+        return attach
+    }
+
+    setModeRaw(rawMode: number) {
+        this.raw_clip_state[0x1f7] = 1
+        this.raw_clip_state[0x1f9] = rawMode
+
+        const writeFields = [0x1f9].concat(this.modeWriteAttach())
+        const tlvArray = writeFields.map((id) => ({ t: id, v: this.raw_clip_state[id] }))
+        this.send([1, 1, 2, 1, 1], tlvArray)
+    }
+
+    publishKnownState() {
+        for (const idStr of Object.keys(this.fields_by_id)) {
+            const id = Number(idStr)
+            if (this.raw_clip_state[id] != null) this.processKeyValue(id, this.raw_clip_state[id])
+        }
+    }
+
     getIDUActionRunningTLVNum() {
         if (this.raw_clip_state[0x189] != null) {
             return 0x189 // IDUThermoOnOff
@@ -262,7 +336,7 @@ export default class Device extends TLVDevice {
         const config: DeviceDiscovery & { components: { climate: ClimateComponent } } = allowExtendedType({
             ...HADevice.config(this.meta, { name: 'LG Air Conditioner' }),
             components: {
-                climate: {
+                climate: allowExtendedType<ClimateComponent, ClimateComponent & { modes?: string[] }>({
                     platform: 'climate',
                     unique_id: '$deviceid-climate',
                     name: null,
@@ -271,13 +345,11 @@ export default class Device extends TLVDevice {
                     /* TODO: detect 0.5 C vs 1 C step */
                     temp_step: 0.5,
                     precision: 0.5,
-                    /* TODO: some devices report these temp ranges via tags 0x2e1 - 0x2ec */
-                    min_temp: 18,
-                    max_temp: 30,
-                    /* TODO: get from 0x2c2 */
-                    fan_modes: ['auto', 'very low', 'low', 'medium', 'high', 'very high'],
-                    /* TODO: get allowed op modes from 0x2c1 */
-                } satisfies ClimateComponent,
+                    min_temp: this.raw_clip_state[0x2e1] != null ? this.raw_clip_state[0x2e1] / 2 : 18,
+                    max_temp: this.raw_clip_state[0x2e2] != null ? this.raw_clip_state[0x2e2] / 2 : 30,
+                    modes: this.getClimateModes(),
+                    fan_modes: this.getFanModes(),
+                }),
             },
         })
 
@@ -315,11 +387,16 @@ export default class Device extends TLVDevice {
             comp: 'climate',
             read_xform: (raw) => {
                 const modes2ha = ['cool', 'dry', 'fan_only', undefined, 'heat', undefined, 'auto']
+                if (this.supportsWinEnergySaverMode()) modes2ha[8] = 'cool'
                 if (this.getPowerTLV() === 0) return 'off'
                 return modes2ha[raw]
             },
             read_callback: (val) => {
                 if (typeof val !== 'string') return true
+                if (this.supportsWinEnergySaverMode()) {
+                    const isOn = this.getPowerTLV() !== 0 && this.getModeTLV() === 8
+                    this.HA.publishProperty(this.id, 'energysaver', isOn ? 'ON' : 'OFF')
+                }
                 if (this.modePrev !== val) for (const hook of this.modeChangeHooks) hook()
                 this.modePrev = val
                 return true
@@ -327,13 +404,25 @@ export default class Device extends TLVDevice {
             write_xform: (val) => {
                 const modes2clip: Record<string, number> = { cool: 0, dry: 1, fan_only: 2, heat: 4, auto: 6 }
                 if (val === 'off') {
+                    if (this.isWinFamily()) {
+                        this.raw_clip_state[0x1f7] = 0
+                        return this.raw_clip_state[0x1f9] ?? 0
+                    }
                     // Call function power (0x1f7) with value OFF
                     this.setProperty('climate-power', 'OFF')
                     return null
                 }
+                if (this.isWinFamily()) this.raw_clip_state[0x1f7] = 1
                 return modes2clip[val]
             },
-            write_attach: [0x1fa, 0x1fe],
+            write_callback: () => {
+                if (this.isWinFamily() && this.raw_clip_state[0x1f7] === 0) {
+                    this.send([1, 1, 2, 1, 1], [{ t: 0x1f7, v: 0 }])
+                    return false
+                }
+                return true
+            },
+            write_attach: () => this.modeWriteAttach(),
         })
 
         this.addField(config, {
@@ -341,6 +430,11 @@ export default class Device extends TLVDevice {
             name: 'fan_mode',
             comp: 'climate',
             read_xform: (raw) => {
+                if (this.isWinFamily()) {
+                    const modes2ha: Record<string, string> = { '2': 'low', '4': 'medium', '6': 'high' }
+                    return modes2ha[raw]
+                }
+
                 const modes2ha = [
                     undefined,
                     undefined,
@@ -355,6 +449,11 @@ export default class Device extends TLVDevice {
                 return modes2ha[raw]
             },
             write_xform: (val) => {
+                if (this.isWinFamily()) {
+                    const modes2clip: Record<string, number> = { low: 2, medium: 4, high: 6 }
+                    return modes2clip[val]
+                }
+
                 const modes2clip: Record<string, number> = {
                     'very low': 2,
                     low: 3,
@@ -378,17 +477,29 @@ export default class Device extends TLVDevice {
         })
 
         if (this.raw_clip_state[0x2cd] & 4) {
-            config['components']['climate']['swing_modes'] = ['1', '2', '3', '4', '5', '6', 'on', 'off']
+            config['components']['climate']['swing_modes'] = this.isWinFamily()
+                ? ['on', 'off']
+                : ['1', '2', '3', '4', '5', '6', 'on', 'off']
             this.addField(config, {
                 id: 0x321,
                 name: 'swing_mode',
                 comp: 'climate',
                 read_xform: (raw) => {
+                    if (this.isWinFamily()) {
+                        const modes2ha: Record<string, string> = { '0': 'off', '100': 'on' }
+                        return modes2ha[raw]
+                    }
+
                     const modes2ha = ['off', '1', '2', '3', '4', '5', '6']
                     modes2ha[100] = 'on'
                     return modes2ha[raw]
                 },
                 write_xform: (val) => {
+                    if (this.isWinFamily()) {
+                        const modes2clip: Record<string, number> = { off: 0, on: 100 }
+                        return modes2clip[val]
+                    }
+
                     const modes2clip: Record<string, number> = {
                         off: 0,
                         '1': 1,
@@ -406,22 +517,19 @@ export default class Device extends TLVDevice {
         }
 
         if (this.raw_clip_state[0x2cd] & 8) {
-            config['components']['climate']['swing_horizontal_modes'] = [
-                '1',
-                '2',
-                '3',
-                '4',
-                '5',
-                '1-3',
-                '3-5',
-                'on',
-                'off',
-            ]
+            config['components']['climate']['swing_horizontal_modes'] = this.isWinFamily()
+                ? ['on', 'off']
+                : ['1', '2', '3', '4', '5', '1-3', '3-5', 'on', 'off']
             this.addField(config, {
                 id: 0x322,
                 name: 'swing_horizontal_mode',
                 comp: 'climate',
                 read_xform: (raw) => {
+                    if (this.isWinFamily()) {
+                        const modes2ha: Record<string, string> = { '0': 'off', '100': 'on' }
+                        return modes2ha[raw]
+                    }
+
                     const modes2ha = ['off', '1', '2', '3', '4', '5']
                     modes2ha[13] = '1-3'
                     modes2ha[35] = '3-5'
@@ -429,6 +537,11 @@ export default class Device extends TLVDevice {
                     return modes2ha[raw]
                 },
                 write_xform: (val) => {
+                    if (this.isWinFamily()) {
+                        const modes2clip: Record<string, number> = { off: 0, on: 100 }
+                        return modes2clip[val]
+                    }
+
                     const modes2clip: Record<string, number> = {
                         off: 0,
                         '1': 1,
@@ -546,9 +659,16 @@ export default class Device extends TLVDevice {
             this.addJetField(config, 0x323, 'jet', 'Jet', 'mdi:wind-power', jetCool, jetHeat)
         }
 
-        if (this.raw_clip_state[0x2d3] & 1) {
+        if (this.supportsSleepTimer()) {
             // 15h - displayed in hex as "FH"
-            this.addTimerField(config, 0x21a, 'sleeptimer', 'Sleep timer', 'mdi:bed-clock', 15)
+            this.addTimerField(
+                config,
+                0x21a,
+                'sleeptimer',
+                'Sleep timer',
+                'mdi:bed-clock',
+                this.isWinFamily() ? 12 : 15,
+            )
         }
 
         if (this.raw_clip_state[0x2d3] & 4) {
@@ -567,6 +687,10 @@ export default class Device extends TLVDevice {
                 'energySave',
                 (mode) => mode === 0,
             )
+        }
+
+        if (this.supportsWinEnergySaverMode()) {
+            this.addWinEnergySaverField(config)
         }
 
         if (this.raw_clip_state[0x2cc] & 4) {
@@ -719,6 +843,7 @@ export default class Device extends TLVDevice {
         }
 
         this.setConfig(config)
+        this.publishKnownState()
 
         if (this.filterLifeTime) {
             this.publishFilterData()
@@ -740,6 +865,7 @@ export default class Device extends TLVDevice {
     }
 
     addTimerField(config: DeviceDiscovery, id: number, name: string, desc: string, icon: string, max: number) {
+        const step = this.isWinFamily() ? 1 : 0.25
         const comp = {
             platform: 'number',
             unique_id: '$deviceid-' + name,
@@ -749,7 +875,7 @@ export default class Device extends TLVDevice {
             unit_of_measurement: 'h',
             min: 0,
             max: max,
-            step: 0.25,
+            step,
             mode: 'slider',
         } as const
         config['components'][name] = comp
@@ -762,9 +888,34 @@ export default class Device extends TLVDevice {
             id: id,
             name: '',
             comp: name,
-            read_xform: (raw) => Math.ceil(raw / 60 / 0.25) * 0.25,
+            read_xform: (raw) => Math.ceil(raw / 60 / step) * step,
             write_xform: (val) => Math.round(Number(val) * 60),
         })
+    }
+
+    addWinEnergySaverField(config: DeviceDiscovery) {
+        config['components']['energysaver'] = allowExtendedType({
+            platform: 'switch',
+            unique_id: '$deviceid-energysaver',
+            name: 'Energy Saver',
+            icon: 'mdi:leaf',
+            state_topic: '$this/energysaver',
+            command_topic: '$this/energysaver/set',
+        })
+
+        this.fields_by_ha['energysaver'] = {
+            name: '',
+            comp: '',
+            write_xform: (val) => (val === 'ON' ? 8 : 0),
+            write_callback: (raw) => {
+                if (raw === 8) {
+                    this.setModeRaw(8)
+                } else if (this.raw_clip_state[0x1f9] === 8) {
+                    this.setModeRaw(0)
+                }
+                return false
+            },
+        }
     }
 
     addJetField(

--- a/cloud/devices/WIN_056905_WW.ts
+++ b/cloud/devices/WIN_056905_WW.ts
@@ -7,27 +7,43 @@ import * as TLV from '@/util/tlv'
 import HADevice from './base'
 
 /**
- * LG Air Conditioner Model LW1823HRSM
+ * LG Window Air Conditioner (e.g. LW6023IVSM, LW1522IVSM)
+ *
+ * Mode wire values: 0=cool, 1=dry, 2=fan_only, 8=eco("Energy Saver")
+ * Fan wire values:  2=low, 4=medium, 6=high
+ * Sleep timer (0x21a): value in minutes; exposed to HA in hours.
  */
 export default class Device extends TLVDevice {
     constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
         super(HA, thinq)
-        const config: DeviceDiscovery = allowExtendedType({
-            ...HADevice.config(meta),
-            name: 'LG Air Conditioner',
+        const config: DeviceDiscovery = {
+            ...HADevice.config(meta, { name: 'LG Air Conditioner' }),
             components: {
-                climate: {
+                climate: allowExtendedType({
                     platform: 'climate',
                     unique_id: '$deviceid-climate',
                     name: null,
                     temperature_unit: 'C',
                     temp_step: 0.5,
                     precision: 0.5,
-                    modes: ['off', 'cool', 'fan_only', 'heat'],
-                    fan_modes: ['low', 'high'],
-                    swing_modes: ['on', 'off'],
-                },
+                    modes: ['off', 'cool', 'dry', 'fan_only'],
+                    fan_modes: ['low', 'medium', 'high'],
+                    preset_modes: ['eco'],
+                }),
             },
+        }
+
+        config['components']['sleeptimer'] = allowExtendedType({
+            platform: 'number',
+            unique_id: '$deviceid-sleeptimer',
+            name: 'Sleep timer',
+            icon: 'mdi:bed-clock',
+            device_class: 'duration',
+            unit_of_measurement: 'h',
+            min: 0,
+            max: 7,
+            step: 1,
+            mode: 'slider',
         })
 
         this.addField(config, {
@@ -46,7 +62,6 @@ export default class Device extends TLVDevice {
             read_xform: (raw) => raw / 2,
             write_xform: (valStr) => {
                 const val = Number(valStr)
-                // set val to min: 61F, max: 86F
                 const minCel = 16
                 const maxCel = 30.0
                 if (val < minCel) return minCel * 2
@@ -65,7 +80,6 @@ export default class Device extends TLVDevice {
             write_attach: (raw) => (raw ? [0x1f9] : []),
             read_xform: (raw) => (raw ? 'ON' : 'OFF'),
             read_callback: (val) => {
-                // update 'mode' instead
                 this.processKeyValue(0x1f9, this.raw_clip_state[0x1f9])
                 return false
             },
@@ -77,30 +91,54 @@ export default class Device extends TLVDevice {
             comp: 'climate',
             read_xform: (raw) => {
                 const modes2ha = [
-                    'cool',
-                    undefined,
-                    'fan_only',
-                    undefined,
-                    'heat',
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined, // 'eco'
+                    'cool', // 0
+                    'dry', // 1
+                    'fan_only', // 2
+                    undefined, // 3
+                    undefined, // 4 (heat — not supported on this unit)
+                    undefined, // 5
+                    undefined, // 6
+                    undefined, // 7
+                    'cool', // 8 — eco/Energy Saver; reported as cool, preset_mode carries 'eco'
                 ]
                 if (this.raw_clip_state[0x1f7] === 0) return 'off'
                 return modes2ha[raw]
             },
+            read_callback: (val) => {
+                const isEco = this.raw_clip_state[0x1f9] === 8 && this.raw_clip_state[0x1f7] !== 0
+                this.HA.publishProperty(this.id, 'climate-preset_mode', isEco ? 'eco' : 'none')
+                return true
+            },
             write_xform: (val) => {
-                const modes2clip: Record<string, number> = { cool: 0, fan_only: 2, heat: 4, dry: 8 }
+                const modes2clip: Record<string, number> = { cool: 0, dry: 1, fan_only: 2 }
                 if (val === 'off') {
-                    // Call function power (0x1f7) with value OFF
-                    this.setProperty('power', 'OFF')
-                } else {
-                    this.setProperty('power', 'ON')
+                    this.setProperty('climate-power', 'OFF')
+                    return undefined
                 }
+                this.raw_clip_state[0x1f7] = 1
                 return modes2clip[val]
             },
-            write_attach: [0x1f7, 0x1fa, 0x1fe, 0x322],
+            write_attach: [0x1f7, 0x1fa, 0x1fe],
+        })
+
+        this.addField(config, {
+            name: 'preset_mode',
+            comp: 'climate',
+            write_xform: (val) => {
+                const mode = val === 'eco' ? 8 : 0
+                this.raw_clip_state[0x1f9] = mode
+                this.raw_clip_state[0x1f7] = 1
+                this.send(
+                    [1, 1, 2, 1, 1],
+                    [
+                        { t: 0x1f7, v: 1 },
+                        { t: 0x1f9, v: mode },
+                        { t: 0x1fa, v: this.raw_clip_state[0x1fa] },
+                        { t: 0x1fe, v: this.raw_clip_state[0x1fe] },
+                    ],
+                )
+                return null
+            },
         })
 
         this.addField(config, {
@@ -108,47 +146,32 @@ export default class Device extends TLVDevice {
             name: 'fan_mode',
             comp: 'climate',
             read_xform: (raw) => {
-                const modes2ha: Record<string, string> = { '2': 'low', '6': 'high' }
+                const modes2ha: Record<string, string> = { '2': 'low', '4': 'medium', '6': 'high' }
                 return modes2ha[raw]
             },
             write_xform: (val) => {
-                const modes2clip: Record<string, number> = {
-                    low: 2,
-                    high: 6,
-                }
+                const modes2clip: Record<string, number> = { low: 2, medium: 4, high: 6 }
                 return modes2clip[val]
             },
             write_attach: [0x1f9, 0x1fe],
         })
 
         this.addField(config, {
-            id: 0x322,
-            name: 'swing_mode',
-            comp: 'climate',
-            read_xform: (raw) => {
-                const modes2ha: Record<string, string> = { '0': 'off', '100': 'on' }
-                return modes2ha[raw]
-            },
-            write_xform: (val) => {
-                const modes2clip: Record<string, number> = {
-                    off: 0,
-                    on: 100,
-                }
-                return modes2clip[val]
-            },
-            write_attach: [0x1f9, 0x1fa],
+            id: 0x21a,
+            name: '',
+            comp: 'sleeptimer',
+            read_xform: (raw) => raw / 60,
+            write_xform: (val) => Math.round(Number(val) * 60),
         })
 
         this.setConfig(config)
     }
 
     isCapsResponse(tlvArray: TLV.TLV[]) {
-        /* eeprom checksum */
-        return tlvArray.some(({ t, v }) => t === 0x2da)
+        return tlvArray.some(({ t }) => t === 0x2da)
     }
 
     isValuesResponse(tlvArray: TLV.TLV[]) {
-        /* power */
-        return tlvArray.length >= 10 && tlvArray.some(({ t, v }) => t === 0x1f7)
+        return tlvArray.length >= 10 && tlvArray.some(({ t }) => t === 0x1f7)
     }
 }

--- a/cloud/devices/tlv_device.ts
+++ b/cloud/devices/tlv_device.ts
@@ -136,7 +136,7 @@ export default class TLVDevice extends HADevice {
             buf[3] == 0x00 &&
             buf[4] == 0x00 &&
             buf[5] == 0x00 &&
-            buf[6] == 0x87 &&
+            (buf[6] == 0x87 || buf[6] == 0xa7) /* 0xa7: WIN_056905_WW firmware variant */ &&
             buf[7] == 0x02 &&
             (buf[8] == 0x01 || buf[8] == 0x04) &&
             /* && buf[9] is a "sequence" number */ buf[10] == buf.length - 13

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -1,7 +1,6 @@
 import POT_056905_WW from './devices/POT_056905_WW'
 import WTDN3 from './devices/WTDN3'
 import RAC_056905_WW from './devices/RAC_056905_WW'
-import WIN_056905_WW from './devices/WIN_056905_WW'
 import Dev_2REF11EIDA__4 from './devices/2REF11EIDA__4'
 import Dev_2RES1VE61NFA2 from './devices/2RES1VE61NFA2'
 import Dev_2REB1GLVB1__2 from './devices/2REB1GLVB1__2'
@@ -27,7 +26,7 @@ const t1deviceTypes: Record<string, T1Factory> = {
 const t2deviceTypes: Record<string, T2Factory> = {
     POT_056905_WW,
     RAC_056905_WW,
-    WIN_056905_WW,
+    WIN_056905_WW: RAC_056905_WW,
     ['2REF11EIDA__4']: Dev_2REF11EIDA__4,
     ['2RES1VE61NFA2']: Dev_2RES1VE61NFA2,
     ['2REB1GLVB1__2']: Dev_2REB1GLVB1__2,

--- a/tests/cloud/devices/RAC_056905_WW.LW1022FVSM.test.ts
+++ b/tests/cloud/devices/RAC_056905_WW.LW1022FVSM.test.ts
@@ -29,6 +29,12 @@ const WRITE_FAN_HIGH_HEX = toDeviceHex([
     { t: 0x1fe, v: 35 },
 ])
 const WRITE_MODE_DRY_HEX = '01010400000065020101097E417DC17E827F9023521E'
+const WRITE_MODE_FAN_ONLY_FROM_OFF_HEX = toDeviceHex([
+    { t: 0x1f9, v: 2 },
+    { t: 0x1f7, v: 1 },
+    { t: 0x1fa, v: 2 },
+    { t: 0x1fe, v: 35 },
+])
 const WRITE_POWER_OFF_HEX = '01010400000065020101027DC00576'
 const WRITE_ENERGY_SAVER_ON_HEX = '01010400000065020101097E487DC17E827F90230B17'
 const WRITE_ENERGY_SAVER_OFF_HEX = '01010400000065020101097E407DC17E827F902315CD'
@@ -254,6 +260,23 @@ describe('RAC unified implementation with LG LW1022FVSM / WIN_056905_WW fixtures
 
             assert.equal(thinq.outbox.length, 1)
             assert.equal(hex(thinq.outbox[0]), WRITE_MODE_DRY_HEX)
+        } finally {
+            dev.drop()
+        }
+    })
+
+    test('HA write climate-mode=fan_only from off includes power-on TLV', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        try {
+            dev.raw_clip_state[0x1f7] = 0
+            dev.raw_clip_state[0x1f9] = 0
+            thinq.resetRecorder()
+
+            ha.setProperty(DEVICE_ID, 'climate', 'mode_command', 'fan_only')
+
+            assert.equal(thinq.outbox.length, 1)
+            assert.equal(hex(thinq.outbox[0]), WRITE_MODE_FAN_ONLY_FROM_OFF_HEX)
         } finally {
             dev.drop()
         }

--- a/tests/cloud/devices/RAC_056905_WW.LW1022FVSM.test.ts
+++ b/tests/cloud/devices/RAC_056905_WW.LW1022FVSM.test.ts
@@ -44,107 +44,9 @@ const VALUES_RESPONSE_ENERGY_SAVER_HEX =
     '000004000000A702041643' +
     '7E487DC17E827F502D7F90238180C8C08340868086C08700884089408A008A50628A808C808CC0' +
     'ACD032D550F9D590FACAD086CB1086CB8CCBC0CC00CC90851B00C0C03967'
-const VALUES_RESPONSE_PARTIAL_TIMERS_HEX = encodePacket({
-    protocol: 'tlv',
-    direction: 'fromDevice',
-    byte5: 0x02,
-    byte6: 0x04,
-    byte7: 0x13,
-    tlv: [
-        { t: 0x1f9, v: 2 },
-        { t: 0x1f7, v: 1 },
-        { t: 0x1fa, v: 2 },
-        { t: 0x1fd, v: 45 },
-        { t: 0x1fe, v: 46 },
-        { t: 0x21a, v: 30 },
-        { t: 0x21b, v: 90 },
-        { t: 0x21c, v: 15 },
-        { t: 0x300, v: 0 },
-        { t: 0x301, v: 0 },
-    ],
-}).hex
-
-const HEAT_HORIZONTAL_SWING_CAPS_HEX = encodePacket({
-    protocol: 'tlv',
-    direction: 'fromDevice',
-    byte5: 0x02,
-    byte6: 0x01,
-    byte7: 0x11,
-    tlv: [
-        { t: 0x2c1, v: (1 << 0) | (1 << 2) | (1 << 4) },
-        { t: 0x2cd, v: 0x8 },
-        { t: 0x2d3, v: 0 },
-        { t: 0x2da, v: 0x1234 },
-        { t: 0x2f5, v: 0x5 },
-    ],
-}).hex
-const HEAT_SWING_VALUES_HEX = encodePacket({
-    protocol: 'tlv',
-    direction: 'fromDevice',
-    byte5: 0x02,
-    byte6: 0x04,
-    byte7: 0x12,
-    tlv: [
-        { t: 0x1f7, v: 1 },
-        { t: 0x1f9, v: 4 },
-        { t: 0x1fa, v: 6 },
-        { t: 0x1fd, v: 42 },
-        { t: 0x1fe, v: 40 },
-        { t: 0x322, v: 100 },
-        { t: 0x300, v: 0 },
-        { t: 0x301, v: 0 },
-        { t: 0x302, v: 0 },
-        { t: 0x303, v: 0 },
-    ],
-}).hex
-const HEAT_VERTICAL_SWING_CAPS_HEX = encodePacket({
-    protocol: 'tlv',
-    direction: 'fromDevice',
-    byte5: 0x02,
-    byte6: 0x01,
-    byte7: 0x21,
-    tlv: [
-        { t: 0x2c1, v: (1 << 0) | (1 << 2) | (1 << 4) },
-        { t: 0x2cd, v: 0x4 },
-        { t: 0x2d3, v: 0 },
-        { t: 0x2da, v: 0x1234 },
-        { t: 0x2f5, v: 0x5 },
-    ],
-}).hex
-const HEAT_VERTICAL_SWING_VALUES_HEX = encodePacket({
-    protocol: 'tlv',
-    direction: 'fromDevice',
-    byte5: 0x02,
-    byte6: 0x04,
-    byte7: 0x22,
-    tlv: [
-        { t: 0x1f7, v: 1 },
-        { t: 0x1f9, v: 4 },
-        { t: 0x1fa, v: 6 },
-        { t: 0x1fd, v: 42 },
-        { t: 0x1fe, v: 40 },
-        { t: 0x321, v: 100 },
-        { t: 0x300, v: 0 },
-        { t: 0x301, v: 0 },
-        { t: 0x302, v: 0 },
-        { t: 0x303, v: 0 },
-    ],
-}).hex
-const WRITE_MODE_HEAT_WITH_HORIZONTAL_SWING_HEX = toDeviceHex([
-    { t: 0x1f9, v: 4 },
-    { t: 0x1f7, v: 1 },
-    { t: 0x1fa, v: 6 },
-    { t: 0x1fe, v: 40 },
-    { t: 0x322, v: 100 },
-])
-const WRITE_MODE_HEAT_WITH_VERTICAL_SWING_HEX = toDeviceHex([
-    { t: 0x1f9, v: 4 },
-    { t: 0x1f7, v: 1 },
-    { t: 0x1fa, v: 6 },
-    { t: 0x1fe, v: 40 },
-    { t: 0x321, v: 100 },
-])
-const WRITE_SWING_HORIZONTAL_OFF_HEX = toDeviceHex([{ t: 0x322, v: 0 }])
+const VALUES_RESPONSE_SLEEP_TIMER_SUBHOUR_HEX = '000004000000A702040D02868F09F5'
+const VALUES_RESPONSE_STOP_TIMER_SUBHOUR_HEX = '000004000000A70204410286CF609F'
+const VALUES_RESPONSE_START_TIMER_SUBHOUR_HEX = '000004000000A70204C602870F06F7'
 
 function makeDevice() {
     const ha = new MockHAConnection()
@@ -290,66 +192,6 @@ describe('RAC unified implementation with LG LW1022FVSM / WIN_056905_WW fixtures
         }
     })
 
-    test('cross-variant capability packet preserves heat and horizontal swing without energy saver', (t) => {
-        const { ha, dev } = buildDeviceFromFixtures(t, HEAT_HORIZONTAL_SWING_CAPS_HEX, HEAT_SWING_VALUES_HEX)
-
-        try {
-            const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
-            assert.deepEqual(components.climate.modes, ['off', 'cool', 'fan_only', 'heat'])
-            assert.deepEqual(components.climate.fan_modes, ['low', 'high'])
-            assert.equal(Object.hasOwn(components.climate, 'swing_modes'), false)
-            assert.deepEqual(components.climate.swing_horizontal_modes, ['on', 'off'])
-            assert.equal(components.climate.swing_horizontal_mode_state_topic, '$this/climate-swing_horizontal_mode')
-            assert.equal(
-                components.climate.swing_horizontal_mode_command_topic,
-                '$this/climate-swing_horizontal_mode/set',
-            )
-            assert.equal(Object.hasOwn(components, 'energysaver'), false)
-            assert.equal(Object.hasOwn(components, 'sleeptimer'), false)
-            assert.equal(Object.hasOwn(components, 'starttimer'), false)
-            assert.equal(Object.hasOwn(components, 'stoptimer'), false)
-        } finally {
-            dev.drop()
-        }
-    })
-
-    test('cross-variant heat and horizontal swing writes attach only supported TLVs', (t) => {
-        const { ha, thinq, dev } = buildDeviceFromFixtures(t, HEAT_HORIZONTAL_SWING_CAPS_HEX, HEAT_SWING_VALUES_HEX)
-
-        try {
-            ha.setProperty(DEVICE_ID, 'climate', 'mode_command', 'heat')
-            assert.equal(thinq.outbox.length, 1)
-            assert.equal(hex(thinq.outbox[0]), WRITE_MODE_HEAT_WITH_HORIZONTAL_SWING_HEX)
-
-            thinq.resetRecorder()
-            ha.setProperty(DEVICE_ID, 'climate', 'swing_horizontal_mode_command', 'off')
-            assert.equal(thinq.outbox.length, 1)
-            assert.equal(hex(thinq.outbox[0]), WRITE_SWING_HORIZONTAL_OFF_HEX)
-        } finally {
-            dev.drop()
-        }
-    })
-
-    test('cross-variant vertical-only swing does not attach horizontal swing TLV', (t) => {
-        const { ha, thinq, dev } = buildDeviceFromFixtures(
-            t,
-            HEAT_VERTICAL_SWING_CAPS_HEX,
-            HEAT_VERTICAL_SWING_VALUES_HEX,
-        )
-
-        try {
-            const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
-            assert.deepEqual(components.climate.swing_modes, ['on', 'off'])
-            assert.equal(Object.hasOwn(components.climate, 'swing_horizontal_modes'), false)
-
-            ha.setProperty(DEVICE_ID, 'climate', 'mode_command', 'heat')
-            assert.equal(thinq.outbox.length, 1)
-            assert.equal(hex(thinq.outbox[0]), WRITE_MODE_HEAT_WITH_VERTICAL_SWING_HEX)
-        } finally {
-            dev.drop()
-        }
-    })
-
     test('initial values publish timer state in hours', (t) => {
         const { ha, dev } = buildReadyDevice(t)
 
@@ -362,15 +204,17 @@ describe('RAC unified implementation with LG LW1022FVSM / WIN_056905_WW fixtures
         }
     })
 
-    test('LW1022FVSM timer readback rounds up to nearest whole hour', (t) => {
+    test('LW1022FVSM timer readback follows manual whole-hour display steps', (t) => {
         const { ha, thinq, dev } = buildReadyDevice(t)
 
         try {
-            thinq.emit('data', buf(VALUES_RESPONSE_PARTIAL_TIMERS_HEX))
+            thinq.emit('data', buf(VALUES_RESPONSE_SLEEP_TIMER_SUBHOUR_HEX))
+            thinq.emit('data', buf(VALUES_RESPONSE_STOP_TIMER_SUBHOUR_HEX))
+            thinq.emit('data', buf(VALUES_RESPONSE_START_TIMER_SUBHOUR_HEX))
 
             assert.equal(ha.getProperty(DEVICE_ID, 'sleeptimer', 'state'), 1)
             assert.equal(ha.getProperty(DEVICE_ID, 'starttimer', 'state'), 1)
-            assert.equal(ha.getProperty(DEVICE_ID, 'stoptimer', 'state'), 2)
+            assert.equal(ha.getProperty(DEVICE_ID, 'stoptimer', 'state'), 1)
         } finally {
             dev.drop()
         }

--- a/tests/cloud/devices/RAC_056905_WW.LW1022FVSM.test.ts
+++ b/tests/cloud/devices/RAC_056905_WW.LW1022FVSM.test.ts
@@ -1,0 +1,511 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import Bridge from '@/cloud/ha_bridge'
+import DUT from '@/cloud/devices/RAC_056905_WW'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf, hex } from '@/tests/helpers/mocks'
+import { enableMockTimers, tickMockTimers } from '@/tests/helpers/timers'
+import { encodePacket } from '@/util/packet-codec'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'WIN_056905_WW'
+const META: Metadata = { modelId: MODEL_ID, modelName: 'WIN_056905_WW', swVersion: '352200' }
+
+// Captured from an LG LW1022FVSM. This model reports TLV capabilities in a 0xA7
+// device-to-cloud packet even though older WIN_056905_WW captures used 0x87.
+const CAPS_RESPONSE_HEX =
+    '000004000000A702016A51' +
+    'B009B0600107B09054B0C1B103B300B340B4E05016B55060B6A003E5B6F0352200B85020B8903C' +
+    'B8D020B9103CBC600201BD30080000BD47B5C0B61020B642B5C1B600B642B5C2B600B642B5C8B600B6427811'
+const QUERY_REQUEST_HEX = '01010400000065020201027D425A6E'
+const VALUES_RESPONSE_HEX =
+    '000004000000A702041643' +
+    '7E427DC17E827F502D7F90238180C8C08340868086C08700884089408A008A50628A808C808CC0' +
+    'ACD032D550F9D590FACAD086CB1086CB8CCBC0CC00CC90851B00C0C03967'
+const WRITE_FAN_MEDIUM_HEX = '01010400000065020101077E847E427F9023133F'
+const WRITE_FAN_HIGH_HEX = toDeviceHex([
+    { t: 0x1fa, v: 6 },
+    { t: 0x1f9, v: 2 },
+    { t: 0x1fe, v: 35 },
+])
+const WRITE_MODE_DRY_HEX = '01010400000065020101097E417DC17E827F9023521E'
+const WRITE_POWER_OFF_HEX = '01010400000065020101027DC00576'
+const WRITE_ENERGY_SAVER_ON_HEX = '01010400000065020101097E487DC17E827F90230B17'
+const WRITE_ENERGY_SAVER_OFF_HEX = '01010400000065020101097E407DC17E827F902315CD'
+const WRITE_SLEEP_TIMER_1H_HEX = '010104000000650201010386903CBAD2'
+const WRITE_STOP_TIMER_1H_HEX = '010104000000650201010386D03CB71E'
+const WRITE_START_TIMER_1H_HEX = '010104000000650201010387103C967A'
+const WRITE_TEMPERATURE_21C_HEX = toDeviceHex([
+    { t: 0x1fe, v: 42 },
+    { t: 0x1f9, v: 2 },
+    { t: 0x1fa, v: 2 },
+])
+const VALUES_RESPONSE_ENERGY_SAVER_HEX =
+    '000004000000A702041643' +
+    '7E487DC17E827F502D7F90238180C8C08340868086C08700884089408A008A50628A808C808CC0' +
+    'ACD032D550F9D590FACAD086CB1086CB8CCBC0CC00CC90851B00C0C03967'
+const VALUES_RESPONSE_PARTIAL_TIMERS_HEX = encodePacket({
+    protocol: 'tlv',
+    direction: 'fromDevice',
+    byte5: 0x02,
+    byte6: 0x04,
+    byte7: 0x13,
+    tlv: [
+        { t: 0x1f9, v: 2 },
+        { t: 0x1f7, v: 1 },
+        { t: 0x1fa, v: 2 },
+        { t: 0x1fd, v: 45 },
+        { t: 0x1fe, v: 46 },
+        { t: 0x21a, v: 30 },
+        { t: 0x21b, v: 90 },
+        { t: 0x21c, v: 15 },
+        { t: 0x300, v: 0 },
+        { t: 0x301, v: 0 },
+    ],
+}).hex
+
+const HEAT_HORIZONTAL_SWING_CAPS_HEX = encodePacket({
+    protocol: 'tlv',
+    direction: 'fromDevice',
+    byte5: 0x02,
+    byte6: 0x01,
+    byte7: 0x11,
+    tlv: [
+        { t: 0x2c1, v: (1 << 0) | (1 << 2) | (1 << 4) },
+        { t: 0x2cd, v: 0x8 },
+        { t: 0x2d3, v: 0 },
+        { t: 0x2da, v: 0x1234 },
+        { t: 0x2f5, v: 0x5 },
+    ],
+}).hex
+const HEAT_SWING_VALUES_HEX = encodePacket({
+    protocol: 'tlv',
+    direction: 'fromDevice',
+    byte5: 0x02,
+    byte6: 0x04,
+    byte7: 0x12,
+    tlv: [
+        { t: 0x1f7, v: 1 },
+        { t: 0x1f9, v: 4 },
+        { t: 0x1fa, v: 6 },
+        { t: 0x1fd, v: 42 },
+        { t: 0x1fe, v: 40 },
+        { t: 0x322, v: 100 },
+        { t: 0x300, v: 0 },
+        { t: 0x301, v: 0 },
+        { t: 0x302, v: 0 },
+        { t: 0x303, v: 0 },
+    ],
+}).hex
+const HEAT_VERTICAL_SWING_CAPS_HEX = encodePacket({
+    protocol: 'tlv',
+    direction: 'fromDevice',
+    byte5: 0x02,
+    byte6: 0x01,
+    byte7: 0x21,
+    tlv: [
+        { t: 0x2c1, v: (1 << 0) | (1 << 2) | (1 << 4) },
+        { t: 0x2cd, v: 0x4 },
+        { t: 0x2d3, v: 0 },
+        { t: 0x2da, v: 0x1234 },
+        { t: 0x2f5, v: 0x5 },
+    ],
+}).hex
+const HEAT_VERTICAL_SWING_VALUES_HEX = encodePacket({
+    protocol: 'tlv',
+    direction: 'fromDevice',
+    byte5: 0x02,
+    byte6: 0x04,
+    byte7: 0x22,
+    tlv: [
+        { t: 0x1f7, v: 1 },
+        { t: 0x1f9, v: 4 },
+        { t: 0x1fa, v: 6 },
+        { t: 0x1fd, v: 42 },
+        { t: 0x1fe, v: 40 },
+        { t: 0x321, v: 100 },
+        { t: 0x300, v: 0 },
+        { t: 0x301, v: 0 },
+        { t: 0x302, v: 0 },
+        { t: 0x303, v: 0 },
+    ],
+}).hex
+const WRITE_MODE_HEAT_WITH_HORIZONTAL_SWING_HEX = toDeviceHex([
+    { t: 0x1f9, v: 4 },
+    { t: 0x1f7, v: 1 },
+    { t: 0x1fa, v: 6 },
+    { t: 0x1fe, v: 40 },
+    { t: 0x322, v: 100 },
+])
+const WRITE_MODE_HEAT_WITH_VERTICAL_SWING_HEX = toDeviceHex([
+    { t: 0x1f9, v: 4 },
+    { t: 0x1f7, v: 1 },
+    { t: 0x1fa, v: 6 },
+    { t: 0x1fe, v: 40 },
+    { t: 0x321, v: 100 },
+])
+const WRITE_SWING_HORIZONTAL_OFF_HEX = toDeviceHex([
+    { t: 0x322, v: 0 },
+    { t: 0x1f9, v: 4 },
+    { t: 0x1fa, v: 6 },
+])
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    ha.on('setProperty', (id: string, prop: string, value: string) => {
+        dev.setProperty(prop, value)
+    })
+    return { ha, thinq, dev }
+}
+
+function toDeviceHex(tlv: { t: number; v: number }[]) {
+    return encodePacket({
+        protocol: 'tlv',
+        direction: 'toDevice',
+        a: 1,
+        s: 1,
+        byte5: 0x02,
+        byte6: 0x01,
+        byte7: 0x01,
+        tlv,
+    }).hex.toUpperCase()
+}
+
+function buildReadyDevice(t: import('node:test').TestContext) {
+    return buildDeviceFromFixtures(t, CAPS_RESPONSE_HEX, VALUES_RESPONSE_HEX)
+}
+
+function buildDeviceFromFixtures(t: import('node:test').TestContext, capsHex: string, valuesHex: string) {
+    enableMockTimers(t)
+    const { ha, thinq, dev } = makeDevice()
+    thinq.resetRecorder()
+
+    thinq.emit('data', buf(capsHex))
+    assert.equal(thinq.outbox.length, 1)
+    assert.equal(hex(thinq.outbox[0]), QUERY_REQUEST_HEX)
+
+    thinq.emit('data', buf(valuesHex))
+    tickMockTimers(t, 6000)
+    thinq.resetRecorder()
+    return { ha, thinq, dev }
+}
+
+describe('RAC unified implementation with LG LW1022FVSM / WIN_056905_WW fixtures', () => {
+    test('discovery config waits for capability packet', () => {
+        const { ha, dev } = makeDevice()
+
+        try {
+            assert.equal(ha.devices[DEVICE_ID]?.config, undefined, 'HA discovery should not publish before caps')
+        } finally {
+            dev.drop()
+        }
+    })
+
+    test('0xA7 caps response triggers values query', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+
+        try {
+            thinq.emit('data', buf(CAPS_RESPONSE_HEX))
+
+            assert.equal(thinq.outbox.length, 1)
+            assert.equal(hex(thinq.outbox[0]), QUERY_REQUEST_HEX)
+        } finally {
+            dev.drop()
+        }
+    })
+
+    test('ha_bridge routes WIN_056905_WW through the unified RAC implementation', () => {
+        const ha = new MockHAConnection()
+        const thinq = new MockThinq2Device(DEVICE_ID, META)
+        const bridge = new Bridge(ha.asConnection())
+
+        try {
+            bridge.newDevice(thinq)
+
+            assert.ok(bridge.haDevices.get(DEVICE_ID) instanceof DUT)
+        } finally {
+            bridge.haDevices.get(DEVICE_ID)?.drop()
+        }
+    })
+
+    test('0xA7 values response publishes expected climate properties', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+
+        try {
+            assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'mode_state'), 'fan_only')
+            assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'fan_mode_state'), 'low')
+            assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'current_temperature'), 22.5)
+            assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'temperature_state'), 17.5)
+        } finally {
+            dev.drop()
+        }
+    })
+
+    test('LW1022FVSM capability packet advertises supported HA controls', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+
+        try {
+            const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+            assert.deepEqual(components.climate.modes, ['off', 'cool', 'dry', 'fan_only'])
+            assert.deepEqual(components.climate.fan_modes, ['low', 'medium', 'high'])
+            assert.equal(components.climate.min_temp, 16)
+            assert.equal(components.climate.max_temp, 30)
+            assert.equal(Object.hasOwn(components.climate, 'swing_modes'), false)
+            assert.equal(Object.hasOwn(components.climate, 'swing_mode_state_topic'), false)
+            assert.equal(Object.hasOwn(components.climate, 'swing_mode_command_topic'), false)
+            assert.equal(components.energysaver.platform, 'switch')
+            assert.equal(components.energysaver.name, 'Energy Saver')
+            assert.equal(components.energysaver.state_topic, '$this/energysaver')
+            assert.equal(components.energysaver.command_topic, '$this/energysaver/set')
+            assert.ok(components.sleeptimer, 'sleep timer number component')
+            assert.equal(components.sleeptimer.platform, 'number')
+            assert.equal(components.sleeptimer.name, 'Sleep timer')
+            assert.equal(components.sleeptimer.max, 12)
+            assert.equal(components.sleeptimer.step, 1)
+            assert.ok(components.starttimer, 'turn-on timer number component')
+            assert.equal(components.starttimer.platform, 'number')
+            assert.equal(components.starttimer.name, 'Turn-on timer')
+            assert.equal(components.starttimer.max, 24)
+            assert.equal(components.starttimer.step, 1)
+            assert.ok(components.stoptimer, 'turn-off timer number component')
+            assert.equal(components.stoptimer.platform, 'number')
+            assert.equal(components.stoptimer.name, 'Turn-off timer')
+            assert.equal(components.stoptimer.max, 24)
+            assert.equal(components.stoptimer.step, 1)
+        } finally {
+            dev.drop()
+        }
+    })
+
+    test('discovery config has no invalid top-level name field after capabilities', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+
+        try {
+            const device = ha.devices[DEVICE_ID]
+            assert.ok(device, 'HA configuration published')
+            assert.equal(Object.hasOwn(device.config!, 'name'), false, 'discovery config should omit top-level name')
+            assert.equal(device.config!.device.name, 'LG Air Conditioner')
+            assert.equal(device.config!.components.climate.name, null)
+        } finally {
+            dev.drop()
+        }
+    })
+
+    test('cross-variant capability packet preserves heat and horizontal swing without energy saver', (t) => {
+        const { ha, dev } = buildDeviceFromFixtures(t, HEAT_HORIZONTAL_SWING_CAPS_HEX, HEAT_SWING_VALUES_HEX)
+
+        try {
+            const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+            assert.deepEqual(components.climate.modes, ['off', 'cool', 'fan_only', 'heat'])
+            assert.deepEqual(components.climate.fan_modes, ['low', 'high'])
+            assert.equal(Object.hasOwn(components.climate, 'swing_modes'), false)
+            assert.deepEqual(components.climate.swing_horizontal_modes, ['on', 'off'])
+            assert.equal(components.climate.swing_horizontal_mode_state_topic, '$this/climate-swing_horizontal_mode')
+            assert.equal(
+                components.climate.swing_horizontal_mode_command_topic,
+                '$this/climate-swing_horizontal_mode/set',
+            )
+            assert.equal(Object.hasOwn(components, 'energysaver'), false)
+            assert.equal(Object.hasOwn(components, 'sleeptimer'), false)
+            assert.equal(Object.hasOwn(components, 'starttimer'), false)
+            assert.equal(Object.hasOwn(components, 'stoptimer'), false)
+        } finally {
+            dev.drop()
+        }
+    })
+
+    test('cross-variant heat and horizontal swing writes attach only supported TLVs', (t) => {
+        const { ha, thinq, dev } = buildDeviceFromFixtures(t, HEAT_HORIZONTAL_SWING_CAPS_HEX, HEAT_SWING_VALUES_HEX)
+
+        try {
+            ha.setProperty(DEVICE_ID, 'climate', 'mode_command', 'heat')
+            assert.equal(thinq.outbox.length, 1)
+            assert.equal(hex(thinq.outbox[0]), WRITE_MODE_HEAT_WITH_HORIZONTAL_SWING_HEX)
+
+            thinq.resetRecorder()
+            ha.setProperty(DEVICE_ID, 'climate', 'swing_horizontal_mode_command', 'off')
+            assert.equal(thinq.outbox.length, 1)
+            assert.equal(hex(thinq.outbox[0]), WRITE_SWING_HORIZONTAL_OFF_HEX)
+        } finally {
+            dev.drop()
+        }
+    })
+
+    test('cross-variant vertical-only swing does not attach horizontal swing TLV', (t) => {
+        const { ha, thinq, dev } = buildDeviceFromFixtures(
+            t,
+            HEAT_VERTICAL_SWING_CAPS_HEX,
+            HEAT_VERTICAL_SWING_VALUES_HEX,
+        )
+
+        try {
+            const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+            assert.deepEqual(components.climate.swing_modes, ['on', 'off'])
+            assert.equal(Object.hasOwn(components.climate, 'swing_horizontal_modes'), false)
+
+            ha.setProperty(DEVICE_ID, 'climate', 'mode_command', 'heat')
+            assert.equal(thinq.outbox.length, 1)
+            assert.equal(hex(thinq.outbox[0]), WRITE_MODE_HEAT_WITH_VERTICAL_SWING_HEX)
+        } finally {
+            dev.drop()
+        }
+    })
+
+    test('initial values publish timer state in hours', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+
+        try {
+            assert.equal(ha.getProperty(DEVICE_ID, 'sleeptimer', 'state'), 0)
+            assert.equal(ha.getProperty(DEVICE_ID, 'starttimer', 'state'), 0)
+            assert.equal(ha.getProperty(DEVICE_ID, 'stoptimer', 'state'), 0)
+        } finally {
+            dev.drop()
+        }
+    })
+
+    test('LW1022FVSM timer readback rounds up to nearest whole hour', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        try {
+            thinq.emit('data', buf(VALUES_RESPONSE_PARTIAL_TIMERS_HEX))
+
+            assert.equal(ha.getProperty(DEVICE_ID, 'sleeptimer', 'state'), 1)
+            assert.equal(ha.getProperty(DEVICE_ID, 'starttimer', 'state'), 1)
+            assert.equal(ha.getProperty(DEVICE_ID, 'stoptimer', 'state'), 2)
+        } finally {
+            dev.drop()
+        }
+    })
+
+    test('HA write climate-fan_mode=medium emits raw fan value 4', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        try {
+            ha.setProperty(DEVICE_ID, 'climate', 'fan_mode_command', 'medium')
+
+            assert.equal(thinq.outbox.length, 1)
+            assert.equal(hex(thinq.outbox[0]), WRITE_FAN_MEDIUM_HEX)
+        } finally {
+            dev.drop()
+        }
+    })
+
+    test('HA write climate-fan_mode=high emits raw fan value 6', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        try {
+            ha.setProperty(DEVICE_ID, 'climate', 'fan_mode_command', 'high')
+
+            assert.equal(thinq.outbox.length, 1)
+            assert.equal(hex(thinq.outbox[0]), WRITE_FAN_HIGH_HEX)
+        } finally {
+            dev.drop()
+        }
+    })
+
+    test('HA write climate-mode=dry emits raw mode value 1', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        try {
+            ha.setProperty(DEVICE_ID, 'climate', 'mode_command', 'dry')
+
+            assert.equal(thinq.outbox.length, 1)
+            assert.equal(hex(thinq.outbox[0]), WRITE_MODE_DRY_HEX)
+        } finally {
+            dev.drop()
+        }
+    })
+
+    test('HA write climate-mode=off emits a power-off packet', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        try {
+            ha.setProperty(DEVICE_ID, 'climate', 'mode_command', 'off')
+
+            assert.equal(thinq.outbox.length, 1)
+            assert.equal(hex(thinq.outbox[0]), WRITE_POWER_OFF_HEX)
+        } finally {
+            dev.drop()
+        }
+    })
+
+    test('HA write climate-temperature=21 emits raw target temperature 42', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        try {
+            ha.setProperty(DEVICE_ID, 'climate', 'temperature_command', '21')
+
+            assert.equal(thinq.outbox.length, 1)
+            assert.equal(hex(thinq.outbox[0]), WRITE_TEMPERATURE_21C_HEX)
+        } finally {
+            dev.drop()
+        }
+    })
+
+    test('raw mode 8 publishes climate cool plus energy saver ON', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        try {
+            thinq.emit('data', buf(VALUES_RESPONSE_ENERGY_SAVER_HEX))
+
+            assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'mode_state'), 'cool')
+            assert.equal(ha.devices[DEVICE_ID].properties.energysaver, 'ON')
+        } finally {
+            dev.drop()
+        }
+    })
+
+    test('HA write energysaver=ON emits raw mode value 8', (t) => {
+        const { thinq, dev } = buildReadyDevice(t)
+
+        try {
+            dev.setProperty('energysaver', 'ON')
+
+            assert.equal(thinq.outbox.length, 1)
+            assert.equal(hex(thinq.outbox[0]), WRITE_ENERGY_SAVER_ON_HEX)
+        } finally {
+            dev.drop()
+        }
+    })
+
+    test('HA write energysaver=OFF from energy saver emits raw cool mode', (t) => {
+        const { thinq, dev } = buildReadyDevice(t)
+
+        try {
+            thinq.emit('data', buf(VALUES_RESPONSE_ENERGY_SAVER_HEX))
+            thinq.resetRecorder()
+
+            dev.setProperty('energysaver', 'OFF')
+
+            assert.equal(thinq.outbox.length, 1)
+            assert.equal(hex(thinq.outbox[0]), WRITE_ENERGY_SAVER_OFF_HEX)
+        } finally {
+            dev.drop()
+        }
+    })
+
+    test('HA timer writes emit protocol minutes', (t) => {
+        const { thinq, dev } = buildReadyDevice(t)
+
+        try {
+            dev.setProperty('sleeptimer-', '1')
+            assert.equal(thinq.outbox.length, 1)
+            assert.equal(hex(thinq.outbox[0]), WRITE_SLEEP_TIMER_1H_HEX)
+
+            thinq.resetRecorder()
+            dev.setProperty('stoptimer-', '1')
+            assert.equal(thinq.outbox.length, 1)
+            assert.equal(hex(thinq.outbox[0]), WRITE_STOP_TIMER_1H_HEX)
+
+            thinq.resetRecorder()
+            dev.setProperty('starttimer-', '1')
+            assert.equal(thinq.outbox.length, 1)
+            assert.equal(hex(thinq.outbox[0]), WRITE_START_TIMER_1H_HEX)
+        } finally {
+            dev.drop()
+        }
+    })
+})

--- a/tests/cloud/devices/WIN_056905_WW.test.ts
+++ b/tests/cloud/devices/WIN_056905_WW.test.ts
@@ -1,0 +1,90 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/WIN_056905_WW'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf, hex } from '@/tests/helpers/mocks'
+import { enableMockTimers, tickMockTimers } from '@/tests/helpers/timers'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'WIN_056905_WW'
+const META: Metadata = { modelId: MODEL_ID, modelName: 'TEST', swVersion: '1.0' }
+
+// Real packet captures from a WIN_056905_WW (LG LW6023IVSM).
+// Note buf[6]=0xa7 instead of the 0x87 seen on RAC/POT — this is the firmware variant byte.
+
+// Capability request (same wire format as RAC)
+const CAPS_REQUEST_HEX = '01010400000065020201027D416A0D'
+
+// Capability response captured live from the device.
+// buf[6]=0xa7, buf[8]=0x01 (caps type), 81-byte TLV payload.
+// TLV body contains t=0x2DA (eeprom checksum) at payload offset 24, which satisfies isCapsResponse().
+const CAPS_RESPONSE_HEX =
+    '000004000000a70201d251' +
+    'b009b0600107b09054b0c1b103b300b340b4e05016b55060' +
+    'b6a003e5b6f0352200b85020b8903cb8d020b9103c' +
+    'bc600201bd30080000bd47' +
+    'b5c0b61029b642b5c1b600b642b5c2b600b642b5c8b600b642' +
+    '074c'
+
+// Synthetic values response: buf[6]=0xa7, buf[8]=0x04 (values type).
+// 10 TLVs: 0x1f7 power=ON, 0x1f9 mode=cool(0), 0x1fa fan=low(2),
+//          0x1fd current_temp=41(20.5C), 0x1fe set_temp=38(19C), 0x322 swing=off(0),
+//          plus four padding tags to satisfy isValuesResponse()'s length>=10 guard.
+// CRC bytes (last 2) are ignored by processData — any value is valid.
+const QUERY_RESPONSE_HEX = '000004000000a702040116' + '7dc17e407e827f50297f9026c88080008040808080c0' + '0000'
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    ha.on('setProperty', (id: string, prop: string, value: string) => {
+        dev.setProperty(prop, value)
+    })
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('constructor sends a queryCaps packet on the wire', () => {
+        const { thinq, dev } = makeDevice()
+        if (dev.query_caps_timeout) {
+            clearInterval(dev.query_caps_timeout)
+            dev.query_caps_timeout = undefined
+        }
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(hex(thinq.outbox[0]), CAPS_REQUEST_HEX.toUpperCase())
+        dev.drop()
+    })
+
+    test('caps response (0xa7 frame) is recognized and stops the retry loop', (t) => {
+        enableMockTimers(t)
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+
+        thinq.emit('data', buf(CAPS_RESPONSE_HEX))
+
+        // caps retry interval must be cleared
+        assert.equal(dev.query_caps_timeout, undefined, 'caps retry loop cleared')
+        // device should immediately fire a values query
+        assert.equal(thinq.outbox.length, 1, 'values query sent after caps')
+
+        dev.drop()
+    })
+
+    test('values response publishes expected climate properties', (t) => {
+        enableMockTimers(t)
+        const { ha, thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+
+        thinq.emit('data', buf(CAPS_RESPONSE_HEX))
+        thinq.emit('data', buf(QUERY_RESPONSE_HEX))
+        tickMockTimers(t, 1000)
+
+        assert.ok(ha.devices[DEVICE_ID]?.config, 'HA config published')
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'current_temperature'), 20.5)
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'temperature_state'), 19)
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'mode_state'), 'cool')
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'fan_mode_state'), 'low')
+
+        dev.drop()
+    })
+})


### PR DESCRIPTION
## Summary

This draft follows the unified RAC direction from #73. It uses sanitized LW1022FVSM / WIN_056905_WW fixtures as regression coverage and only changes the shared RAC path for fixture-proven gaps. I also live-tested the patched RAC path locally against an installed LG LW1022FVSM reporting ThinQ model id `WIN_056905_WW`, then restored my local runtime.

- Route `WIN_056905_WW` through `RAC_056905_WW`.
- Add sanitized LW1022FVSM fixture coverage against the unified RAC implementation.
- Teach RAC the fixture-proven LW1022FVSM / observed `WIN_056905_WW` differences: capability-derived modes/fan modes/temperature limits, raw fan values `2/4/6`, raw mode `8` Energy Saver, power-off behavior, the tested off-to-fan-only write path, and manual whole-hour timer controls/readback with protocol-minute writes.
- Replay the initial raw TLV state after RAC builds dynamic discovery config so the first values response publishes Home Assistant state.

## Evidence Level

Fixture coverage plus live validation against an installed LG LW1022FVSM / `WIN_056905_WW` through rethink, MQTT, and Home Assistant.

## Validation

- `node --import tsx --test --test-reporter=spec tests/cloud/devices/RAC_056905_WW.LW1022FVSM.test.ts`
- `node --import tsx --test --test-reporter=spec tests/cloud/devices/RAC_056905_WW.test.ts tests/cloud/devices/RAC_056905_WW.LW1022FVSM.test.ts`
- `npm run test`
- `npm run build`
- `npm exec -- prettier . --check --ignore-path .gitignore`
- `git diff --check`
- Live validation against LG LW1022FVSM / `WIN_056905_WW` through local rethink runtime, MQTT, and Home Assistant

Result: LW1022FVSM RAC fixture test passed 18/18, RAC plus LW1022FVSM fixture tests passed 24/24, full suite passed 248/248, build passed, formatting passed, and diff whitespace check passed.

Live result: discovery, modes (`dry`, `fan_only`, `cool`, `off`), fan speeds (`low`, `medium`, `high`), target temperature, Energy Saver, Sleep Timer, Turn-off Timer, Turn-on Timer, focused `0x1f7` A/B behavior, and rollback were tested through the live path. Manual-backed timer behavior is Sleep `1h` to `12h`, Turn-off `1h` to `24h` while running, and Turn-on `1h` to `24h` while off. Turn-on Timer is accepted/read back when the unit is `off`; the unit ignores that command while already running.

Focused `0x1f7` A/B result: already-on Energy Saver mode writes worked with or without `0x1f7=1`; the tested off-to-fan-only mode write required `0x1f7=1` to power the unit on.

## Notes

- The unit under validation is LG LW1022FVSM with ThinQ model id `WIN_056905_WW`.
- The sanitized fixture expects modes `off`, `cool`, `dry`, and `fan_only`; fan modes `low`, `medium`, and `high`; no heat or swing fields for the observed capability packet; Energy Saver represented by raw mode `8`; and Sleep / Turn-on / Turn-off timers exposed as whole-hour controls matching the owner's manual.
- Turn-on Timer was live-validated as a turn-on timer: when the unit was `off`, a `1h` command was accepted, published back as `starttimer- 1`, and the physical unit showed the timer; clearing it published `starttimer- 0`.
