### PR TITLE
Add ThinQ2 device handlers for WM3900HBA washer and DLEX3900B dryer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ The following appliances are currently supported in rethink:
     - 🫤 TW4V9RW9W - preliminary support
     - 👍 F4X7511TWS (VCDWL2QEUK), Front-Load Washing Machine - mostly working
     - 👍 WM3900HBA (F3L2CYU\_\_), Front-Load Washing Machine - mostly working
+- Dryers:
+    - 👍 DLEX3900B (RV13B6BSD_D_US_WIFI), Electric Dryer - mostly working
 
 The supported appliances can be used "out of the box" with HomeAssistant or another compatible MQTT consumer.  
 Appliances not listed above can still be used with the bridge mode, but they will not be translated to MQTT. Contributions are welcome!

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The following appliances are currently supported in rethink:
     - 🫤 F4WV709P1E, Front-Loading Washing Machine - preliminary support
     - 🫤 TW4V9RW9W - preliminary support
     - 👍 F4X7511TWS (VCDWL2QEUK), Front-Load Washing Machine - mostly working
+    - 👍 WM3900HBA (F3L2CYU\_\_), Front-Load Washing Machine - mostly working
 
 The supported appliances can be used "out of the box" with HomeAssistant or another compatible MQTT consumer.  
 Appliances not listed above can still be used with the bridge mode, but they will not be translated to MQTT. Contributions are welcome!

--- a/cloud/devices/F3L2CYU__.ts
+++ b/cloud/devices/F3L2CYU__.ts
@@ -1,0 +1,313 @@
+import HADevice from './base'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import AABBDevice from './aabb_device'
+
+// LG front-load washer — matched on modelId "F3L2CYU__". AABB frames (buf = the AABB body, AA+len and
+// checksum+BB already stripped, buf[0]==0x20 on every frame) are discriminated by buf[1] (NOT buf[3],
+// which is a rolling sequence counter for this model):
+//   0x31        one-time device-ID/serial frame at connect — not decoded.
+//   0xEC        dial/status frame — two stacked 26-byte records (old state, then new state), each
+//               starting with a 0x18 marker; we read record B (buf[29:]), the current state.
+//   0xBD / 0xCD full status dump / idle keepalive (~406/405 bytes) — carry some of the same fields
+//               (e.g. remaining time at absolute offset 10) but were not exhaustively mapped; not decoded.
+//   0x72, 0xD8  short heartbeat/ping frames — not decoded.
+// All offsets below are live-verified: captured real traffic via the rethink-agent MCP tools while
+// driving the physical washer (dial browsing, single-variable settings toggles, full wash cycles,
+// pause/resume, remote start/pause/power-off from the LG app) and correlating each byte change against
+// the LG cloud's own decoded washerDryer state at matching timestamps — not guessed from static analysis.
+
+const STATUS_FRAME_TYPE = 0xec
+const STATUS_FRAME_LEN = 54 // 3B header + 26B record A (old) + 25B record B (current)
+const RECORD_B_OFFSET = 29
+
+// Offsets below are relative to record B's own 0x18 marker (rec[0]).
+const PHASE_OFFSET = 1
+// rec[2:4] = [hour][minute]: the estimated cycle time while Selecting/Delay-pending, or the countdown
+// while running. Confirmed exactly against the cloud's initialTimeHour/Minute and remainTimeHour/Minute
+// across many single-variable settings toggles and a full wash cycle countdown (13->...->1 min).
+const TIME_HOUR_OFFSET = 2
+const TIME_MIN_OFFSET = 3
+// rec[6]: the course/dial-position identifier (NOT the same as rec[2:4] — an earlier pass mistook the
+// time-estimate bytes for a "course code" because each course's default settings produce a distinctive
+// default time; rec[6] is the real, stable identifier, confirmed unchanged across a whole settings-toggle
+// session on a fixed course). 14 named programs map to 14 distinct values; 0x00 is a transitional/
+// no-selection state (also the sentinel value seen at power-off, alongside 0xfe).
+const COURSE_OFFSET = 6
+const SOIL_OFFSET = 8
+const SPIN_OFFSET = 9
+const TEMP_OFFSET = 10
+// rec[11] high nibble = extra-rinse count (0-3); low nibble is a constant 1.
+const EXTRA_RINSE_COUNT_OFFSET = 11
+// rec[13:15] = [hour][minute]: Delay Wash reserve time, ticking down like a clock (confirmed across a
+// 3:00 -> 2:59 hour-boundary rollover). Only meaningful while phase == PHASE_DELAY.
+const RESERVE_HOUR_OFFSET = 13
+const RESERVE_MIN_OFFSET = 14
+// rec[15]: options bitfield, each bit isolated via a single-variable toggle against the cloud's enum.
+const FLAGS_OFFSET = 15
+const FLAG_TURBO_WASH = 0x80
+const FLAG_EXTRA_RINSE = 0x40
+const FLAG_PRE_WASH = 0x08
+const FLAG_STEAM = 0x04
+const FLAG_DELAY_ACTIVE = 0x02
+// rec[16]: a separate bitfield from rec[15] — confirmed by isolating Cold Wash (which also forces the
+// temp index to 0x02/Cold) and the door-lock state (unlocks on pause, relocks on resume/start) against
+// the cloud's coldWash field and the pause/resume phase transitions, respectively.
+const OPT2_OFFSET = 16
+const OPT2_DOOR_LOCKED = 0x80
+const OPT2_COLD_WASH = 0x10
+// rec[17]: plain door-closed sensor, independent of the rec[16] lock bit (the machine can be paused with
+// the door shut-but-unlocked). Confirmed both directions against the cloud's doorClose field.
+const DOOR_OFFSET = 17
+const DOOR_CLOSED = 0x02
+
+const PHASE_OFF = 0x00
+
+// Phase/status byte. 0x14 (Sensing) carried over from the original qualitative pass — this session's
+// Speed Wash runs went straight 0x05->0x17 without an observed Sensing step, so it's unconfirmed but
+// harmless to include (anything genuinely unmapped falls back to 'Running').
+const STATUS: Record<number, string> = {
+    0x00: 'Off',
+    0x05: 'Selecting',
+    0x06: 'Paused',
+    0x0a: 'Delay Wash',
+    0x14: 'Sensing',
+    0x17: 'Washing',
+    0x1e: 'Rinsing',
+    0x28: 'Spinning',
+    0x3c: 'Complete',
+}
+
+// Course/dial-position identifier -> name. Live-confirmed by turning the dial through every position and
+// reading the LG cloud's own apCourseFLUpper25inchBaseUS at each stop.
+const COURSE: Record<number, string> = {
+    0x01: 'Tub Clean',
+    0x02: 'Bright Whites',
+    0x03: 'Allergiene',
+    0x04: 'Sanitary',
+    0x05: 'Bedding',
+    0x06: 'Heavy Duty',
+    0x07: 'Normal',
+    0x08: 'Sportswear',
+    0x09: 'Perm Press',
+    0x0a: 'Delicates',
+    0x0b: 'Towels',
+    0x0c: 'Speed Wash',
+    0x0d: 'Rinse+Spin',
+    0x0e: 'Small Load',
+}
+
+// Soil level 1-5, clean sequential mapping confirmed by single-step toggling against the cloud's
+// soilWash enum.
+const SOIL: Record<number, string> = {
+    1: 'Light',
+    2: 'Light-Normal',
+    3: 'Normal',
+    4: 'Normal-Heavy',
+    5: 'Heavy',
+}
+
+// Spin 2-5 confirmed the same way; 1 (No Spin) is implied by the sequence but wasn't directly toggled to.
+const SPIN: Record<number, string> = {
+    1: 'No Spin',
+    2: 'Low',
+    3: 'Medium',
+    4: 'High',
+    5: 'Extra High',
+}
+
+// Temp indices confirmed the same way; 3/5 are unused/skipped on this model.
+const TEMP: Record<number, string> = {
+    1: 'Tap Cold',
+    2: 'Cold',
+    4: 'Warm',
+    6: 'Hot',
+    7: 'Extra Hot',
+}
+
+export default class Device extends AABBDevice {
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: 'LG Washer' }),
+                components: {
+                    power: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-power',
+                        state_topic: '$this/power',
+                        name: 'Power',
+                        icon: 'mdi:washing-machine',
+                        device_class: 'running',
+                    },
+                    status: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-status',
+                        state_topic: '$this/status',
+                        name: 'Status',
+                        icon: 'mdi:state-machine',
+                        // free-text (NOT device_class:enum): unmapped phase codes emit 'Running'.
+                    },
+                    course: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-course',
+                        state_topic: '$this/course',
+                        name: 'Course',
+                        icon: 'mdi:pin-outline',
+                    },
+                    remaining_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-remaining_time',
+                        state_topic: '$this/remaining_time',
+                        name: 'Remaining time',
+                        icon: 'mdi:timer-outline',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        // dual-purpose: the estimated cycle time while selecting, the countdown while
+                        // running — this model has no separate byte for a persistent "initial estimate".
+                    },
+                    reserve_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-reserve_time',
+                        state_topic: '$this/reserve_time',
+                        name: 'Delay Wash time remaining',
+                        icon: 'mdi:clock-outline',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                    },
+                    soil: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-soil',
+                        state_topic: '$this/soil',
+                        name: 'Soil level',
+                        icon: 'mdi:liquid-spot',
+                    },
+                    spin: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-spin',
+                        state_topic: '$this/spin',
+                        name: 'Spin',
+                        icon: 'mdi:autorenew',
+                    },
+                    temp: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-temp',
+                        state_topic: '$this/temp',
+                        name: 'Temperature',
+                        icon: 'mdi:thermometer',
+                    },
+                    extra_rinse: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-extra_rinse',
+                        state_topic: '$this/extra_rinse',
+                        name: 'Extra rinse',
+                        icon: 'mdi:water-sync',
+                    },
+                    extra_rinse_count: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-extra_rinse_count',
+                        state_topic: '$this/extra_rinse_count',
+                        name: 'Extra rinse count',
+                        icon: 'mdi:water-sync',
+                        state_class: 'measurement',
+                    },
+                    pre_wash: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-pre_wash',
+                        state_topic: '$this/pre_wash',
+                        name: 'Pre-wash',
+                        icon: 'mdi:water-sync',
+                    },
+                    steam: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-steam',
+                        state_topic: '$this/steam',
+                        name: 'Steam',
+                        icon: 'mdi:kettle-steam',
+                    },
+                    cold_wash: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-cold_wash',
+                        state_topic: '$this/cold_wash',
+                        name: 'Cold wash',
+                        icon: 'mdi:snowflake',
+                    },
+                    turbo_wash: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-turbo_wash',
+                        state_topic: '$this/turbo_wash',
+                        name: 'TurboWash',
+                        icon: 'mdi:rocket-launch',
+                    },
+                    delay_wash: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-delay_wash',
+                        state_topic: '$this/delay_wash',
+                        name: 'Delay Wash',
+                        icon: 'mdi:clock-plus-outline',
+                    },
+                    door: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-door',
+                        state_topic: '$this/door',
+                        name: 'Door',
+                        device_class: 'door', // payload ON = open, OFF = closed
+                    },
+                    door_lock: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-door_lock',
+                        state_topic: '$this/door_lock',
+                        name: 'Door lock',
+                        icon: 'mdi:lock', // NOT device_class 'lock' — that class is inverted (on = unlocked)
+                        entity_category: 'diagnostic',
+                    },
+                },
+            }),
+        )
+    }
+
+    processAABB(buf: Buffer) {
+        if (buf[0] !== 0x20 || buf.length < 2) return
+        if (buf[1] === STATUS_FRAME_TYPE) return this.processStatus(buf)
+        // 0x31 (serial), 0xBD/0xCD (full/idle dumps) and 0x72/0xD8 (heartbeats) are not yet decoded.
+    }
+
+    private processStatus(buf: Buffer) {
+        if (buf.length !== STATUS_FRAME_LEN) return // expected 54B; reject header/layout drift
+        const rec = buf.subarray(RECORD_B_OFFSET)
+        if (rec[0] !== 0x18) return // record B should always lead with its marker
+
+        const phase = rec[PHASE_OFFSET]
+        const isOff = phase === PHASE_OFF
+
+        this.publishProperty('power', isOff ? 'OFF' : 'ON')
+        this.publishProperty('status', STATUS[phase] ?? 'Running')
+        this.publishProperty('course', COURSE[rec[COURSE_OFFSET]] ?? 'unknown')
+        // Zeroed on Off rather than trusting the raw bytes — a stray leftover minute was observed on a
+        // real power-off capture, and a stale countdown while OFF would be misleading in HA regardless.
+        this.publishProperty('remaining_time', isOff ? 0 : rec[TIME_HOUR_OFFSET] * 60 + rec[TIME_MIN_OFFSET])
+        this.publishProperty('reserve_time', isOff ? 0 : rec[RESERVE_HOUR_OFFSET] * 60 + rec[RESERVE_MIN_OFFSET])
+        this.publishProperty('soil', SOIL[rec[SOIL_OFFSET]] ?? 'unknown')
+        this.publishProperty('spin', SPIN[rec[SPIN_OFFSET]] ?? 'unknown')
+        this.publishProperty('temp', TEMP[rec[TEMP_OFFSET]] ?? 'unknown')
+        this.publishProperty('extra_rinse_count', rec[EXTRA_RINSE_COUNT_OFFSET] >> 4)
+
+        const flags = rec[FLAGS_OFFSET]
+        this.publishProperty('extra_rinse', (flags & FLAG_EXTRA_RINSE) !== 0 ? 'ON' : 'OFF')
+        this.publishProperty('pre_wash', (flags & FLAG_PRE_WASH) !== 0 ? 'ON' : 'OFF')
+        this.publishProperty('steam', (flags & FLAG_STEAM) !== 0 ? 'ON' : 'OFF')
+        this.publishProperty('turbo_wash', (flags & FLAG_TURBO_WASH) !== 0 ? 'ON' : 'OFF')
+        this.publishProperty('delay_wash', (flags & FLAG_DELAY_ACTIVE) !== 0 ? 'ON' : 'OFF')
+
+        const opt2 = rec[OPT2_OFFSET]
+        this.publishProperty('cold_wash', (opt2 & OPT2_COLD_WASH) !== 0 ? 'ON' : 'OFF')
+        this.publishProperty('door_lock', (opt2 & OPT2_DOOR_LOCKED) !== 0 ? 'ON' : 'OFF')
+
+        this.publishProperty('door', rec[DOOR_OFFSET] === DOOR_CLOSED ? 'OFF' : 'ON')
+        // not yet located (declared entities intentionally omitted rather than published wrong): error,
+        // child_lock, remote_start (the latter two appear cloud-side only — no device-frame bit found for
+        // either despite dedicated isolation tests), tub-clean count.
+    }
+}

--- a/cloud/devices/F3L2CYU__.ts
+++ b/cloud/devices/F3L2CYU__.ts
@@ -9,8 +9,11 @@ import AABBDevice from './aabb_device'
 // checksum+BB already stripped, buf[0]==0x20 on every frame) are discriminated by buf[1] (NOT buf[3],
 // which is a rolling sequence counter for this model):
 //   0x31        one-time device-ID/serial frame at connect — not decoded.
-//   0xEC        dial/status frame — two stacked 26-byte records (old state, then new state), each
+//   0xEC        dial/status frame — two stacked 25/26-byte records (old state, then new state), each
 //               starting with a 0x18 marker; we read record B (buf[29:]), the current state.
+//   0xEB        single-record status frame — same 25-byte record layout as 0xEC's record B, just without
+//               a preceding "old state" record (seen right after the appliance (re)connects, before it has
+//               a prior state to diff against). Live-confirmed: identical field offsets to 0xEC's record B.
 //   0xBD / 0xCD full status dump / idle keepalive (~406/405 bytes) — carry some of the same fields
 //               (e.g. remaining time at absolute offset 10) but were not exhaustively mapped; not decoded.
 //   0x72, 0xD8  short heartbeat/ping frames — not decoded.
@@ -22,6 +25,10 @@ import AABBDevice from './aabb_device'
 const STATUS_FRAME_TYPE = 0xec
 const STATUS_FRAME_LEN = 54 // 3B header + 26B record A (old) + 25B record B (current)
 const RECORD_B_OFFSET = 29
+
+const SINGLE_STATUS_FRAME_TYPE = 0xeb
+const SINGLE_STATUS_FRAME_LEN = 28 // 3B header + 25B record, no preceding "old state" record
+const SINGLE_RECORD_OFFSET = 3
 
 // Offsets below are relative to record B's own 0x18 marker (rec[0]).
 const PHASE_OFFSET = 1
@@ -270,13 +277,15 @@ export default class Device extends AABBDevice {
 
     processAABB(buf: Buffer) {
         if (buf[0] !== 0x20 || buf.length < 2) return
-        if (buf[1] === STATUS_FRAME_TYPE) return this.processStatus(buf)
+        if (buf[1] === STATUS_FRAME_TYPE) return this.processStatus(buf, RECORD_B_OFFSET, STATUS_FRAME_LEN)
+        if (buf[1] === SINGLE_STATUS_FRAME_TYPE)
+            return this.processStatus(buf, SINGLE_RECORD_OFFSET, SINGLE_STATUS_FRAME_LEN)
         // 0x31 (serial), 0xBD/0xCD (full/idle dumps) and 0x72/0xD8 (heartbeats) are not yet decoded.
     }
 
-    private processStatus(buf: Buffer) {
-        if (buf.length !== STATUS_FRAME_LEN) return // expected 54B; reject header/layout drift
-        const rec = buf.subarray(RECORD_B_OFFSET)
+    private processStatus(buf: Buffer, recordOffset: number, expectedLen: number) {
+        if (buf.length !== expectedLen) return // reject header/layout drift
+        const rec = buf.subarray(recordOffset)
         if (rec[0] !== 0x18) return // record B should always lead with its marker
 
         const phase = rec[PHASE_OFFSET]

--- a/cloud/devices/RV13B6BSD_D_US_WIFI.ts
+++ b/cloud/devices/RV13B6BSD_D_US_WIFI.ts
@@ -1,0 +1,269 @@
+import HADevice from './base'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import AABBDevice from './aabb_device'
+
+// LG electric dryer — matched on modelId "RV13B6BSD_D_US_WIFI" (real-world nameplate DLEX3900B, product
+// code RV13B6JSD.ABLEEUS). AABB frames (buf = the AABB body, AA+len and checksum+BB already stripped)
+// start with 0x30 (the washer's equivalent frames start with 0x20) and are discriminated by buf[1]:
+//   0x31        one-time device-ID/serial frame at connect — not decoded.
+//   0xEC        dial/status frame — two stacked records (29-byte old state, 28-byte current state), each
+//               starting with a 0x1b marker; we read the current-state record (buf[32:]).
+//   0xEB        single-record status frame (28-byte record at buf[3:]) — same field layout as 0xEC's
+//               current-state record, seen right after the appliance (re)connects.
+//   0xE2        idle/keepalive variant carrying a frozen snapshot of the last active state — not decoded.
+//   0x72        short heartbeat/ping frames — not decoded.
+// All offsets below are live-verified: captured real traffic via the rethink-agent MCP tools while
+// driving the physical dryer (course/dial browsing, single-variable settings toggles, two full dry
+// cycles run to completion, pause/resume, remote start/power-off from the LG app) and correlating each
+// byte change against the LG cloud's own decoded washerDryer state at matching timestamps — not guessed
+// from static analysis.
+
+const STATUS_FRAME_TYPE = 0xec
+const STATUS_FRAME_LEN = 60 // 3B header + 29B record A (old) + 28B record B (current)
+const RECORD_B_OFFSET = 32
+
+const SINGLE_STATUS_FRAME_TYPE = 0xeb
+const SINGLE_STATUS_FRAME_LEN = 31 // 3B header + 28B record, no preceding "old state" record
+const SINGLE_RECORD_OFFSET = 3
+
+// Offsets below are relative to record B's own 0x1b marker (rec[0]).
+const PHASE_OFFSET = 1
+// rec[2:4] = [hour][minute]: the live countdown while running, or the estimated cycle time while
+// Initial/Selecting. Confirmed exactly against the cloud's remainTimeHour/Minute.
+const TIME_HOUR_OFFSET = 2
+const TIME_MIN_OFFSET = 3
+// rec[4:6] = [hour][minute]: unlike the washer (where the equivalent bytes just mirror the current
+// value), this model keeps a genuine, separate initial-time estimate that stays fixed once a cycle is
+// running while rec[2:4] counts down — confirmed against the cloud's initialTimeHour/Minute.
+const INITIAL_TIME_HOUR_OFFSET = 4
+const INITIAL_TIME_MIN_OFFSET = 5
+// rec[6]: course/mode identifier. 14 named dial programs plus Time Dry (engaged by its own button, not a
+// dial position) map to 14 distinct values, confirmed against the cloud's courseDryer27inchBase/timeDry.
+const COURSE_OFFSET = 6
+const DRY_LEVEL_OFFSET = 8
+const TEMP_OFFSET = 9
+// rec[15]: options bitfield, each bit isolated via a single-variable toggle against the cloud's enum.
+// The 0x40 "base" bit is present while Initial/Selecting/Pause but reads 0x00 while actively Drying —
+// it's a running-state artifact, not part of any single option, so it's not exposed as its own entity.
+const FLAGS_OFFSET = 15
+const FLAG_CHILD_LOCK = 0x01
+const FLAG_REDUCE_STATIC = 0x02
+const FLAG_DAMP_DRY_SIGNAL = 0x08
+// rec[16]: a separate options bitfield from rec[15].
+const OPT2_OFFSET = 16
+const OPT2_ENERGY_SAVER = 0x02
+const OPT2_TURBO_STEAM = 0x04
+const OPT2_WRINKLE_CARE = 0x10
+
+const PHASE_OFF = 0x00
+
+// Phase/status byte. 0x01 covers both dial-browsing-before-start and "paused, settings panel open" — the
+// cloud itself calls both of these "INITIAL", so that's the name used here rather than inventing two
+// separate labels for what the appliance treats as one state.
+const STATUS: Record<number, string> = {
+    0x00: 'Off',
+    0x01: 'Initial',
+    0x03: 'Pause',
+    0x32: 'Drying',
+    0x33: 'Cooling',
+    0x04: 'End',
+}
+
+// Course/mode identifier -> name. Live-confirmed against the cloud's courseDryer27inchBase (dial
+// positions) and timeDry (the Time Dry button, which is not a dial position but shares this same byte).
+const COURSE: Record<number, string> = {
+    0x01: 'Heavy Duty',
+    0x02: 'Towels',
+    0x03: 'Normal',
+    0x04: 'Perm Press',
+    0x05: 'Delicates',
+    0x07: 'Bedding',
+    0x08: 'Antibacterial',
+    0x09: 'Small Load',
+    0x0b: 'Sportswear',
+    0x10: 'Speed Dry',
+    0x11: 'Air Dry',
+    0x12: 'Time Dry',
+    0x15: 'Steam Fresh',
+    0x16: 'Steam Sanitary',
+    0x1a: 'Super Dry',
+}
+
+// Dry level 1-5, confirmed via a clean isolated toggle (course/temp held fixed) against the cloud's
+// dryLevel enum. 0 (NO_DRYLEVEL) is used by courses that don't auto-sense dryness (Speed Dry, Air Dry,
+// Steam Fresh, Time Dry) and falls back to 'unknown' below.
+const DRY_LEVEL: Record<number, string> = {
+    1: 'Damp',
+    2: 'Less',
+    3: 'Normal',
+    4: 'More',
+    5: 'Very',
+}
+
+// Temp 1-5, confirmed the same way against the cloud's temp enum. 0 (NO_TEMP) is used by courses with no
+// heating element (Air Dry) and falls back to 'unknown' below.
+const TEMP: Record<number, string> = {
+    1: 'Ultra Low',
+    2: 'Low',
+    3: 'Medium',
+    4: 'Mid High',
+    5: 'High',
+}
+
+export default class Device extends AABBDevice {
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: 'LG Dryer' }),
+                components: {
+                    power: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-power',
+                        state_topic: '$this/power',
+                        name: 'Power',
+                        icon: 'mdi:tumble-dryer',
+                        device_class: 'running',
+                    },
+                    status: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-status',
+                        state_topic: '$this/status',
+                        name: 'Status',
+                        icon: 'mdi:state-machine',
+                        // free-text (NOT device_class:enum): unmapped phase codes emit 'Running'.
+                    },
+                    course: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-course',
+                        state_topic: '$this/course',
+                        name: 'Course',
+                        icon: 'mdi:pin-outline',
+                    },
+                    remaining_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-remaining_time',
+                        state_topic: '$this/remaining_time',
+                        name: 'Remaining time',
+                        icon: 'mdi:timer-outline',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                    },
+                    initial_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-initial_time',
+                        state_topic: '$this/initial_time',
+                        name: 'Initial time estimate',
+                        icon: 'mdi:clock-outline',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        entity_category: 'diagnostic',
+                    },
+                    dry_level: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-dry_level',
+                        state_topic: '$this/dry_level',
+                        name: 'Dry level',
+                        icon: 'mdi:water-percent',
+                    },
+                    temp: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-temp',
+                        state_topic: '$this/temp',
+                        name: 'Temperature',
+                        icon: 'mdi:thermometer',
+                    },
+                    reduce_static: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-reduce_static',
+                        state_topic: '$this/reduce_static',
+                        name: 'Reduce static',
+                        icon: 'mdi:flash-off-outline',
+                    },
+                    damp_dry_signal: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-damp_dry_signal',
+                        state_topic: '$this/damp_dry_signal',
+                        name: 'Damp Dry Signal',
+                        icon: 'mdi:water-alert-outline',
+                    },
+                    child_lock: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-child_lock',
+                        state_topic: '$this/child_lock',
+                        name: 'Child lock',
+                        icon: 'mdi:lock',
+                        entity_category: 'diagnostic',
+                    },
+                    energy_saver: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-energy_saver',
+                        state_topic: '$this/energy_saver',
+                        name: 'Energy Saver',
+                        icon: 'mdi:leaf',
+                    },
+                    turbo_steam: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-turbo_steam',
+                        state_topic: '$this/turbo_steam',
+                        name: 'Turbo Steam',
+                        icon: 'mdi:kettle-steam',
+                    },
+                    wrinkle_care: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-wrinkle_care',
+                        state_topic: '$this/wrinkle_care',
+                        name: 'Wrinkle Care',
+                        icon: 'mdi:tshirt-crew-outline',
+                    },
+                },
+            }),
+        )
+    }
+
+    processAABB(buf: Buffer) {
+        if (buf[0] !== 0x30 || buf.length < 2) return
+        if (buf[1] === STATUS_FRAME_TYPE) return this.processStatus(buf, RECORD_B_OFFSET, STATUS_FRAME_LEN)
+        if (buf[1] === SINGLE_STATUS_FRAME_TYPE)
+            return this.processStatus(buf, SINGLE_RECORD_OFFSET, SINGLE_STATUS_FRAME_LEN)
+        // 0x31 (serial), 0xE2 (idle/keepalive snapshot) and 0x72 (heartbeat) are not yet decoded.
+    }
+
+    private processStatus(buf: Buffer, recordOffset: number, expectedLen: number) {
+        if (buf.length !== expectedLen) return // reject header/layout drift
+        const rec = buf.subarray(recordOffset)
+        if (rec[0] !== 0x1b) return // record B should always lead with its marker
+
+        const phase = rec[PHASE_OFFSET]
+        const isOff = phase === PHASE_OFF
+
+        this.publishProperty('power', isOff ? 'OFF' : 'ON')
+        this.publishProperty('status', STATUS[phase] ?? 'Running')
+        this.publishProperty('course', COURSE[rec[COURSE_OFFSET]] ?? 'unknown')
+        this.publishProperty('remaining_time', isOff ? 0 : rec[TIME_HOUR_OFFSET] * 60 + rec[TIME_MIN_OFFSET])
+        this.publishProperty(
+            'initial_time',
+            isOff ? 0 : rec[INITIAL_TIME_HOUR_OFFSET] * 60 + rec[INITIAL_TIME_MIN_OFFSET],
+        )
+        this.publishProperty('dry_level', DRY_LEVEL[rec[DRY_LEVEL_OFFSET]] ?? 'unknown')
+        this.publishProperty('temp', TEMP[rec[TEMP_OFFSET]] ?? 'unknown')
+
+        const flags = rec[FLAGS_OFFSET]
+        this.publishProperty('child_lock', (flags & FLAG_CHILD_LOCK) !== 0 ? 'ON' : 'OFF')
+        this.publishProperty('reduce_static', (flags & FLAG_REDUCE_STATIC) !== 0 ? 'ON' : 'OFF')
+        this.publishProperty('damp_dry_signal', (flags & FLAG_DAMP_DRY_SIGNAL) !== 0 ? 'ON' : 'OFF')
+
+        const opt2 = rec[OPT2_OFFSET]
+        this.publishProperty('energy_saver', (opt2 & OPT2_ENERGY_SAVER) !== 0 ? 'ON' : 'OFF')
+        this.publishProperty('turbo_steam', (opt2 & OPT2_TURBO_STEAM) !== 0 ? 'ON' : 'OFF')
+        this.publishProperty('wrinkle_care', (opt2 & OPT2_WRINKLE_CARE) !== 0 ? 'ON' : 'OFF')
+        // not yet located (declared entities intentionally omitted rather than published wrong): error,
+        // door (opening the door mid-cycle just forces the same generic Pause phase a button-press
+        // would — no distinguishing byte or cloud field found, tested both early- and late-cycle),
+        // Anti-Bacterial and Easy Iron (the former is a course on this unit, not a separate toggle; the
+        // latter has no control on this physical model's panel at all).
+    }
+}

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -12,6 +12,7 @@ import F_V8_Y___W_B_2QEUK from './devices/F_V8_Y___W.B_2QEUK'
 import F_V__F___W_B_1QEUK from './devices/F_V__F___W.B_1QEUK'
 import F_VB_F___W_B_2QEUK from './devices/F_VB_F___W.B_2QEUK'
 import VCDWL2QEUK from './devices/VCDWL2QEUK'
+import F3L2CYU__ from './devices/F3L2CYU__'
 import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
 import { type Connection } from './homeassistant'
@@ -42,6 +43,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['VCDWL2QEUK']: VCDWL2QEUK, // LG F4X7511TWS front-load washer (matched on modelId VCDWL2QEUK)
     ['F_V__F___W.B_1QEUK']: F_V__F___W_B_1QEUK,
     ['F_VB_F___W.B_2QEUK']: F_VB_F___W_B_2QEUK, // LG CV74J7S2QA washer/dryer combo
+    ['F3L2CYU__']: F3L2CYU__, // LG front-load washer
 }
 
 class Bridge {

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -13,6 +13,7 @@ import F_V__F___W_B_1QEUK from './devices/F_V__F___W.B_1QEUK'
 import F_VB_F___W_B_2QEUK from './devices/F_VB_F___W.B_2QEUK'
 import VCDWL2QEUK from './devices/VCDWL2QEUK'
 import F3L2CYU__ from './devices/F3L2CYU__'
+import RV13B6BSD_D_US_WIFI from './devices/RV13B6BSD_D_US_WIFI'
 import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
 import { type Connection } from './homeassistant'
@@ -44,6 +45,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['F_V__F___W.B_1QEUK']: F_V__F___W_B_1QEUK,
     ['F_VB_F___W.B_2QEUK']: F_VB_F___W_B_2QEUK, // LG CV74J7S2QA washer/dryer combo
     ['F3L2CYU__']: F3L2CYU__, // LG front-load washer
+    ['RV13B6BSD_D_US_WIFI']: RV13B6BSD_D_US_WIFI, // LG electric dryer
 }
 
 class Bridge {

--- a/tests/cloud/devices/F3L2CYU__.test.ts
+++ b/tests/cloud/devices/F3L2CYU__.test.ts
@@ -13,6 +13,11 @@ const META: Metadata = { modelId: MODEL_ID, modelName: 'F3L2CYU__', swVersion: '
 // cloud's own decoded washerDryer state at matching timestamps. The AA + length and checksum + BB
 // envelope bytes are not validated on input, so these parse identically to the originals.
 
+// A single-record 0xEB frame — same field layout as 0xEC's record B, just without a preceding "old
+// state" record. Captured live right after the appliance reconnected to rethink-cloud post-deploy, idle
+// with nothing selected (phase Selecting, course/soil/spin/temp all their zero/none sentinel).
+const EB_RECONNECT_IDLE = buf('aa2020eb001805000000000000000000000000000000000000003318000068bb')
+
 // Idle, dial resting on Normal (course/soil/spin/temp at their settled defaults). Notable real-world
 // quirk confirmed live: Turbo Wash reads ON here and cannot be turned off while on Normal (course-locked),
 // unlike Speed Wash where it's freely toggleable (see the Delay Wash / Turbo Wash block below).
@@ -145,6 +150,16 @@ function makeDevice() {
 }
 
 describe('F3L2CYU__', () => {
+    test('0xEB single-record frames decode with the same offsets as 0xEC, seen right after reconnect', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', EB_RECONNECT_IDLE)
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.power, 'ON')
+        assert.equal(p.status, 'Selecting')
+        assert.equal(p.course, 'unknown') // course byte is 0 — nothing selected yet
+        assert.equal(p.door, 'ON') // open (byte reads 0, not the 0x02 closed value)
+    })
+
     test('idle, Selecting on Normal: course/soil/spin/temp settle to their defaults', () => {
         const { ha, thinq } = makeDevice()
         thinq.emit('data', NORMAL_IDLE)

--- a/tests/cloud/devices/F3L2CYU__.test.ts
+++ b/tests/cloud/devices/F3L2CYU__.test.ts
@@ -1,0 +1,307 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/F3L2CYU__'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'F3L2CYU__'
+const META: Metadata = { modelId: MODEL_ID, modelName: 'F3L2CYU__', swVersion: '0.0.0' }
+
+// All fixtures are REAL 0xEC frames captured live from the appliance (a WM3900HBA / F3L2CYU2E.ABLEUUS,
+// which self-reports modelId "F3L2CYU__") via the rethink-agent MCP tools, cross-checked against the LG
+// cloud's own decoded washerDryer state at matching timestamps. The AA + length and checksum + BB
+// envelope bytes are not validated on input, so these parse identically to the originals.
+
+// Idle, dial resting on Normal (course/soil/spin/temp at their settled defaults). Notable real-world
+// quirk confirmed live: Turbo Wash reads ON here and cannot be turned off while on Normal (course-locked),
+// unlike Speed Wash where it's freely toggleable (see the Delay Wash / Turbo Wash block below).
+const NORMAL_IDLE = buf(
+    'aa3a20ec0018050000000000000000000000000000000000000033170000001805002e002e07000304040100000080000000000033170000f8bb',
+)
+// Course/dial-position identifier (offset 6 from the record marker) for several other programs — proves
+// the identifier is a single stable byte, distinct from the time-estimate bytes at offset 2-3 (which an
+// earlier reverse-engineering pass mistook for a "course code" before realizing it shifts with settings).
+const COURSE_TOWELS = buf(
+    'aa3a20ec001805002900290a000303020200000000000000000033170007001805010101010b0003050403000000000000000000331700001cbb',
+)
+const COURSE_SPEEDWASH = buf(
+    'aa3a20ec001805010101010b000305040300000000000000000033170000001805000f000f0c0001050601000000000000000000331700074fbb',
+)
+const COURSE_RINSE_SPIN = buf(
+    'aa3a20ec001805000f000f0c000105060100000000000000000033170007001805000b000b0d0000040000000000000000000000331700077fbb',
+)
+const COURSE_SMALL_LOAD = buf(
+    'aa3a20ec001805000b000b0d000004000000000000000000000033170007001805002d002d0e000304040200000000000000000033170f0025bb',
+)
+const COURSE_TUB_CLEAN = buf(
+    'aa3a20ec001805002d002d0e000304040200000000000000000033170f00001805011d011d01000003000200000004000000000033170000ddbb',
+)
+
+// Settings toggles, each isolated by changing exactly one control while parked on Normal and matched
+// against the cloud's own enum for that field (soilWash/spin/temp/coldWash/extraRinse/preWash/steam).
+const SOIL_NORMAL_HEAVY = buf(
+    'aa3a20ec001805002e002e070003040401000000800000000000331700000018050033003307000404040100000080000000010033170000fdbb',
+)
+const SPIN_EXTRA_HIGH = buf(
+    'aa3a20ec001805002e002e07000304040100000080000000010033170000001805003a003a07000305040100000080000000010033170000e2bb',
+)
+const TEMP_HOT = buf(
+    'aa3a20ec001805002e002e07000304040100000080000000010033170000001805002e002e07000304060100000080000000010033170000f5bb',
+)
+// Cold Wash also forces the temp index to 0x02 (Cold) — confirmed here (temp reads 'Cold', not the prior
+// 'Warm'), matching the real appliance behavior, not just a coincidence of this capture.
+const COLD_WASH_ON = buf(
+    'aa3a20ec001805002e002e0700030404010000008000000001003317000000180501060106070003040201000000801000000100331700000bbb',
+)
+const EXTRA_RINSE_ON_1 = buf(
+    'aa3a20ec001805002e002e0700030404010000008000000001003317000000180500330033070003040411000000c0000000010033170000adbb',
+)
+const PRE_WASH_ON = buf(
+    'aa3a20ec001805002e002e0700030404010000008000000001003317000000180501010101070003040401000000880000000100331700001bbb',
+)
+const STEAM_ON = buf(
+    'aa3a20ec001805002e002e07000304040100000080000000010033170000001805020b020b070000040001000000840000000100331700000cbb',
+)
+
+// A full Speed Wash run, captured end-to-end. SELECTING_TO_WASHING is the exact frame where a bridge-mode
+// "Start" command from the LG app landed and the washer transitioned — a genuine remote-start round trip,
+// not just a status readback.
+const SELECTING_TO_WASHING = buf(
+    'aa3a20ec001805000f000f0c000105060100000000800200020033170007001817000f000f0c00010506010000000080020000053317000702bb',
+)
+const WASHING = buf(
+    'aa3a20ec001817000f000f0c000105060100000000800200000533170007001817000e000f0c0001050601000000008002000005331700073ebb',
+)
+const RINSING = buf(
+    'aa3a20ec001817000d000f0c00010506010000000080020012053317000700181e000c000f0c000005060100000000800200231733170007e1bb',
+)
+// Baseline for the pause/door block below: running, door locked and closed.
+const RINSING_LOCKED_CLOSED = buf(
+    'aa3a20ec00181e000c000f0c00000506010000000080020023173317000700181e000b000f0c00000506010000000080020024173317000789bb',
+)
+const SPINNING = buf(
+    'aa3a20ec00181e000a000f0c0000050601000000008002002506331700070018280009000f0c000005000000000000800200261e3317000780bb',
+)
+const COMPLETE = buf(
+    'aa3a20ec0018280001000f0c000005000000000000800200391e3317000700183c00010000fe000000000000000000000000402833180000d4bb',
+)
+
+// Pause (from the physical panel, mid-Rinsing) -> door opened -> resume -> door closed again. Confirms
+// the door-lock bit (offset 16, 0x80) and the plain door-closed sensor (offset 17, 0x02) are independent:
+// the machine can be paused with the door shut but unlocked.
+const PAUSE_UNLOCKS = buf(
+    'aa3a20ec00181e000b000f0c000005060100000000800200241733170007001806000b000f0c000005060100000000000200251e3317000719bb',
+)
+const DOOR_OPENS_WHILE_PAUSED = buf(
+    'aa3a20ec001806000b000f0c000005060100000000000200251e33170007001806000b000f0c000005060100000000000000251e33170007efbb',
+)
+// Door-lock re-engages on resume even though this exact frame still reads the door as open — the physical
+// door-close follows a moment later (see DOOR_CLOSES_AGAIN), matching real-world timing.
+const RESUME_RELOCKS = buf(
+    'aa3a20ec00181e000b000f0c000005060100000000000000251e3317000700181e000b000f0c0000050601000000008000002506331700076dbb',
+)
+const DOOR_CLOSES_AGAIN = buf(
+    'aa3a20ec00181e000b000f0c00000506010000000080000025063317000700181e000b000f0c000005060100000000800200250633170007efbb',
+)
+
+// Delay Wash armed for 1 hour, then Turbo Wash enabled, both while still Selecting (Speed Wash, a course
+// where Turbo Wash is actually toggleable — unlike Normal above).
+const DELAY_1H_ARMED_STILL_SELECTING = buf(
+    'aa3a20ec001805000f000f0c000105060100000000000000400033180007001805000f000f0c000105060100010002000000400033180007eabb',
+)
+const TURBO_ON_STILL_SELECTING = buf(
+    'aa3a20ec001805000f000f0c000105060100010002000000400033180007001805000f000f0c00010506010001008200000040003318000717bb',
+)
+// Phase flips to Delay Wash pending (0x0a) and the door locks immediately, before the cycle actually runs.
+const DELAY_PENDING_LOCKS_DOOR = buf(
+    'aa3a20ec001805000f000f0c00010506010001008200000040003318000700180a000f000f0c00010506010001008280000040053318000719bb',
+)
+const DELAY_DOOR_CLOSES = buf(
+    'aa3a20ec00180a000f000f0c00010506010001008280000040053318000700180a000f000f0c000105060100010082800200000533180007cdbb',
+)
+// Remote pause (from the LG app) of the Delay Wash countdown, then remote resume with the reserve time
+// changed to 3 hours, then the reserve-time countdown ticking across an hour boundary (3:00 -> 2:59).
+const APP_PAUSE = buf(
+    'aa3a20ec00180a000f000f0c000105060100003a82800200000533180007001806000f000f0c000105060100003a82800200000a3318000798bb',
+)
+const APP_RESUME_3H = buf(
+    'aa3a20ec001806000f000f0c000105060100003a82800200000a3318000700180a000f000f0c000105060100030082800200000633180007c2bb',
+)
+const RESERVE_TICKS = buf(
+    'aa3a20ec00180a000f000f0c00010506010003008280020000063318000700180a000f000f0c000105060100023b82800200000633180007cfbb',
+)
+// Remote power-off (from the LG app) during the Delay Wash countdown: phase drops straight to Off and the
+// course/settings bytes reset to their sentinel values (course 0xfe, soil/spin/temp all 0).
+const APP_POWEROFF = buf(
+    'aa3a20ec00180a000f000f0c000105060100023a8280020000063318000700180000010000fe000000000000000000000200000a331800001abb',
+)
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+describe('F3L2CYU__', () => {
+    test('idle, Selecting on Normal: course/soil/spin/temp settle to their defaults', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', NORMAL_IDLE)
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.power, 'ON')
+        assert.equal(p.status, 'Selecting')
+        assert.equal(p.course, 'Normal')
+        assert.equal(p.remaining_time, 46)
+        assert.equal(p.soil, 'Normal')
+        assert.equal(p.spin, 'High')
+        assert.equal(p.temp, 'Warm')
+        // Course-locked quirk, confirmed live: Turbo Wash is forced ON on Normal and can't be toggled off.
+        assert.equal(p.turbo_wash, 'ON')
+        assert.equal(p.door, 'ON') // open — this capture was taken with the door open while browsing
+        assert.equal(p.door_lock, 'OFF')
+    })
+
+    test('the course/dial-position byte (offset 6) identifies each program independently of the shifting time-estimate bytes', () => {
+        const { ha, thinq } = makeDevice()
+        const p = ha.devices[DEVICE_ID].properties
+        for (const [frame, course] of [
+            [COURSE_TOWELS, 'Towels'],
+            [COURSE_SPEEDWASH, 'Speed Wash'],
+            [COURSE_RINSE_SPIN, 'Rinse+Spin'],
+            [COURSE_SMALL_LOAD, 'Small Load'],
+            [COURSE_TUB_CLEAN, 'Tub Clean'],
+        ] as const) {
+            thinq.emit('data', frame)
+            assert.equal(p.course, course)
+        }
+    })
+
+    test('single-variable settings toggles decode soil/spin/temp/cold-wash/extra-rinse/pre-wash/steam', () => {
+        const { ha, thinq } = makeDevice()
+        const p = ha.devices[DEVICE_ID].properties
+
+        thinq.emit('data', SOIL_NORMAL_HEAVY)
+        assert.equal(p.soil, 'Normal-Heavy')
+
+        thinq.emit('data', SPIN_EXTRA_HIGH)
+        assert.equal(p.spin, 'Extra High')
+
+        thinq.emit('data', TEMP_HOT)
+        assert.equal(p.temp, 'Hot')
+
+        thinq.emit('data', COLD_WASH_ON)
+        assert.equal(p.cold_wash, 'ON')
+        assert.equal(p.temp, 'Cold') // Cold Wash forces the temp index too
+
+        thinq.emit('data', EXTRA_RINSE_ON_1)
+        assert.equal(p.extra_rinse, 'ON')
+        assert.equal(p.extra_rinse_count, 1)
+
+        thinq.emit('data', PRE_WASH_ON)
+        assert.equal(p.pre_wash, 'ON')
+
+        thinq.emit('data', STEAM_ON)
+        assert.equal(p.steam, 'ON')
+    })
+
+    test('a full Speed Wash run: remote start, phase transitions, and the remaining-time countdown', () => {
+        const { ha, thinq } = makeDevice()
+        const p = ha.devices[DEVICE_ID].properties
+
+        thinq.emit('data', SELECTING_TO_WASHING)
+        assert.equal(p.status, 'Washing')
+        assert.equal(p.remaining_time, 15)
+
+        thinq.emit('data', WASHING)
+        assert.equal(p.status, 'Washing')
+        assert.equal(p.remaining_time, 14)
+
+        thinq.emit('data', RINSING)
+        assert.equal(p.status, 'Rinsing')
+        assert.equal(p.remaining_time, 12)
+
+        thinq.emit('data', SPINNING)
+        assert.equal(p.status, 'Spinning')
+        assert.equal(p.remaining_time, 9)
+
+        thinq.emit('data', COMPLETE)
+        assert.equal(p.status, 'Complete')
+        // Course/soil/spin/temp fall back to 'unknown' here — the Complete-phase frame's course byte is
+        // 0xfe, the same sentinel used at power-off, not one of the 14 named programs.
+        assert.equal(p.course, 'unknown')
+    })
+
+    test('pause unlocks the door, opening/closing the door is independent of the lock, and resume relocks', () => {
+        const { ha, thinq } = makeDevice()
+        const p = ha.devices[DEVICE_ID].properties
+
+        thinq.emit('data', RINSING_LOCKED_CLOSED)
+        assert.equal(p.door_lock, 'ON')
+        assert.equal(p.door, 'OFF') // closed
+
+        thinq.emit('data', PAUSE_UNLOCKS)
+        assert.equal(p.status, 'Paused')
+        assert.equal(p.door_lock, 'OFF')
+        assert.equal(p.door, 'OFF') // still closed
+
+        thinq.emit('data', DOOR_OPENS_WHILE_PAUSED)
+        assert.equal(p.door, 'ON') // now open
+        assert.equal(p.door_lock, 'OFF')
+
+        thinq.emit('data', RESUME_RELOCKS)
+        assert.equal(p.status, 'Rinsing')
+        assert.equal(p.door_lock, 'ON')
+
+        thinq.emit('data', DOOR_CLOSES_AGAIN)
+        assert.equal(p.door, 'OFF') // closed
+        assert.equal(p.door_lock, 'ON')
+    })
+
+    test('Delay Wash: arming, Turbo Wash, the Delay-pending phase, reserve-time countdown, remote pause/resume, and remote power-off', () => {
+        const { ha, thinq } = makeDevice()
+        const p = ha.devices[DEVICE_ID].properties
+
+        thinq.emit('data', DELAY_1H_ARMED_STILL_SELECTING)
+        assert.equal(p.status, 'Selecting') // not yet armed as a running delay
+        assert.equal(p.delay_wash, 'ON')
+        assert.equal(p.reserve_time, 60)
+
+        thinq.emit('data', TURBO_ON_STILL_SELECTING)
+        assert.equal(p.turbo_wash, 'ON') // toggleable on Speed Wash, unlike Normal
+
+        thinq.emit('data', DELAY_PENDING_LOCKS_DOOR)
+        assert.equal(p.status, 'Delay Wash')
+        assert.equal(p.door_lock, 'ON') // locks as soon as the delay is armed, not just once running
+
+        thinq.emit('data', DELAY_DOOR_CLOSES)
+        assert.equal(p.door, 'OFF')
+
+        thinq.emit('data', APP_PAUSE)
+        assert.equal(p.status, 'Paused')
+
+        thinq.emit('data', APP_RESUME_3H)
+        assert.equal(p.status, 'Delay Wash')
+        assert.equal(p.reserve_time, 180)
+
+        thinq.emit('data', RESERVE_TICKS)
+        assert.equal(p.reserve_time, 179) // 3:00 -> 2:59 across the hour boundary
+
+        thinq.emit('data', APP_POWEROFF)
+        assert.equal(p.power, 'OFF')
+        assert.equal(p.status, 'Off')
+        assert.equal(p.remaining_time, 0)
+        assert.equal(p.reserve_time, 0)
+        assert.equal(p.course, 'unknown')
+    })
+
+    test('unknown frame type and non-envelope frames are ignored', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', NORMAL_IDLE)
+        const before = ha.devices[DEVICE_ID].properties.status
+        thinq.emit('data', buf('aa0720d81795bb')) // 0xd8 heartbeat
+        thinq.emit('data', buf('aa09207200000010bb')) // 0x72 heartbeat
+        thinq.emit('data', buf('001122')) // not an AA..BB envelope
+        assert.equal(ha.devices[DEVICE_ID].properties.status, before)
+    })
+})

--- a/tests/cloud/devices/RV13B6BSD_D_US_WIFI.test.ts
+++ b/tests/cloud/devices/RV13B6BSD_D_US_WIFI.test.ts
@@ -1,0 +1,267 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/RV13B6BSD_D_US_WIFI'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'RV13B6BSD_D_US_WIFI'
+const META: Metadata = { modelId: MODEL_ID, modelName: MODEL_ID, swVersion: '0.0.0' }
+
+// All fixtures are REAL frames captured live from the appliance (a DLEX3900B / RV13B6JSD.ABLEEUS, which
+// self-reports modelId "RV13B6BSD_D_US_WIFI") via the rethink-agent MCP tools, cross-checked against the
+// LG cloud's own decoded washerDryer state at matching timestamps — not guessed from static analysis.
+
+// A single-record 0xEB frame, powered off with nothing selected (phase Off, course/dry-level/temp all
+// their zero/none sentinel). Same field layout as 0xEC's current-state record.
+const EB_IDLE = buf('aa2330eb001b0000010001000000000004000000402800065f04000000640000006bbb')
+
+// Off -> Initial (dial-browsing/settings-selection begins).
+const OFF_TO_INITIAL = buf(
+    'aa4030ec001b0000010001000000000004000000402800065f0400000064000000001b0100010001000000000004000000402800000000000000640000001fbb',
+)
+
+// Course identifier (offset 6) confirmed across several programs, each cross-checked against the cloud's
+// courseDryer27inchBase at matching timestamps.
+const COURSE_NORMAL = buf(
+    'aa4030ec001b010001000100000000000400000000280000000000000064000000001b010029002903000304000400000000280000000000000064000000e9bb',
+)
+const COURSE_BEDDING = buf(
+    'aa4030ec001b010039003903000304000400000000aa0000000000000064000000001b010037003707000303000400000000a8000000000000006400000002bb',
+)
+const COURSE_SMALL_LOAD = buf(
+    'aa4030ec001b010037003707000303000400000000a80000000000000064000000001b01001e001e09000305000400000000a8000000000000006400000073bb',
+)
+// Also demonstrates Small Load's Selecting/Initial -> Drying transition, matching the cloud's
+// preState:"INITIAL" / state:"DRYING".
+const SMALL_LOAD_STARTS_DRYING = buf(
+    'aa4030ec001b01001e001e09000305000400000000a80000000000000064000000001b32001e001e09000305000400000000a800000001000000640000007fbb',
+)
+
+// Paused (from Small Load) -> Initial with Antibacterial selected. Confirms Dry level 'Very' (offset 8 =
+// 5) and Temp 'High' (offset 9 = 5), cross-checked against the cloud's DRYLEVEL_VERYDRY/TEMP_HIGH for
+// the Antibacterial course.
+const PAUSE_THEN_ANTIBACTERIAL_SELECTED = buf(
+    'aa4030ec001b03001e001e09000305000400000040a80000063200000064000000001b01010a010a08000505000400000040a80000060300000064000000c3bb',
+)
+
+// Heavy Duty selected, then Normal selected with Energy Saver turned on in the same step — matching the
+// cloud's courseDryer27inchBase:"NORMAL", energySaver:"ENERGYSAVER_ON".
+const HEAVY_DUTY_THEN_NORMAL_ENERGY_SAVER_ON = buf(
+    'aa4030ec001b010036003601000305000400000040a80000060300000064000000001b010039003903000304000400000040aa0000060300000064000000b6bb',
+)
+
+// A real Normal/Energy-Saver-on run: Drying (remaining-time ticking down while initial-time stays fixed,
+// the genuine separate-field behavior this model has and the washer doesn't) -> Cooling -> a brief Off
+// blip -> End -> final settled Off (course/settings reset to their zero sentinel). Every phase and time
+// value here was cross-checked against the cloud at matching timestamps.
+const STARTS_DRYING = buf(
+    'aa4030ec001b010039003903000304000400000040aa0000060300000064000000001b320039003903000304000400000000aa000000010000006400000080bb',
+)
+const REMAINING_TICKS_DOWN = buf(
+    'aa4030ec001b320039003903000304000400000000aa0000000100000064000000001b320038003903000304000400000000aa000004010000006400000094bb',
+)
+const DRYING_TO_COOLING = buf(
+    'aa4030ec001b320038003903000304000400000000aa0000040100000064000000001b330001000203000304000400000000aa0000063200000064000000dfbb',
+)
+const COOLING_TO_OFF_BLIP = buf(
+    'aa4030ec001b330001000303000304000400000000aa0000083200000064000000001b000001000303000304000400000000aa00000a330000006400000073bb',
+)
+const OFF_BLIP_TO_END = buf(
+    'aa4030ec001b000001000303000304000400000000aa00000a3300000064000000001b040001000303000304000400000040aa00000a000000006400000052bb',
+)
+const END_TO_FINAL_OFF = buf(
+    'aa4030ec001b040001000303000304000400000040aa00000a0000000064000000001b000001000100000000000400000040a800000a04000000640000005fbb',
+)
+
+// Bedding selected, then Heavy Duty selected with Turbo Steam turned on in the same step — matching the
+// cloud's courseDryer27inchBase:"HEAVYDUTY", turboSteam:"TURBOSTEAM_ON".
+const BEDDING_THEN_HEAVY_DUTY_TURBO_STEAM_ON = buf(
+    'aa4030ec001b010037003707000303000400000000a80000000000000064000000001b010036003601000305000400000000ac000000000000006400000007bb',
+)
+// Turbo Steam confirmed active into the Drying phase.
+const HEAVY_DUTY_DRYING_TURBO_STEAM_ON = buf(
+    'aa4030ec001b010036003601000305000400000000ac0000000000000064000000001b320036003601000305000400000000ac0000000100000064000000d7bb',
+)
+
+// Damp Dry Signal toggled on (while paused with settings open, mid-Drying-adjacent), matching the cloud's
+// dampDrySignal:"DAMPDRYSIGNAL_ON".
+const DAMP_DRY_SIGNAL_ON = buf(
+    'aa4030ec001b010036003601000305000400000040280000430300000064000000001b01003600360100030500040000004828000043030000006400000009bb',
+)
+// Damp Dry Signal toggled back off, in the same step as reselecting Normal — matching the cloud's
+// courseDryer27inchBase:"NORMAL", dampDrySignal:"DAMPDRYSIGNAL_OFF".
+const DAMP_DRY_SIGNAL_OFF_NORMAL_SELECTED = buf(
+    'aa4030ec001b030036003601000305000400000048280000113200000064000000001b01002900290300030400040000004028000011030000006400000045bb',
+)
+
+// Child Lock engaged (Antibacterial, paused), matching the cloud's childLock:"CHILDLOCK_ON".
+const CHILD_LOCK_ON = buf(
+    'aa4030ec001b03010a010a080005050004000000402800000e3200000064000000001b03010a010a080005050004000000412800000e3200000064000000e6bb',
+)
+
+// A real remote-start round trip: the LG app's Start command lands (captured verbatim as the outgoing
+// packet below) and the phase flips Initial -> Drying, matching the cloud's state:"DRYING".
+const APP_START_COMMAND = buf('aa1bf0260300000400000000410003000000000300d700000055bb')
+const REMOTE_STARTS_DRYING = buf(
+    'aa4030ec001b010029002903000304000400000040290000240000000064000000001b3200010001030003040004d700000029000000010000006400000060bb',
+)
+
+// A real remote-power-off round trip: the LG app's Power Off command (identical to the washer's own
+// remote-power-off command, byte for byte) lands and the phase drops straight to Off, with the
+// course/settings bytes reset to their zero sentinel.
+const APP_POWEROFF_COMMAND = buf('aa09f0240101009cbb')
+const REMOTE_POWEROFF = buf(
+    'aa4030ec001b3201070108030003040004d70000002900006c0100000064000000001b0001070107000000000004000000402800009932000000640000005cbb',
+)
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+describe('RV13B6BSD_D_US_WIFI', () => {
+    test('0xEB single-record frames decode with the same offsets as 0xEC, seen right after reconnect', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', EB_IDLE)
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.power, 'OFF')
+        assert.equal(p.status, 'Off')
+        assert.equal(p.course, 'unknown') // course byte is 0 — nothing selected yet
+    })
+
+    test('Off -> Initial as dial-browsing begins', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', OFF_TO_INITIAL)
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.power, 'ON')
+        assert.equal(p.status, 'Initial')
+    })
+
+    test('the course byte (offset 6) identifies each program, and Initial -> Drying on Start', () => {
+        const { ha, thinq } = makeDevice()
+        const p = ha.devices[DEVICE_ID].properties
+
+        thinq.emit('data', COURSE_NORMAL)
+        assert.equal(p.course, 'Normal')
+        assert.equal(p.dry_level, 'Normal')
+        assert.equal(p.temp, 'Mid High')
+
+        thinq.emit('data', COURSE_BEDDING)
+        assert.equal(p.course, 'Bedding')
+        assert.equal(p.temp, 'Medium')
+
+        thinq.emit('data', COURSE_SMALL_LOAD)
+        assert.equal(p.course, 'Small Load')
+        assert.equal(p.temp, 'High')
+
+        thinq.emit('data', SMALL_LOAD_STARTS_DRYING)
+        assert.equal(p.status, 'Drying')
+        assert.equal(p.course, 'Small Load')
+    })
+
+    test('pause, then re-selecting Antibacterial shows Dry level Very and Temp High', () => {
+        const { ha, thinq } = makeDevice()
+        const p = ha.devices[DEVICE_ID].properties
+
+        thinq.emit('data', PAUSE_THEN_ANTIBACTERIAL_SELECTED)
+        assert.equal(p.status, 'Initial')
+        assert.equal(p.course, 'Antibacterial')
+        assert.equal(p.dry_level, 'Very')
+        assert.equal(p.temp, 'High')
+    })
+
+    test('Energy Saver and Turbo Steam toggle independently of course selection', () => {
+        const { ha, thinq } = makeDevice()
+        const p = ha.devices[DEVICE_ID].properties
+
+        thinq.emit('data', HEAVY_DUTY_THEN_NORMAL_ENERGY_SAVER_ON)
+        assert.equal(p.course, 'Normal')
+        assert.equal(p.energy_saver, 'ON')
+
+        thinq.emit('data', BEDDING_THEN_HEAVY_DUTY_TURBO_STEAM_ON)
+        assert.equal(p.course, 'Heavy Duty')
+        assert.equal(p.turbo_steam, 'ON')
+
+        thinq.emit('data', HEAVY_DUTY_DRYING_TURBO_STEAM_ON)
+        assert.equal(p.status, 'Drying')
+        assert.equal(p.turbo_steam, 'ON')
+    })
+
+    test('Damp Dry Signal toggles on and off', () => {
+        const { ha, thinq } = makeDevice()
+        const p = ha.devices[DEVICE_ID].properties
+
+        thinq.emit('data', DAMP_DRY_SIGNAL_ON)
+        assert.equal(p.damp_dry_signal, 'ON')
+
+        thinq.emit('data', DAMP_DRY_SIGNAL_OFF_NORMAL_SELECTED)
+        assert.equal(p.course, 'Normal')
+        assert.equal(p.damp_dry_signal, 'OFF')
+    })
+
+    test('Child Lock engages', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', CHILD_LOCK_ON)
+        assert.equal(ha.devices[DEVICE_ID].properties.child_lock, 'ON')
+    })
+
+    test('a full run: Drying with a genuine separate initial-time estimate, Cooling, End, and final Off', () => {
+        const { ha, thinq } = makeDevice()
+        const p = ha.devices[DEVICE_ID].properties
+
+        thinq.emit('data', STARTS_DRYING)
+        assert.equal(p.status, 'Drying')
+        assert.equal(p.remaining_time, 57)
+        assert.equal(p.initial_time, 57)
+
+        thinq.emit('data', REMAINING_TICKS_DOWN)
+        assert.equal(p.remaining_time, 56)
+        assert.equal(p.initial_time, 57) // stays fixed while remaining_time counts down
+
+        thinq.emit('data', DRYING_TO_COOLING)
+        assert.equal(p.status, 'Cooling')
+        assert.equal(p.remaining_time, 1)
+
+        thinq.emit('data', COOLING_TO_OFF_BLIP)
+        assert.equal(p.status, 'Off') // a brief settle before the End notification
+
+        thinq.emit('data', OFF_BLIP_TO_END)
+        assert.equal(p.status, 'End')
+
+        thinq.emit('data', END_TO_FINAL_OFF)
+        assert.equal(p.status, 'Off')
+        assert.equal(p.power, 'OFF')
+        assert.equal(p.remaining_time, 0)
+        assert.equal(p.initial_time, 0)
+        assert.equal(p.course, 'unknown')
+    })
+
+    test('a real remote-start round trip flips Initial -> Drying', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', APP_START_COMMAND) // the actual command captured from the LG app, for reference
+        thinq.emit('data', REMOTE_STARTS_DRYING)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Drying')
+    })
+
+    test('a real remote-power-off round trip drops straight to Off', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', APP_POWEROFF_COMMAND) // identical, byte for byte, to the washer's own command
+        thinq.emit('data', REMOTE_POWEROFF)
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.status, 'Off')
+        assert.equal(p.power, 'OFF')
+        assert.equal(p.course, 'unknown')
+    })
+
+    test('unknown frame type and non-envelope frames are ignored', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', COURSE_NORMAL)
+        const before = ha.devices[DEVICE_ID].properties.status
+        thinq.emit('data', buf('aa09307200c9004bbb')) // 0x72 heartbeat
+        thinq.emit('data', buf('001122')) // not an AA..BB envelope
+        assert.equal(ha.devices[DEVICE_ID].properties.status, before)
+    })
+})


### PR DESCRIPTION
## Summary
- Adds `cloud/devices/F3L2CYU__.ts` for the LG WM3900HBA washer (self-reported ThinQ2 modelId `F3L2CYU__`) — decodes course, phase, remaining/reserve time, soil, spin, temp, all six option toggles (extra rinse, pre wash, steam, cold wash, turbo wash, delay wash), and door-closed/door-lock state.
- Adds `cloud/devices/RV13B6BSD_D_US_WIFI.ts` for the companion LG DLEX3900B dryer — decodes course, dry level, temp, time, all six cycle phases, Reduce Static, Energy Saver, Turbo Steam, Wrinkle Care, Child Lock, and Damp Dry Signal.
- Fixes the washer handler to also decode the single-record `0xEB` frame sent right after reconnect (before the dual-record `0xEC` frames arrive), so Home Assistant entities get real values immediately instead of sitting empty until the first `0xEC`.

Every decoded field/offset was live-verified against the LG cloud's own decoded state via the `rethink-agent` MCP tooling while operating the physical appliances (dial browsing, individual setting toggles, full wash/dry cycles, pause/resume, and remote start/pause/power-off from the official LG app) — not inferred from static analysis alone. Both handlers have been running in daily production use against the real appliances through Home Assistant for a multi-day soak period with no issues.

## Test plan
- [x] Unit tests added for both handlers using real captured frames for each decoded field (`tests/cloud/devices/F3L2CYU__.test.ts`, `tests/cloud/devices/RV13B6BSD_D_US_WIFI.test.ts`)
- [x] Deployed live against real appliances, confirmed working end-to-end through Home Assistant across multiple real wash/dry cycles