### PR TITLE
Add ThinQ2 device handler for Y_V8_F___W.B_2QEUK (LG W4WR70E61 washer/dryer combo)

### DIFF
--- a/cloud/devices/Y_V8_F___W.B_2QEUK.ts
+++ b/cloud/devices/Y_V8_F___W.B_2QEUK.ts
@@ -1,0 +1,209 @@
+import HADevice from './base'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import AABBDevice from './aabb_device'
+import { ERRORS, STATES, COURSES, TEMPERATURES, SPINS, DRYING_MODES } from './washer_common'
+
+// LG W4WR70E61 washer/dryer combo (article F4Y7ERP1W.ABWQPDG).
+// Control commands are identical to F_V8_Y___W.B_2QEUK / Y_V8_Y___W.B32QEUK, but the status
+// frame layout differs: status frames come as a 53-byte single block (status block at offset
+// 15) or a 92-byte double block (previous + current state, current block at offset 54).
+// Field offsets are documented on the wiki page Appliance:Y_V8_F___W.B_2QEUK.
+export default class Device extends AABBDevice {
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: 'LG Washer' }),
+                components: {
+                    power: {
+                        platform: 'switch',
+                        unique_id: '$deviceid-power',
+                        state_topic: '$this/power',
+                        command_topic: '$this/power/set',
+                        name: '',
+                        icon: 'mdi:washing-machine',
+                    },
+                    start: {
+                        platform: 'button',
+                        unique_id: '$deviceid-start',
+                        command_topic: '$this/start/set',
+                        payload_press: '',
+                        name: 'Start',
+                        icon: 'mdi:play-circle-outline',
+                    },
+                    pause: {
+                        platform: 'button',
+                        unique_id: '$deviceid-pause',
+                        command_topic: '$this/pause/set',
+                        payload_press: '',
+                        name: 'Pause',
+                        icon: 'mdi:pause-circle-outline',
+                    },
+                    status: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-status',
+                        state_topic: '$this/status',
+                        name: 'Status',
+                        icon: 'mdi:state-machine',
+                        device_class: 'enum',
+                        options: STATES.filter((a) => a !== undefined),
+                    },
+                    error: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-error',
+                        state_topic: '$this/error',
+                        name: 'Error',
+                        icon: 'mdi:check-circle',
+                        device_class: 'problem',
+                        entity_category: 'diagnostic',
+                    },
+                    error_message: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-error-message',
+                        state_topic: '$this/error_message',
+                        name: 'Error message',
+                        icon: 'mdi:alert-circle-outline',
+                        device_class: 'enum',
+                        entity_category: 'diagnostic',
+                        options: ERRORS.filter((a) => a !== undefined),
+                    },
+                    course: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-course',
+                        state_topic: '$this/course',
+                        name: 'Course',
+                        icon: 'mdi:pin-outline',
+                    },
+                    temp: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-temp',
+                        state_topic: '$this/temp',
+                        name: 'Temperature',
+                        device_class: 'temperature',
+                        unit_of_measurement: '°C',
+                        suggested_display_precision: 0,
+                        value_template: "{{ value if value | is_number else 'None' }}",
+                    },
+                    spin: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-spin',
+                        state_topic: '$this/spin',
+                        name: 'Spin',
+                        icon: 'mdi:autorenew',
+                        unit_of_measurement: 'RPM',
+                        value_template: "{{ value if value | is_number else 'None' }}",
+                    },
+                    drying_mode: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-drying-mode',
+                        state_topic: '$this/drying_mode',
+                        name: 'Drying mode',
+                        icon: 'mdi:tumble-dryer',
+                    },
+                    cycles: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-cycles',
+                        state_topic: '$this/cycles',
+                        name: 'Cycle count',
+                        icon: 'mdi:counter',
+                    },
+                    remote_start: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-remote_start',
+                        state_topic: '$this/remote_start',
+                        name: 'Remote start',
+                        icon: 'mdi:play-circle-outline',
+                    },
+                    door_lock: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-door_lock',
+                        state_topic: '$this/door_lock',
+                        name: 'Door lock',
+                        device_class: 'lock',
+                    },
+                    energy: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-energy',
+                        state_topic: '$this/energy',
+                        name: 'Energy',
+                        icon: 'mdi:lightning-bolt',
+                        device_class: 'energy',
+                        state_class: 'total_increasing',
+                        unit_of_measurement: 'Wh',
+                    },
+                    initial_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-initial_time',
+                        state_topic: '$this/initial_time',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        name: 'Initial time',
+                    },
+                    remaining_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-remaining_time',
+                        state_topic: '$this/remaining_time',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        name: 'Remaining time',
+                    },
+                },
+            }),
+        )
+    }
+
+    processAABB(buf: Buffer) {
+        if (buf[0] !== 0x20) return
+
+        // 79-byte configuration frame (buf[8] == 0x02) carries the wash cycle counter
+        if (buf[8] === 0x02 && buf.length === 79) {
+            this.publishProperty('cycles', buf[19])
+            return
+        }
+        if (buf[8] !== 0x01) return
+
+        const S = buf.length > 73 ? 54 : 15
+        if (buf.length <= S + 19) return
+
+        const status = buf[S]
+        const remaining = buf[S + 1] * 60 + buf[S + 2]
+        const initial = buf[S + 3] * 60 + buf[S + 4]
+        const course = buf[S + 5]
+        const error = buf[S + 6]
+        const spin = buf[S + 8]
+        const temp = buf[S + 9]
+        const drying = buf[S + 11]
+
+        this.publishProperty('power', status > 0 ? 'ON' : 'OFF')
+        this.publishProperty('error_message', ERRORS[error] ?? 'unknown') // publish message before set error state
+        this.publishProperty('error', error ? 'ON' : 'OFF')
+        this.publishProperty('status', STATES[status] ?? 'unknown')
+        this.publishProperty('course', COURSES[course] ?? 'unknown')
+        this.publishProperty('spin', SPINS[spin] ?? 'unknown')
+        this.publishProperty('temp', TEMPERATURES[temp] ?? 'unknown')
+        this.publishProperty('drying_mode', DRYING_MODES[drying] ?? 'unknown')
+        // NB: on this variant remote-start is bit 0x40 of S+15 (V8_Y carries it in bit 0x02 of the lock byte)
+        this.publishProperty('remote_start', buf[S + 15] & 0x40 ? 'ON' : 'OFF')
+        this.publishProperty('door_lock', !(buf[S + 19] & 0x40) ? 'ON' : 'OFF') // inverted logic, off=locked
+        this.publishProperty('initial_time', initial)
+        this.publishProperty('remaining_time', remaining)
+        // per-cycle energy counter (Wh); not present in the shorter frame variants
+        if (buf.length > S + 29) this.publishProperty('energy', buf[S + 28] * 256 + buf[S + 29])
+    }
+
+    setProperty(prop: string, mqttValue: string) {
+        if (prop === 'power') {
+            if (mqttValue === 'ON') {
+                this.send(Buffer.from('F02A0100', 'hex'))
+            } else if (mqttValue === 'OFF') {
+                this.send(Buffer.from('F024010100', 'hex'))
+            }
+        }
+
+        if (prop === 'pause') this.send(Buffer.from('F024040100', 'hex'))
+        if (prop === 'start') this.send(Buffer.from(mqttValue || 'F024050100', 'hex'))
+    }
+}

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -9,6 +9,7 @@ import Dev_2REB1GLVB1__2 from './devices/2REB1GLVB1__2'
 import Dev_2RES1VE600FWC from './devices/2RES1VE600FWC'
 import Y_V8_Y___W_B32QEUK from './devices/Y_V8_Y___W.B32QEUK'
 import F_V8_Y___W_B_2QEUK from './devices/F_V8_Y___W.B_2QEUK'
+import Y_V8_F___W_B_2QEUK from './devices/Y_V8_F___W.B_2QEUK'
 import F_V__F___W_B_1QEUK from './devices/F_V__F___W.B_1QEUK'
 import F_VB_F___W_B_2QEUK from './devices/F_VB_F___W.B_2QEUK'
 import VCDWL2QEUK from './devices/VCDWL2QEUK'
@@ -42,6 +43,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['2RES1VE600FWC']: Dev_2RES1VE600FWC,
     ['Y_V8_Y___W.B32QEUK']: Y_V8_Y___W_B32QEUK,
     ['F_V8_Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK,
+    ['Y_V8_F___W.B_2QEUK']: Y_V8_F___W_B_2QEUK,
     ['F_V__Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK, // NOTE: we reuse F_V8_Y___W_B_2QEUK as the models appear to be compatible
     ['VCDWL2QEUK']: VCDWL2QEUK, // LG F4X7511TWS front-load washer (matched on modelId VCDWL2QEUK)
     ['F_V__F___W.B_1QEUK']: F_V__F___W_B_1QEUK,

--- a/tests/cloud/devices/Y_V8_F___W.B_2QEUK.test.ts
+++ b/tests/cloud/devices/Y_V8_F___W.B_2QEUK.test.ts
@@ -1,0 +1,111 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/Y_V8_F___W.B_2QEUK'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'Y_V8_F___W.B_2QEUK'
+const META: Metadata = { modelId: MODEL_ID, modelName: 'Y_V8_F___W.B_2QEUK', swVersion: '0.0.0' }
+
+// All hex dumps below are telegrams captured from an LG W4WR70E61 washer/dryer combo
+// (firmware clip_hna 2.11.207) across full wash+dry cycles, see issue #98.
+// Status frames are 92-byte double blocks (previous + current state, current block at 54).
+
+// Wash+Dry, 30°C, 1400 RPM, auto drying, armed for remote start, ready to run (250 min).
+const SAMPLE_ARMED_READY = buf(
+    'aaff200a0060007f7f000100ec004e000001040a040a1300030a03010200000042000004000010000000000400000000000000000000000001040a040a1300030a0301020000004200000400001000000000040000000000000000c0007a96bb',
+)
+
+// Same cycle running, rinse phase, 159 min remaining, energy counter at 152 Wh.
+const SAMPLE_RINSING = buf(
+    'aaff200a006000823e000100ec004e000006022803131300030a03010200000042200001040010000000000400009800000000000000000007022703131300030a000102000000420000010600100000000004000098000000000000001066bb',
+)
+
+// Drying phase of the same cycle, 89 min remaining, energy counter at 1001 Wh.
+const SAMPLE_DRYING = buf(
+    'aaff200a0060008a6a000100ec004e000009011d031d130000000000020000004200000104001000000000040003e800000000000000000009011d031d130000000000020000004200000104001000000000040003e9000000000000005a45bb',
+)
+
+// Machine turned off after the finished cycle, total energy 2162 Wh.
+const SAMPLE_OFF = buf(
+    'aaff200a0060009437000100ec004e00000b0000031d13000000000002000000400000020a00100000000004000872000000000000000000000000031d13000000000000000000400000040b00100000000004000872000000000000008feabb',
+)
+
+// 79-byte configuration frame (byte 8 = 0x02) carrying the wash cycle counter at byte 19.
+const SAMPLE_CONFIG = buf(
+    'aaff200a005300c807000201030018120a0102120134000807001d00000000000000000000000001050025595f56385f465f5f5f572e425f325145554b00000102d51ced6f0104000000000000000000b596bb',
+)
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('config exposes the drying mode and energy sensors', () => {
+        const { ha } = makeDevice()
+        const cfg = ha.devices[DEVICE_ID].config
+        assert.ok(cfg, 'config published')
+        const components = cfg!.components as Record<string, Record<string, unknown>>
+        assert.equal(components.drying_mode.platform, 'sensor')
+        assert.equal(components.energy.platform, 'sensor')
+        assert.equal(components.cycles.platform, 'sensor')
+    })
+
+    test('armed ready state decodes course, spin, temp, drying mode and remote start', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_ARMED_READY)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.power, 'ON')
+        assert.equal(props.status, 'Ready')
+        assert.equal(props.course, 'Wash + Dry')
+        assert.equal(props.spin, 1400)
+        assert.equal(props.temp, 30)
+        assert.equal(props.drying_mode, 'Auto')
+        assert.equal(props.remote_start, 'ON')
+        assert.equal(props.door_lock, 'ON')
+        assert.equal(props.initial_time, 250)
+        assert.equal(props.remaining_time, 250)
+        assert.equal(props.energy, 0)
+    })
+
+    test('rinse phase decodes remaining time and the running energy counter', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_RINSING)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.status, 'Rinsing')
+        assert.equal(props.course, 'Wash + Dry')
+        assert.equal(props.remaining_time, 159)
+        assert.equal(props.initial_time, 199)
+        assert.equal(props.energy, 152)
+    })
+
+    test('drying phase decodes status=Drying with the energy counter advancing', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_DRYING)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.status, 'Drying')
+        assert.equal(props.drying_mode, 'Auto')
+        assert.equal(props.remaining_time, 89)
+        assert.equal(props.energy, 1001)
+    })
+
+    test('powered-off frame decodes power=OFF and the final cycle energy', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_OFF)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.power, 'OFF')
+        assert.equal(props.status, 'Off')
+        assert.equal(props.energy, 2162)
+    })
+
+    test('configuration frame decodes the wash cycle counter', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_CONFIG)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.cycles, 52)
+    })
+})


### PR DESCRIPTION
Adds a ThinQ2 device handler for the **LG W4WR70E61 washer/dryer combo** (article F4Y7ERP1W.ABWQPDG), ThinQ model ID `Y_V8_F___W.B_2QEUK`. Closes #98.

The control commands are identical to `F_V8_Y___W.B_2QEUK`, but the status frame layout differs (53-byte single block with the status block at offset 15, or a 92-byte double block with the current state at offset 54), so none of the existing classes decode it.

**Decoded:**
- state, remaining/initial time, course, error, spin, temperature
- drying mode (`DRYING_MODES`, offset S+11) — this is a washer/dryer combo
- remote-start flag (bit 0x40 of S+15) and door lock (S+19; the bit positions differ from `Y_V8_Y___W.B32QEUK`)
- per-cycle energy counter in Wh (uint16 at S+28/S+29; the sibling models' offset `buf[71]*256+buf[72]` does not apply to this variant)
- wash cycle counter from the 79-byte configuration frame (byte 8 = 0x02, counter at byte 19)

**Tests:** telegrams captured from a real unit (firmware `clip_hna 2.11.207`) across full wash+dry cycles — armed/ready, rinse phase, drying phase, powered-off (final energy 2162 Wh) and a configuration frame. `npm test` passes (296/296), prettier clean.

Verified on a single unit running against rethink-cloud for several weeks. A wiki page draft documenting the full frame layout and the WMDownload/WMStart body (including the drying-stage and delayed-start bytes) is ready as well — the wiki is collaborator-restricted, so I can post it in #98 or push it if access is enabled.