### PR TITLE
Adding support for F_V7_Y___W.B_2QEUK/F4WV508S2E washing machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The following appliances are currently supported in rethink:
 - Washing Machines:
     - 🫤 (model name unknown) Washing Machine - preliminary support
     - 👍 F2J7HG1W, Washing Machine - mostly working,
+    - 🫤 F4WV508S2E, Front-Loading Washing Machine - preliminary support
     - 🫤 F4WV709P1E, Front-Loading Washing Machine - preliminary support
     - 🫤 TW4V9RW9W - preliminary support
     - 👍 F4X7511TWS (VCDWL2QEUK), Front-Load Washing Machine - mostly working

--- a/cloud/devices/F_V8_Y___W.B_2QEUK.ts
+++ b/cloud/devices/F_V8_Y___W.B_2QEUK.ts
@@ -112,6 +112,13 @@ export default class Device extends AABBDevice {
                         name: 'Door lock',
                         device_class: 'lock',
                     },
+                    child_lock: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-child_lock',
+                        state_topic: '$this/child_lock',
+                        name: 'Child lock',
+                        device_class: 'lock',
+                    },
                     energy: {
                         platform: 'sensor',
                         unique_id: '$deviceid-energy',
@@ -137,6 +144,15 @@ export default class Device extends AABBDevice {
                         device_class: 'duration',
                         unit_of_measurement: 'min',
                         name: 'Remaining time',
+                    },
+                    reserve_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-reserve_time',
+                        state_topic: '$this/reserve_time',
+                        device_class: 'duration',
+                        unit_of_measurement: 'h',
+                        name: 'Reserve time',
+                        icon: 'mdi:timer-sand',
                     },
                     extra_rinse: {
                         platform: 'binary_sensor',
@@ -193,6 +209,7 @@ export default class Device extends AABBDevice {
             const spin = buf[51]
             const temp = buf[52]
             const extra_rinse = buf[53]
+            const time_reserve_hour = buf[55]
             const options = buf[57]
             const lock_status = buf[58]
             const cycles = buf[64]
@@ -208,8 +225,10 @@ export default class Device extends AABBDevice {
             this.publishProperty('cycles', cycles)
             this.publishProperty('remote_start', lock_status & 2 ? 'ON' : 'OFF')
             this.publishProperty('door_lock', !(lock_status & 0x40) ? 'ON' : 'OFF') // inverted logic, off=locked
+            this.publishProperty('child_lock', !(lock_status & 0x80) ? 'ON' : 'OFF') // inverted logic, off=locked
             this.publishProperty('initial_time', time_initial)
             this.publishProperty('remaining_time', time_remain)
+            this.publishProperty('reserve_time', time_reserve_hour)
             this.publishProperty('energy', energy)
             this.publishProperty('extra_rinse', extra_rinse >= 2 ? 'ON' : 'OFF') // 0/1=off, 2+=one or more extra rinses (Rinse+)
             this.publishProperty('turbowash', options & 0x01 ? 'ON' : 'OFF')

--- a/cloud/devices/washer_common.ts
+++ b/cloud/devices/washer_common.ts
@@ -74,6 +74,7 @@ export const COURSES: Record<number, string> = {
     0x2d: 'Allergy Care',
     0x2c: 'Baby Steam Care',
     0x31: 'TurboWash 39',
+    0x32: 'TurboWash 59',
     0x33: 'Baby Clothes',
     0x34: 'Children Clothing',
     0x35: 'School Uniform',
@@ -105,7 +106,7 @@ export const TEMPERATURES = [
     undefined,
     10,
     20,
-    30, // assumed
+    30,
     40,
     50, // assumed
     60,

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -41,6 +41,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['2REB1GLVB1__2']: Dev_2REB1GLVB1__2,
     ['2RES1VE600FWC']: Dev_2RES1VE600FWC,
     ['Y_V8_Y___W.B32QEUK']: Y_V8_Y___W_B32QEUK,
+    ['F_V7_Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK, // NOTE: we reuse F_V8_Y___W_B_2QEUK as the models appear to be compatible
     ['F_V8_Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK,
     ['F_V__Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK, // NOTE: we reuse F_V8_Y___W_B_2QEUK as the models appear to be compatible
     ['VCDWL2QEUK']: VCDWL2QEUK, // LG F4X7511TWS front-load washer (matched on modelId VCDWL2QEUK)


### PR DESCRIPTION
Hello,
Thank you for your awesome work.

I've been tinkering with my LG F4WV508S2E washing machine. It looks like the F_V8_Y___W_B_2QEUK handler is also compatible with mine F_V7_Y___W.B_2QEUK.

Also I've done some packet analysis from my machine, and I find some additional sensors that can be added. 
I've added status of reserve/delay time and status of child lock.
I've also added missing course 0x32 TurboWash 59, which my machine features.

New sensors in home assistant correctly shows values from my washing machine.
Unit tests are passing after my changes. 

Best regards,
Paweł