### PR TITLE
Complete RTL8720cm/BK7234 provisioning: local handshake, generic fallback, UI improvements

### DIFF
--- a/cloud/devices/generic.ts
+++ b/cloud/devices/generic.ts
@@ -1,0 +1,61 @@
+import HADevice from './base'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import log from '@/util/logging'
+
+// Generic capture class for unknown ThinQ2 devices. Enrolls the device so it
+// stays connected and publishes raw packet hex to a diagnostic HA sensor.
+export default class GenericDevice extends HADevice {
+    publishCache: Record<string, string | number> = {}
+
+    constructor(
+        HA: Connection,
+        readonly thinq: Thinq2Device,
+        readonly meta: Metadata,
+    ) {
+        super(HA, thinq.id)
+        this.thinq.on('data', (buf) => this.onData(buf))
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: meta.modelName || 'LG device (generic)' }),
+                components: {
+                    raw: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-raw',
+                        state_topic: '$this/raw',
+                        name: 'Raw packet',
+                        icon: 'mdi:code-braces',
+                        entity_category: 'diagnostic',
+                    },
+                    last_seen: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-last-seen',
+                        state_topic: '$this/last_seen',
+                        name: 'Last packet at',
+                        icon: 'mdi:clock-outline',
+                        entity_category: 'diagnostic',
+                    },
+                },
+            }),
+        )
+    }
+
+    onData(buf: Buffer) {
+        try {
+            const hex = buf.toString('hex')
+            log('status', this.id, 'generic raw packet:', hex)
+            this.pub('raw', hex.slice(0, 255))
+            this.pub('last_seen', new Date().toISOString())
+        } catch (err) {
+            log('status', this.id, 'generic onData error', String(err))
+        }
+    }
+
+    pub(prop: string, value: string | number) {
+        if (this.publishCache[prop] === value) return
+        this.publishCache[prop] = value
+        this.HA.publishProperty(this.id, prop, value)
+    }
+}

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -12,6 +12,7 @@ import F_V8_Y___W_B_2QEUK from './devices/F_V8_Y___W.B_2QEUK'
 import F_V__F___W_B_1QEUK from './devices/F_V__F___W.B_1QEUK'
 import F_VB_F___W_B_2QEUK from './devices/F_VB_F___W.B_2QEUK'
 import VCDWL2QEUK from './devices/VCDWL2QEUK'
+import GenericDevice from './devices/generic'
 import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
 import { type Connection } from './homeassistant'
@@ -69,6 +70,10 @@ class Bridge {
         } else if (thinqdev.platform === 'thinq2') {
             const devclass = t2deviceTypes[meta.modelId]
             if (devclass) hadevice = new devclass(this.HA, thinqdev, meta)
+            else {
+                console.warn(`thinq2 device type ${meta.modelId} unknown — enrolling with generic raw class`)
+                hadevice = new GenericDevice(this.HA, thinqdev as T2Device, meta)
+            }
         }
 
         if (!hadevice) {

--- a/cloud/thinq2/device.ts
+++ b/cloud/thinq2/device.ts
@@ -89,12 +89,14 @@ export class DeviceAcceptor extends TypedEmitter<DeviceAcceptorEvents> {
                 this.completeProvisioning(payload.did, payload, client)
             }
 
-            if (payload.cmd === 'device_packet' && client.deviceObj && payload.did === client.deviceObj.id) {
-                const buf = Buffer.from(payload.data as string, 'hex')
-                client.deviceObj.emit('data', buf)
+            if (payload.cmd === 'device_packet' && payload.did === client.deployMsg?.did) {
+                if (client.deviceObj) {
+                    const buf = Buffer.from(payload.data as string, 'hex')
+                    client.deviceObj.emit('data', buf)
+                }
             }
 
-            if (payload.cmd === 'req_timesync' && client.deviceObj && payload.did === client.deviceObj.id) {
+            if (payload.cmd === 'req_timesync' && client.deployMsg && payload.did === client.deployMsg.did) {
                 this.timeSyncRequest(client)
             }
         }
@@ -156,7 +158,25 @@ export class DeviceAcceptor extends TypedEmitter<DeviceAcceptorEvents> {
         buf[5] = now.getUTCSeconds()
         buf[6] = now.getUTCDay()
 
-        client.deviceObj?.send('resp_timesync', 1, buf.toString('base64'))
+        const deviceId = client.deployMsg?.did
+        if (!deviceId) return
+
+        this.broker.publish(
+            {
+                topic: 'lime/devices/' + deviceId,
+                retain: false,
+                qos: 0,
+                dup: false,
+                payload: JSON.stringify({
+                    did: deviceId,
+                    mid: Date.now(),
+                    cmd: 'resp_timesync',
+                    type: 1,
+                    data: buf.toString('base64'),
+                }),
+            },
+            null,
+        )
     }
 
     disconnected(_client: Client) {

--- a/cloud/thinq2/device.ts
+++ b/cloud/thinq2/device.ts
@@ -140,6 +140,7 @@ export class DeviceAcceptor extends TypedEmitter<DeviceAcceptorEvents> {
             modelId: client.deployMsg.kind,
             modelName: client.deployMsg.data?.appInfo?.modelName,
             swVersion: client.deployMsg.data?.appInfo?.softVer,
+            deviceType: client.deployMsg.data?.appInfo?.DeviceType,
         }
 
         const dev = new Device(this.broker, 'lime/devices/' + deviceId, deviceId, meta)

--- a/cloud/thinq2/provisioning.ts
+++ b/cloud/thinq2/provisioning.ts
@@ -83,7 +83,7 @@ export function generateDeployResponse(payload: ClipDeployMessage) {
                     provisioning: 'clip/provisioning/devices/' + payload.did,
                 },
             },
-            provisioningType: payload.cmd,
+            provisioningType: 'deploy',
             deployInterval: 600,
         },
     }

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-  "hostname": "rethink.lan",
+  "hostname": "common.lgthinq.com",
   "//": "this can't be an IP address",
 
   "homeassistant": {

--- a/html/panel.js
+++ b/html/panel.js
@@ -7,10 +7,21 @@ document.addEventListener('DOMContentLoaded', function () {
             '101 (Refrigerator)': null,
             '201 (Washer)': null,
             '202 (Dryer)': null,
+            '204 (Dishwasher)': null,
+            '301 (Gas Range)': null,
+            '302 (Microwave)': null,
             '401 (Air Conditioner)': null,
         },
     })
 })
+
+// Human-readable labels for model IDs
+const FRIENDLY_NAMES = {
+    WMVEL2137: 'Microwave / Hood',
+    WLDGL6924: 'Gas Range',
+    '2REF11EBIW__4': 'Refrigerator',
+    N15: 'Dishwasher',
+}
 
 let ws
 let reconnectTimer
@@ -57,9 +68,13 @@ class DeviceEntry {
         children.push(td)
 
         td = document.createElement('td')
-        let model = this.remoteState.model
+        let label = FRIENDLY_NAMES[this.remoteState.model] || this.remoteState.model
+        let model = label
         if (!this.remoteState.mapped) {
             model += ` <i class="material-icons tooltipped tiny" data-position="bottom" data-tooltip="This device is not supported by rethink. It will not be mapped to HomeAssistant">warning</i>`
+        }
+        if (this.remoteState.model !== label && !this.remoteState.mapped) {
+            model += ` <small class="grey-text">(${this.remoteState.model})</small>`
         }
         td.innerHTML = model
         children.push(td)
@@ -98,6 +113,7 @@ class DeviceEntry {
 
             try {
                 await fetchWrapper(`bridge/${this.id}/enable`, { deviceType }, { method: 'POST' })
+                this.remoteState.bridged = true
             } finally {
                 this.bridgeBusy = false
                 this.refreshUI()
@@ -110,6 +126,7 @@ class DeviceEntry {
 
             try {
                 await fetchWrapper(`bridge/${this.id}/disable`, {}, { method: 'POST' })
+                this.remoteState.bridged = false
             } finally {
                 this.bridgeBusy = false
                 this.refreshUI()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "rethink",
+  "name": "lg-thinq-rethink",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/rethink-cloud.ts
+++ b/rethink-cloud.ts
@@ -17,6 +17,7 @@ import { Config, CA } from './util/config'
 import * as Management from './management'
 
 import log, { setFilter as setLogFilter } from './util/logging'
+import { rawHttp } from './util/raw-logger'
 import { DeviceManager } from './cloud/devmgr'
 import { Bridge } from './bridge'
 import { JSONStorage } from './bridge/state'
@@ -77,8 +78,8 @@ const ca = loadOrCreateCert()
 function t1setup(manager: DeviceManager) {
     // Thinq1 HTTPS server
     const app = express()
-    app.use(function (req, res, next) {
-        log('HTTPS', req.hostname, req.url)
+    app.use((req, _res, next) => {
+        rawHttp('T1', req, Buffer.alloc(0))
         next()
     })
 
@@ -100,9 +101,12 @@ function t2setup(manager: DeviceManager) {
     // Thinq2 HTTPS server
     const app = express()
     app.use(express.json())
-
-    app.use(function (req, res, next) {
-        log('HTTPS', req.hostname, req.url)
+    app.use((req, _res, next) => {
+        const body =
+            req.body && Object.keys(req.body).length > 0
+                ? Buffer.from(JSON.stringify(req.body), 'utf-8')
+                : Buffer.alloc(0)
+        rawHttp('T2', req, body)
         next()
     })
 

--- a/rethink-setup.ts
+++ b/rethink-setup.ts
@@ -73,14 +73,14 @@ function thinq2Setup() {
     // own keypair. But we don't need to verify anything, so why bother. this makes
     // the setup process simpler.
     const publicKey = `-----BEGIN PUBLIC KEY-----
-	MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApYRAZXRWijMuWNr9LHOJ
-	fcPcZHDYcO3CwRF9olsPvtJpkrDXR7jEDA6qPHF1jvJ7ArxDLVj8rbkwXb3oXNmN
-	Sc+n0DPNDiRgghDaDyJpN0qfzmt06MKdihVScwghyYKWD+oA9d1+j3wy3W32he+X
-	7FnS+yUmmbQ8cT0PYS7p2E8YtbgHrH+SbUzHAgBbaS8E92l7f0qOpQFmYEyP/OX+
-	1n0dLdXXJ8kFxCLP2n8Wy6XXTutrT0YuZCxabPVYSKsjLh86MuHEM6V8BdBoZItW
-	qA1bDeDvjP7QC93lGxmwIYR0H8VVQq7gBZYWpPfsRSfwsE/PCMrF1WS4sPnSauaV
-	QwIDAQAB
-	-----END PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApYRAZXRWijMuWNr9LHOJ
+fcPcZHDYcO3CwRF9olsPvtJpkrDXR7jEDA6qPHF1jvJ7ArxDLVj8rbkwXb3oXNmN
+Sc+n0DPNDiRgghDaDyJpN0qfzmt06MKdihVScwghyYKWD+oA9d1+j3wy3W32he+X
+7FnS+yUmmbQ8cT0PYS7p2E8YtbgHrH+SbUzHAgBbaS8E92l7f0qOpQFmYEyP/OX+
+1n0dLdXXJ8kFxCLP2n8Wy6XXTutrT0YuZCxabPVYSKsjLh86MuHEM6V8BdBoZItW
+qA1bDeDvjP7QC93lGxmwIYR0H8VVQq7gBZYWpPfsRSfwsE/PCMrF1WS4sPnSauaV
+QwIDAQAB
+-----END PUBLIC KEY-----
 	`
     return new Promise<void>((resolve, reject) => {
         console.log(`Connecting to ${host}:5500`)

--- a/util/raw-logger.ts
+++ b/util/raw-logger.ts
@@ -1,0 +1,62 @@
+// Safe raw-data logger — try/catch wraps everything, never throws.
+// Logs to stdout (systemd journal). Raw body capture + headers, method, URL.
+
+function ts() {
+    return new Date().toISOString()
+}
+
+function hex(buf: Buffer, maxLen = 4096): string {
+    const b = buf.slice(0, maxLen)
+    const lines: string[] = []
+    for (let i = 0; i < b.length; i += 16) {
+        const chunk = b.slice(i, i + 16)
+        const h = Array.from(chunk)
+            .map((x) => x.toString(16).padStart(2, '0'))
+            .join(' ')
+        const a = Array.from(chunk)
+            .map((x) => (x >= 0x20 && x < 0x7f ? String.fromCharCode(x) : '.'))
+            .join('')
+        lines.push(`  ${i.toString(16).padStart(4, '0')}: ${h.padEnd(48, ' ')} ${a}`)
+    }
+    return lines.join('\n')
+}
+
+export function rawHttp(label: string, req: any, body: Buffer) {
+    try {
+        const hdr = { ...req.headers }
+        delete hdr.authorization // never log auth tokens
+        console.log(`\n${'='.repeat(80)}`)
+        console.log(ts(), 'RAW', label, req.method, (req.hostname || '') + req.url)
+        console.log('HEADERS:', JSON.stringify(hdr, null, 2))
+        if (body.length > 0) {
+            console.log(`BODY (${body.length} bytes):`)
+            console.log('  TEXT:', body.toString('utf-8').slice(0, 4000))
+            if (body.length <= 8192) console.log('HEX:\n' + hex(body))
+        }
+    } catch {
+        /* logging must never throw */
+    }
+}
+
+export function rawSocket(label: string, addr: string, data: Buffer) {
+    try {
+        console.log(`\n${'='.repeat(80)}`)
+        console.log(ts(), 'RAW', label, `from ${addr} (${data.length} bytes):`)
+        console.log('  TEXT:', data.toString('utf-8').slice(0, 2000))
+        if (data.length <= 4096) console.log('HEX:\n' + hex(data))
+    } catch {
+        /* logging must never throw */
+    }
+}
+
+export function rawSocketConnect(label: string, addr: string) {
+    try {
+        console.log(ts(), 'RAW', label, 'connect from', addr)
+    } catch {}
+}
+
+export function rawSocketClose(label: string, addr: string) {
+    try {
+        console.log(ts(), 'RAW', label, 'disconnect from', addr)
+    } catch {}
+}


### PR DESCRIPTION
## Summary

This PR builds on **#81** (by @aaronsb — publicKey whitespace fix + generic device fallback) and extends it with fixes and features discovered while provisioning 4 new LG appliances (microwave, gas range, fridge, dishwasher) fully locally.

All credit to @aaronsb for identifying the root causes and initial implementations. We've reimplemented their key fixes and added significant improvements on top.

---

## What's Included

### 1. PublicKey whitespace fix (reimplemented from #81)

The hardcoded setup `publicKey` has tab-indented base64 lines. RTL8720cm "CLIP" modules use a strict PEM parser — with tabs, `getDeviceInfo`'s RSA encrypt step fails silently (`encryptRes:ffff`) and the device loops on `/route` indefinitely. Stripping the tabs fixes it. Confirmed on WMVEL2137 (microwave), WLDGL6924 (gas range), 2REF11EBIW__4 (fridge), and N15 (dishwasher — Beken BK7234, which also needs clean PEM).

### 2. Generic device fallback (reimplemented from #81)

Unknown `modelId`s were previously dropped entirely — no enrollment, no HA mapping. A new `GenericDevice` class now catches any unknown ThinQ2 device, enrolls it, and publishes raw packet hex to a diagnostic HA sensor. This turns unsupported models from silent dead ends into observable data sources, and keeps the device online.

### 3. Local-only provisioning fix (novel)

After analyzing the bridge mode handshake between the device and LG's real cloud, we discovered the device needs **`provisioningType: "deploy"`** (not `"preDeploy"`) in the `completeProvisioning` response, plus a **`resp_timesync`** before `completeProvisioning_ack` — otherwise the chipset stays in setup mode and never exits to normal operation.

Three changes in `cloud/thinq2/provisioning.ts` and `device.ts`:
- `generateDeployResponse` always responds with `provisioningType: "deploy"`
- `req_timesync` handler now checks `client.deployMsg` (exists during provisioning) instead of `client.deviceObj` (only exists AFTER ack)
- `timeSyncRequest` publishes directly via the broker instead of via `deviceObj.send()` (deviceObj doesn't exist yet)

Result: factory reset → provision → device completes full handshake locally → chimes → exits setup. No bridge mode needed.

### 4. Auto-detect DeviceType for bridge mode

`DeviceType` (101, 204, 301, 302, etc.) is in the `preDeploy` payload but wasn't being stored in `Metadata`. Now populated during `completeProvisioning`, so the management UI auto-fills it when enabling bridge mode — no manual entry needed for any device.

### 5. UI improvements

- **Friendly device names**: Added a mapping from model IDs to human-readable labels (e.g. `WMVEL2137` → "Microwave / Hood", `N15` → "Dishwasher"). Unknown models fall back to raw ID.
- **Bridge button state fix**: Optimistic state update after bridge toggle success. Previously, the WebSocket update sometimes arrived after `refreshUI()`, causing the checkbox to revert to the wrong state — especially visible when adding a new device.
- Added device types 204, 301, 302 to the autocomplete picker.

### 6. Raw HTTP logging

Safe try/catch-wrapped request logging middleware for both ThinQ1 and ThinQ2 HTTPS servers. Logs headers, method, URL, and parsed body — never throws.

---

## Testing

Tested against 4 previously-unsupported LG appliances, all now fully provisioned and controllable locally:

| Appliance | Model ID | Type | Chipset | FW |
|-----------|----------|------|---------|-----|
| Microwave / Hood (MVEL2033F) | WMVEL2137 | 302 | RTL8720cm | CLIP v1.9.210 |
| Gas Range (LDGL6924S) | WLDGL6924 | 301 | RTL8720cm | CLIP v1.9.223 |
| Fridge (LRFLS3206S) | 2REF11EBIW__4 | 101 | RTL8720cm | CLIP v1.9.196 |
| Dishwasher (LDNPM545S) | N15 | 204 | Beken BK7234 | CLIP v1.9.226 |

**Local provisioning**: All 4 devices complete the full handshake locally (no cloud) — deploy → timesync → ack → normal mode.

**Bridge mode**: All 4 register with LG cloud successfully. DNS forwarder + `/etc/hosts` trick allows simultaneous local-only + bridge operation.

**Local control (fan/light)**: Fully reverse-engineered and working via direct MQTT publish — no app, no cloud.

**Raw packet capture**: All 4 streaming TLV hex to HA diagnostic sensors via the generic fallback.

---

## Additional Discoveries

**Bridge mode + DNS coexistence**: When using a DNS forwarder to redirect `common.lgthinq.com` → local server, bridge mode can't reach LG's real cloud. Fix: add the real CloudFront IP for `common.lgthinq.com` to `/etc/hosts` on the rethink host. The NUC resolves to the real LG cloud (for bridge mode API calls) while appliances still resolve to rethink (for local-only mode).

**LG registration conflict (error 9006)**: When a device was previously registered to the LG account, the `addDevice` call returns `resultCode: 9006` ("already registered"). Retrying after the `removeDevice` step succeeds resolves it.

**Beken BK7234 dishwasher**: Uses the same CLIP provisioning flow as RTL8720cm. Provisioned without changes. Uses JITP (`PERF_jitp` step) and a different package structure — bridge mode needs the LG app to finish/time out its registration attempt before taking over.
