### PR TITLE
Add ThinQ2 device handler for CST_570004_WW (LG ceiling-cassette AC)

### DIFF
--- a/cloud/devices/CST_570004_WW.ts
+++ b/cloud/devices/CST_570004_WW.ts
@@ -126,9 +126,13 @@ export default class Device extends RAC {
                     this.setProperty('climate-power', 'OFF')
                     return null
                 }
+                // Selecting a mode from HA must also turn the unit on: setting the mode alone is
+                // ignored while powered off (verified on hardware — the app turns on by sending
+                // 0x1f7=1 together with the mode). Force power on and attach it to the write.
+                this.raw_clip_state[0x1f7] = 1
                 return modeW[val]
             },
-            write_attach: [0x1fa, 0x1fe],
+            write_attach: [0x1f7, 0x1fa, 0x1fe],
         })
 
         // Swing: CST exposes plain on/off vertical and horizontal swing on 0x205 / 0x206.

--- a/cloud/devices/CST_570004_WW.ts
+++ b/cloud/devices/CST_570004_WW.ts
@@ -1,0 +1,379 @@
+import RAC from './RAC_056905_WW'
+import { type DeviceDiscovery } from '../homeassistant'
+import { allowExtendedType } from '@/util/casting'
+
+// LG ceiling-cassette IDU, ThinQ model CST_570004_WW, deviceType 401 (RTK_RTL8720cm),
+// typically installed as several IDUs on one multi-split ODU.
+//
+// The control/telemetry protocol is the same DualCool AC TLV scheme as RAC_056905_WW
+// (standard tags 0x1f7 power, 0x1f9 mode, 0x1fa fan, 0x1fd current temp, 0x1fe target
+// temp, 0x2b3 instantaneous power, ...), so we reuse the RAC handler and only patch the
+// CST-specific differences:
+//
+// 1. Wire header: CST emits its async/query TLV frames with UART header byte6 = 0xa7
+//    instead of 0x87. The base tlv_device framing check only accepts 0x87, so processData
+//    normalizes 0xa7 -> 0x87 before delegating. (POT_056905_WW has the same quirk.)
+//
+// 2. Feature gating: RAC gates air-clean/energy-saving/auto-dry on the capability bitmap
+//    tag 0x2cc, and the filter sensors on 0x2f1. CST never sends 0x2cc (though it does
+//    report the value tags 0x20d/0x20e) and reports 0x2f1&1 (="no filter") even though its
+//    filter priv-command returns real data. This handler synthesizes the missing 0x2cc bits
+//    from the present value tags and always probes for the filter.
+//
+// 3. Extra sensors CST exposes but RAC has no field for / gates out:
+//    - Humidity: tag 0x336, raw/10 = %RH.
+//    - Power: RAC only creates the Power (W) sensor when tag 0x2b3 is non-zero at config
+//      time. On a multi-split the IDU is often idle at init, so this handler always creates
+//      it. setConfig injects both into the finished config.
+export default class Device extends RAC {
+    processData(buf: Buffer) {
+        if (buf[6] === 0xa7) {
+            const b = Buffer.from(buf)
+            b[6] = 0x87
+            super.processData(b)
+            return
+        }
+        super.processData(buf)
+    }
+
+    // The tags driving CST's capability differences arrive only in the caps reply, which a
+    // caps retry can re-deliver. Each override is therefore applied at the exact point RAC reads
+    // the tag, so a duplicate caps reply cannot undo it:
+    //   - filter (RAC reads 0x2f1 in valuesReceived): CST always has a filter, so probe
+    //     unconditionally rather than gating on 0x2f1;
+    //   - jet / positional swing / energy-save (RAC reads 0x2cd/0x2cc in initMakeSetConfig):
+    //     rewrite those tags in an initMakeSetConfig override, right before super reads them.
+
+    valuesReceived() {
+        if (this.initialValuesReceived) return
+        this.initialValuesReceived = true
+        // ask the modem to report all TLV changes (empty blacklist) — same as RAC
+        this.thinq.send('setMaskingInfo', 0, { blacklist_tlv: '1200' })
+        this.tlvBlacklistDisableTimer = setTimeout(() => {
+            this.tlvBlacklistDisableTimer = undefined
+            this.initProbeForFilter()
+        }, 500)
+    }
+
+    initMakeSetConfig() {
+        // RAC reads the feature bitmap from 0x2cc. CST omits 0x2cc but reports the same bitmap
+        // under 0x2cb (adjacent tag; low bits match RAC's 0x2cc layout — bit0 air-purify,
+        // bit1 energy-save, bit2 auto-dry). Map 0x2cb into 0x2cc so RAC reads the real caps,
+        // masking bit2: CST exposes auto-dry as a duration select (0x20e), added in setConfig,
+        // not RAC's binary sensor.
+        if (this.raw_clip_state[0x2cc] == null && this.raw_clip_state[0x2cb] != null) {
+            this.raw_clip_state[0x2cc] = this.raw_clip_state[0x2cb] & ~0x4
+        }
+        // Suppress jet and RAC's positional swing. CST's 0x2cd is not RAC's jet/swing bitmap
+        // (its value has many unrelated bits set), and the unit has no jet and no heat hardware,
+        // so clear the bits RAC reads as jet-cool/heat (1|2) and swing-V/H (4|8). Swing comes
+        // from the on/off value tags 0x205/0x206 instead, wired up in setConfig.
+        this.raw_clip_state[0x2cd] &= ~(1 | 2 | 4 | 8)
+        super.initMakeSetConfig()
+    }
+
+    setConfig(config: DeviceDiscovery) {
+        // Render Energy saving as a plain toggle. RAC marks it optimistic, which makes HA show
+        // it as two assumed-state buttons instead of a switch. Drop optimistic; RAC's read/write
+        // logic and its power/mode hooks are left untouched.
+        if (config.components['energysave']) {
+            delete (config.components['energysave'] as { optimistic?: boolean }).optimistic
+        }
+
+        // Fan speed: CST uses a different 0x1fa scale than RAC's DualCool wall units:
+        //   1=very low, 2=low, 4=medium, 6=high, 7=power, 8=auto
+        // Re-register the field and replace the advertised fan_modes list with the app's 6 options.
+        const fanR: Record<number, string> = { 1: 'very low', 2: 'low', 4: 'medium', 6: 'high', 7: 'power', 8: 'auto' }
+        const fanW: Record<string, number> = { 'very low': 1, low: 2, medium: 4, high: 6, power: 7, auto: 8 }
+        ;(config.components['climate'] as { fan_modes?: string[] }).fan_modes = [
+            'auto',
+            'very low',
+            'low',
+            'medium',
+            'high',
+            'power',
+        ]
+        this.addField(config, {
+            id: 0x1fa,
+            name: 'fan_mode',
+            comp: 'climate',
+            read_xform: (raw) => fanR[raw],
+            write_xform: (val) => fanW[val],
+            write_attach: [0x1f9, 0x1fe],
+        })
+
+        // HVAC mode: CST's 0x1f9 wire values differ from RAC's. CST advertises modes {0,1,2,3}
+        // in caps 0x2c1 and reports 0x1f9=3 live for auto, whereas RAC uses auto=6 (and 4=heat).
+        // So on CST: cool=0, dry=1, fan_only=2, auto=3 (no heat). RAC's table reads wire 3 as
+        // undefined and writes auto as the unsupported wire 6, so re-register the field with
+        // CST's table. Mode-change hooks and power-off handling are kept identical to RAC.
+        const modeR: (string | undefined)[] = ['cool', 'dry', 'fan_only', 'auto']
+        const modeW: Record<string, number> = { cool: 0, dry: 1, fan_only: 2, auto: 3 }
+        this.addField(config, {
+            id: 0x1f9,
+            name: 'mode',
+            comp: 'climate',
+            read_xform: (raw) => (this.getPowerTLV() === 0 ? 'off' : modeR[raw]),
+            read_callback: (val) => {
+                if (typeof val !== 'string') return true
+                if (this.modePrev !== val) for (const hook of this.modeChangeHooks) hook()
+                this.modePrev = val
+                return true
+            },
+            write_xform: (val) => {
+                if (val === 'off') {
+                    this.setProperty('climate-power', 'OFF')
+                    return null
+                }
+                return modeW[val]
+            },
+            write_attach: [0x1fa, 0x1fe],
+        })
+
+        // Swing: CST exposes plain on/off vertical and horizontal swing on 0x205 / 0x206.
+        // RAC's positional 0x321/0x322 swing is suppressed in initMakeSetConfig, so wire these
+        // up as the climate swing attributes.
+        const climate = config.components['climate'] as {
+            modes?: string[]
+            swing_modes?: string[]
+            swing_horizontal_modes?: string[]
+            min_temp?: number
+            max_temp?: number
+        }
+        // Temperature range from caps. RAC hardcodes 18–30 °C with a TODO to read tags
+        // 0x2e1–0x2ec; CST advertises the cooling range in 0x2e1 (min) / 0x2e2 (max), raw/2 = °C
+        // (32/60 -> 16/30), so read it instead of inheriting RAC's hardcoded minimum.
+        if (this.raw_clip_state[0x2e1] != null) climate.min_temp = this.raw_clip_state[0x2e1] / 2
+        if (this.raw_clip_state[0x2e2] != null) climate.max_temp = this.raw_clip_state[0x2e2] / 2
+        // CST is cooling-only (no heat hardware) — restrict the HVAC mode list so HA doesn't
+        // offer 'heat'. Supported per the official app: cool / dry / fan_only / auto (+ off).
+        climate.modes = ['off', 'cool', 'dry', 'fan_only', 'auto']
+        climate.swing_modes = ['on', 'off']
+        this.addField(config, {
+            id: 0x205,
+            name: 'swing_mode',
+            comp: 'climate',
+            read_xform: (raw) => (raw ? 'on' : 'off'),
+            write_xform: (val) => (val === 'on' ? 1 : 0),
+        })
+        climate.swing_horizontal_modes = ['on', 'off']
+        this.addField(config, {
+            id: 0x206,
+            name: 'swing_horizontal_mode',
+            comp: 'climate',
+            read_xform: (raw) => (raw ? 'on' : 'off'),
+            write_xform: (val) => (val === 'on' ? 1 : 0),
+        })
+
+        // Auto-dry duration setting (0x20e): writable select (255 = smart).
+        this.addValueSelect(config, 'autodry_setting', 0x20e, 'Auto dry', 'mdi:hair-dryer', [
+            ['off', 0],
+            ['10 min', 1],
+            ['30 min', 2],
+            ['60 min', 3],
+            ['smart', 255],
+        ])
+
+        // Auto-dry remaining (0x225): minutes left in the auto-dry cycle (0 when not drying).
+        // Independent of the 0x20e setting — 0x225 only changes while drying runs.
+        if (this.raw_clip_state[0x225] != null && !config.components['autodryremain']) {
+            config.components['autodryremain'] = allowExtendedType({
+                platform: 'sensor',
+                unique_id: '$deviceid-autodryremain',
+                name: 'Auto dry remaining',
+                icon: 'mdi:hair-dryer-outline',
+                device_class: 'duration',
+                unit_of_measurement: 'min',
+                suggested_display_precision: 0,
+                entity_category: 'diagnostic',
+            })
+            this.addField(config, { id: 0x225, name: '', comp: 'autodryremain', writable: false })
+        }
+
+        // Display brightness (0x21f, RAC's "display light"): raw 100/150/200.
+        this.addValueSelect(config, 'display', 0x21f, 'Display', 'mdi:brightness-6', [
+            ['off', 100],
+            ['50%', 150],
+            ['100%', 200],
+        ])
+
+        // Wind mode (comfort airflow): five mutually-exclusive one-hot flags —
+        // 0x3d6=manner, 0x3d7=long power, 0x291=study, 0x290=auto temp, all-0=off.
+        // Expose as a single select. Only effective in cool mode. Reads derive the mode from
+        // whichever flag is set (via a read hook on each); the write is handled in setProperty.
+        if (this.raw_clip_state[0x3d6] != null && !config.components['wind_mode']) {
+            config.components['wind_mode'] = allowExtendedType({
+                platform: 'select',
+                unique_id: '$deviceid-wind_mode',
+                name: 'Wind mode',
+                icon: 'mdi:weather-windy',
+                entity_category: 'config',
+                options: ['off', 'manner', 'long power', 'study', 'auto temp'],
+                state_topic: '$this/wind_mode',
+                command_topic: '$this/wind_mode/set',
+            })
+            for (const id of Device.WIND_FLAGS) {
+                this.addField(
+                    config,
+                    {
+                        id,
+                        name: `flag_${id.toString(16)}`,
+                        comp: 'wind_mode',
+                        readable: false,
+                        writable: false,
+                        read_callback: () => {
+                            this.HA.publishProperty(this.id, 'wind_mode', this.windModeFromState())
+                            return false
+                        },
+                    },
+                    false,
+                )
+            }
+        }
+
+        // Comfort energy saving (0x23f): on/off switch (only effective in cool mode). Distinct
+        // from plain energy saving (0x20d, exposed by RAC as "energysave").
+        if (this.raw_clip_state[0x23f] != null && !config.components['comfort_saving']) {
+            config.components['comfort_saving'] = allowExtendedType({
+                platform: 'switch',
+                unique_id: '$deviceid-comfort_saving',
+                name: 'Comfort energy saving',
+                icon: 'mdi:leaf',
+                entity_category: 'config',
+            })
+            this.addField(config, {
+                id: 0x23f,
+                name: '',
+                comp: 'comfort_saving',
+                read_xform: (raw) => (raw ? 'ON' : 'OFF'),
+                write_xform: (val) => (val === 'ON' ? 1 : 0),
+            })
+        }
+
+        // Humidity (0x336, raw/10 = %RH) — CST reports it but RAC has no field for it.
+        if (this.raw_clip_state[0x336] != null && !config.components['humidity']) {
+            config.components['humidity'] = allowExtendedType({
+                platform: 'sensor',
+                unique_id: '$deviceid-humidity',
+                name: 'Humidity',
+                device_class: 'humidity',
+                unit_of_measurement: '%',
+                state_class: 'measurement',
+                suggested_display_precision: 0,
+            })
+            this.addField(config, {
+                id: 0x336,
+                name: '',
+                comp: 'humidity',
+                writable: false,
+                read_xform: (raw) => Math.round(raw / 10),
+            })
+        }
+
+        // Power (W) — RAC only adds this when 0x2b3 is non-zero at config time; always
+        // expose it on CST (multi-split IDUs are usually idle when the handler initializes).
+        if (!config.components['energy_current']) {
+            config.components['energy_current'] = allowExtendedType({
+                platform: 'sensor',
+                unique_id: '$deviceid-energy_current',
+                name: 'Power',
+                device_class: 'power',
+                unit_of_measurement: 'W',
+                state_class: 'measurement',
+                suggested_display_precision: 0,
+            })
+            // Report 0x2b3 as-is (watts). CST's 0x2b3 is already a clean value (0 when off), so
+            // RAC's max(5, raw-60) bias/floor is not applied. It tracks the IDU's compressor
+            // share and excludes the indoor fan's own draw, so fan-only reads ~0.
+            this.addField(config, {
+                id: 0x2b3,
+                name: '',
+                comp: 'energy_current',
+                writable: false,
+            })
+        }
+
+        super.setConfig(config)
+    }
+
+    // Register a writable HA select whose options map one-to-one to wire values. The
+    // [label, wire] list is the single source of truth — the option list and both the read and
+    // write transforms are derived from it, so they can't drift out of sync.
+    addValueSelect(
+        config: DeviceDiscovery,
+        comp: string,
+        id: number,
+        name: string,
+        icon: string,
+        levels: ReadonlyArray<readonly [string, number]>,
+    ) {
+        if (this.raw_clip_state[id] == null || config.components[comp]) return
+        const toLabel = new Map(levels.map(([label, raw]) => [raw, label]))
+        const toRaw = new Map(levels.map(([label, raw]) => [label, raw]))
+        config.components[comp] = allowExtendedType({
+            platform: 'select',
+            unique_id: `$deviceid-${comp}`,
+            name,
+            icon,
+            entity_category: 'config',
+            options: levels.map(([label]) => label),
+        })
+        this.addField(config, {
+            id,
+            name: '',
+            comp,
+            read_xform: (raw) => toLabel.get(raw),
+            write_xform: (val) => toRaw.get(val),
+        })
+    }
+
+    // Wind-mode one-hot flags: 0x290 auto temp, 0x291 study, 0x3d5 release, 0x3d6 manner,
+    // 0x3d7 long power. Exactly one is 1 at a time; "off" is all flags 0.
+    static readonly WIND_FLAGS = [0x290, 0x291, 0x3d5, 0x3d6, 0x3d7]
+    static readonly WIND_TO_FLAG: Record<string, number | undefined> = {
+        manner: 0x3d6,
+        'long power': 0x3d7,
+        study: 0x291,
+        'auto temp': 0x290,
+        off: undefined,
+    }
+
+    windModeFromState(): string {
+        if (this.raw_clip_state[0x3d6]) return 'manner'
+        if (this.raw_clip_state[0x3d7]) return 'long power'
+        if (this.raw_clip_state[0x291]) return 'study'
+        if (this.raw_clip_state[0x290]) return 'auto temp'
+        return 'off'
+    }
+
+    // RAC probes for the filter once and, if no reply comes within 5 s, builds the config
+    // without filter entities. On a multi-split the probe can race with the caps/values/masking
+    // traffic, so retry it a few times before falling back. A reply clears
+    // filterInitialQueryTimeout (in RAC.processFilterData), stopping the retries and proceeding
+    // to config.
+    filterProbeAttempts = 0
+    initProbeForFilter() {
+        this.filterProbeAttempts++
+        this.sendFilterQuery()
+        this.filterInitialQueryTimeout = setTimeout(() => {
+            this.filterInitialQueryTimeout = undefined
+            if (this.filterProbeAttempts < 5) {
+                this.initProbeForFilter()
+            } else {
+                this.initMakeSetConfig()
+            }
+        }, 4 * 1000)
+    }
+
+    setProperty(prop: string, mqttValue: string) {
+        if (prop === 'wind_mode') {
+            const on = Device.WIND_TO_FLAG[mqttValue]
+            // select one flag exclusively: chosen=1, everything else (incl. 0x3d5 release)=0
+            const tlv = Device.WIND_FLAGS.map((id) => ({ t: id, v: id === on ? 1 : 0 }))
+            for (const { t, v } of tlv) this.raw_clip_state[t] = v
+            this.send([1, 1, 2, 1, 1], tlv)
+            return
+        }
+        super.setProperty(prop, mqttValue)
+    }
+}

--- a/cloud/devices/CST_570004_WW.ts
+++ b/cloud/devices/CST_570004_WW.ts
@@ -15,12 +15,15 @@ import { allowExtendedType } from '@/util/casting'
 //    normalizes 0xa7 -> 0x87 before delegating. (POT_056905_WW has the same quirk.)
 //
 // 2. Feature gating: RAC gates air-clean/energy-saving/auto-dry on the capability bitmap
-//    tag 0x2cc, and the filter sensors on 0x2f1. CST never sends 0x2cc (though it does
-//    report the value tags 0x20d/0x20e) and reports 0x2f1&1 (="no filter") even though its
-//    filter priv-command returns real data. This handler synthesizes the missing 0x2cc bits
-//    from the present value tags and always probes for the filter.
+//    tag 0x2cc. CST omits 0x2cc but reports the same bitmap under the adjacent tag 0x2cb,
+//    which initMakeSetConfig maps back into 0x2cc so RAC reads the real capability bits.
 //
-// 3. Extra sensors CST exposes but RAC has no field for / gates out:
+// 3. Filter: RAC reads filter usage from a basic-filter priv-command (0x02/0x02). On CST that
+//    command returns an unpopulated counter (used=0, life=720) that does not match the app, so
+//    it is not used — valuesReceived skips the probe. The real filter usage is in value tags:
+//    0x356 = rated life (2400 h), 0x355 = remaining hours; setConfig derives the entities.
+//
+// 4. Extra sensors CST exposes but RAC has no field for / gates out:
 //    - Humidity: tag 0x336, raw/10 = %RH.
 //    - Power: RAC only creates the Power (W) sensor when tag 0x2b3 is non-zero at config
 //      time. On a multi-split the IDU is often idle at init, so this handler always creates
@@ -36,14 +39,12 @@ export default class Device extends RAC {
         super.processData(buf)
     }
 
-    // The tags driving CST's capability differences arrive only in the caps reply, which a
-    // caps retry can re-deliver. Each override is therefore applied at the exact point RAC reads
-    // the tag, so a duplicate caps reply cannot undo it:
-    //   - filter (RAC reads 0x2f1 in valuesReceived): CST always has a filter, so probe
-    //     unconditionally rather than gating on 0x2f1;
-    //   - jet / positional swing / energy-save (RAC reads 0x2cd/0x2cc in initMakeSetConfig):
-    //     rewrite those tags in an initMakeSetConfig override, right before super reads them.
-
+    // RAC's valuesReceived probes the basic-filter priv-command, then builds the config. On CST
+    // that probe returns bogus data (used=0, life=720), so skip it and go straight to config —
+    // filterLifeTime stays 0, so RAC creates none of its priv-command filter entities, and the
+    // real filter is added from value tags in setConfig. (The jet / swing / energy-save caps
+    // fix-ups are applied in initMakeSetConfig, at the point RAC reads those tags, so a duplicate
+    // caps reply can't undo them.)
     valuesReceived() {
         if (this.initialValuesReceived) return
         this.initialValuesReceived = true
@@ -51,7 +52,7 @@ export default class Device extends RAC {
         this.thinq.send('setMaskingInfo', 0, { blacklist_tlv: '1200' })
         this.tlvBlacklistDisableTimer = setTimeout(() => {
             this.tlvBlacklistDisableTimer = undefined
-            this.initProbeForFilter()
+            this.initMakeSetConfig()
         }, 500)
     }
 
@@ -293,6 +294,55 @@ export default class Device extends RAC {
             })
         }
 
+        // Filter usage from value tags: 0x356 = rated life (2400 h, constant), 0x355 = remaining
+        // hours. RAC's basic-filter priv-command is unpopulated on CST (see valuesReceived), so
+        // derive the entities here. Both are published from a read hook on 0x355, the live
+        // counter (0x356 is constant); used = life - remaining, remaining % = remaining / life.
+        if (this.raw_clip_state[0x356] && !config.components['filter_remaining']) {
+            config.components['filter_remaining'] = allowExtendedType({
+                platform: 'sensor',
+                unique_id: '$deviceid-filter_remaining',
+                name: 'Filter remaining',
+                icon: 'mdi:air-filter',
+                unit_of_measurement: '%',
+                state_class: 'measurement',
+                suggested_display_precision: 0,
+                entity_category: 'diagnostic',
+                state_topic: '$this/filter_remaining',
+            })
+            config.components['filter_used'] = allowExtendedType({
+                platform: 'sensor',
+                unique_id: '$deviceid-filter_used',
+                name: 'Filter used time',
+                icon: 'mdi:air-filter',
+                device_class: 'duration',
+                unit_of_measurement: 'h',
+                state_class: 'total_increasing',
+                entity_category: 'diagnostic',
+                state_topic: '$this/filter_used',
+            })
+            this.addField(
+                config,
+                {
+                    id: 0x355,
+                    name: '',
+                    comp: 'filter_remaining',
+                    readable: false,
+                    writable: false,
+                    read_callback: () => {
+                        const life = this.raw_clip_state[0x356]
+                        const remaining = this.raw_clip_state[0x355]
+                        if (life) {
+                            this.HA.publishProperty(this.id, 'filter_remaining', Math.round((remaining / life) * 100))
+                            this.HA.publishProperty(this.id, 'filter_used', life - remaining)
+                        }
+                        return false
+                    },
+                },
+                false,
+            )
+        }
+
         super.setConfig(config)
     }
 
@@ -344,25 +394,6 @@ export default class Device extends RAC {
         if (this.raw_clip_state[0x291]) return 'study'
         if (this.raw_clip_state[0x290]) return 'auto temp'
         return 'off'
-    }
-
-    // RAC probes for the filter once and, if no reply comes within 5 s, builds the config
-    // without filter entities. On a multi-split the probe can race with the caps/values/masking
-    // traffic, so retry it a few times before falling back. A reply clears
-    // filterInitialQueryTimeout (in RAC.processFilterData), stopping the retries and proceeding
-    // to config.
-    filterProbeAttempts = 0
-    initProbeForFilter() {
-        this.filterProbeAttempts++
-        this.sendFilterQuery()
-        this.filterInitialQueryTimeout = setTimeout(() => {
-            this.filterInitialQueryTimeout = undefined
-            if (this.filterProbeAttempts < 5) {
-                this.initProbeForFilter()
-            } else {
-                this.initMakeSetConfig()
-            }
-        }, 4 * 1000)
     }
 
     setProperty(prop: string, mqttValue: string) {

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -13,6 +13,7 @@ import Y_V8_F___W_B_2QEUK from './devices/Y_V8_F___W.B_2QEUK'
 import F_V__F___W_B_1QEUK from './devices/F_V__F___W.B_1QEUK'
 import F_VB_F___W_B_2QEUK from './devices/F_VB_F___W.B_2QEUK'
 import VCDWL2QEUK from './devices/VCDWL2QEUK'
+import CST_570004_WW from './devices/CST_570004_WW'
 import T1789EFH_F from './devices/T1789EFH_F'
 import RV13U6AM8W_D_US_WIFI from './devices/RV13U6AM8W_D_US_WIFI'
 import F3L2CYU__ from './devices/F3L2CYU__'
@@ -35,6 +36,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     POT_056905_WW,
     RAC_056905_WW,
     ['RAC_0B0001_WW']: RAC_056905_WW, // a different European variant (deviceType 401, RTK_RTL8720cm), same TLV handler
+    CST_570004_WW, // LG ceiling-cassette IDU (multi-split, deviceType 401); RAC handler + 0xa7 header normalization
     WIN_056905_WW,
     ['2REF11EIDA__4']: Dev_2REF11EIDA__4,
     ['2REF11EBIVPC4']: Dev_2REF11EBIVPC4,

--- a/tests/cloud/devices/CST_570004_WW.test.ts
+++ b/tests/cloud/devices/CST_570004_WW.test.ts
@@ -185,6 +185,22 @@ describe(MODEL_ID, () => {
         dev.drop()
     })
 
+    test('selecting a mode while off turns the unit on (attaches 0x1f7=1)', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        dev.raw_clip_state[0x1f7] = 0 // powered off
+        ha.setProperty(DEVICE_ID, 'climate', 'mode_command', 'cool')
+
+        assert.equal(thinq.outbox.length, 1)
+        const frame = thinq.outbox[0]
+        const m = new Map(TLV.parse(frame.subarray(11, frame.length - 2)).map(({ t, v }) => [t, v]))
+        // Mode-only writes are ignored while off; the frame must also carry power on.
+        assert.equal(m.get(0x1f7), 1, 'power on attached')
+        assert.equal(m.get(0x1f9), 0, 'mode cool')
+
+        dev.drop()
+    })
+
     test('writing wind_mode emits an exclusive one-hot TLV', (t) => {
         const { ha, thinq, dev } = buildReadyDevice(t)
 

--- a/tests/cloud/devices/CST_570004_WW.test.ts
+++ b/tests/cloud/devices/CST_570004_WW.test.ts
@@ -45,11 +45,6 @@ const QUERY_RESPONSE_HEX =
     'ED56002FBD5A00960BC88D5D03CD61020C9009C40A88087D0C8AC40E9C16640668066C067006740678067C' +
     '068008F80F7407C8189501E9380D558'
 
-// Filter priv-command reply (sub-command 0x02). Uses the normal 0x87 header. Decodes to
-// used=0, life=720, changed-date=0. Emitting it lets the filter probe complete immediately
-// instead of timing out.
-const FILTER_REPLY_HEX = '02ff0400000087fd03010d0200000000d0020000000000003920'
-
 function makeDevice() {
     const ha = new MockHAConnection()
     const thinq = new MockThinq2Device(DEVICE_ID, META)
@@ -60,8 +55,8 @@ function makeDevice() {
     return { ha, thinq, dev }
 }
 
-/** Bring the device through caps -> values -> filter-probe -> initMakeSetConfig using mock
- *  timers, so the config is installed. Returns with the thinq recorder cleared. */
+/** Bring the device through caps -> values -> initMakeSetConfig using mock timers, so the
+ *  config is installed. Returns with the thinq recorder cleared. */
 function buildReadyDevice(t: import('node:test').TestContext) {
     enableMockTimers(t)
     const { ha, thinq, dev } = makeDevice()
@@ -72,11 +67,8 @@ function buildReadyDevice(t: import('node:test').TestContext) {
     thinq.emit('data', buf(CAPS_RESPONSE_HEX))
     thinq.emit('data', buf(QUERY_RESPONSE_HEX))
 
-    // valuesReceived arms a 500 ms masking delay, after which the filter probe is sent.
+    // valuesReceived arms a 500 ms masking delay, after which the config is built.
     tickMockTimers(t, 600)
-    // Answer the probe so config is built now (rather than after the 5-retry fallback).
-    thinq.emit('data', buf(FILTER_REPLY_HEX))
-    tickMockTimers(t, 100)
 
     thinq.resetRecorder()
     return { ha, thinq, dev }
@@ -139,8 +131,11 @@ describe(MODEL_ID, () => {
         assert.ok(c.energysave, 'energysave present')
         assert.ok(!('optimistic' in c.energysave), 'energysave optimistic flag removed')
 
-        // Filter probe answered -> filter entities present.
-        assert.ok(c.filterused && c.filterlife, 'filter entities present')
+        // Filter usage comes from value tags 0x355/0x356, not RAC's priv-command (unpopulated on
+        // CST). No RAC priv-command filter entities; a remaining % and used-time sensor instead.
+        assert.ok(!c.filterused && !c.filterlife && !c.filterreset, 'no RAC priv-command filter entities')
+        assert.equal(c.filter_remaining?.unit_of_measurement, '%')
+        assert.equal(c.filter_used?.unit_of_measurement, 'h')
 
         dev.drop()
     })
@@ -163,6 +158,10 @@ describe(MODEL_ID, () => {
         assert.equal(ha.getProperty(DEVICE_ID, 'display', 'state'), '100%') // 0x21F=200
         assert.equal(ha.getProperty(DEVICE_ID, 'comfort_saving', 'state'), 'OFF') // 0x23F=0
         assert.equal(ha.getProperty(DEVICE_ID, 'wind_mode', 'state'), 'off') // all wind flags 0
+
+        // Filter: 0x355=763 remaining of 0x356=2400 -> 32%, used = 2400-763 = 1637 h.
+        assert.equal(ha.getProperty(DEVICE_ID, 'filter_remaining', 'state'), 32)
+        assert.equal(ha.getProperty(DEVICE_ID, 'filter_used', 'state'), 1637)
 
         dev.drop()
     })

--- a/tests/cloud/devices/CST_570004_WW.test.ts
+++ b/tests/cloud/devices/CST_570004_WW.test.ts
@@ -1,0 +1,218 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/CST_570004_WW'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf, hex } from '@/tests/helpers/mocks'
+import { enableMockTimers, tickMockTimers } from '@/tests/helpers/timers'
+import * as TLV from '@/util/tlv'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'CST_570004_WW'
+const META: Metadata = { modelId: MODEL_ID, modelName: 'CST_570004_WW', swVersion: '1.0' }
+
+// Real packet captures from a CST_570004_WW ceiling-cassette IDU (multi-split).
+// NB: CST emits its async/query TLV frames with UART header byte6 = 0xA7 (not 0x87);
+// the base framing check only accepts 0x87, so the handler normalizes it. These captures
+// keep the 0xA7 byte so the test exercises that normalization end to end.
+
+// Capability response (query 0x1F5/1). Contains t=0x2DA (eeprom checksum) -> isCapsResponse.
+// Notably 0x2CD = 2089015 (jet bits 0/1 AND positional-swing bits 4/8 all set) and
+// 0x2F1 = 1 ("no filter") — both of which CST must override.
+const CAPS_RESPONSE_HEX =
+    '000004000000A702010077B00AB04FB0A001D5B0C1B103B4F0401011B710FEBB81BBC0BC41BC88BCC1B37' +
+    '01FE037B381B54EB2E01006B7600120B85020B8903CB8D020B9103CBD600203B5C0B646B61030B5C1B646' +
+    'B61030B5C2B646B61030B5C3B646B603B69037B6F0570004D41010BD30800400DD1020B5B010000064903' +
+    'EFA05EFE0'
+
+// Comprehensive state response (query 0x1F5/2). Contains t=0x1F7 (power) -> isValuesResponse.
+// Captured while the IDU was powered OFF. Ground-truth tags used below:
+//      0x1F7=0   power OFF
+//      0x1F9=0   mode cool (reported as 'off' because power is 0)
+//      0x1FA=6   fan = high (CST scale)
+//      0x1FD=52  current temp = 26.0 (raw/2)
+//      0x1FE=48  target temp  = 24.0 (raw/2)
+//      0x20D=0   energy saving off
+//      0x20E=3   auto-dry setting = 60 min
+//      0x21F=200 display = 100%
+//      0x225=30  auto-dry remaining = 30 min
+//      0x23F=0   comfort saving off
+//      0x290..0x3D7 = 0  wind mode = off
+//      0x2B3=0   power = 0 W (compressor idle)
+//      0x336=811 humidity = 81 %RH (raw/10)
+const QUERY_RESPONSE_HEX =
+    '000004000000A7020400837DC07E407E867F50347F90307F0086808840D4C0D500C84181408180C940A38' +
+    '0A3C0A400A440F540F580F5C08340838389501E83C08FC0CD40CD00CCC0CDA0032BADA01CC6ACC0AD41B54' +
+    'ED56002FBD5A00960BC88D5D03CD61020C9009C40A88087D0C8AC40E9C16640668066C067006740678067C' +
+    '068008F80F7407C8189501E9380D558'
+
+// Filter priv-command reply (sub-command 0x02). Uses the normal 0x87 header. Decodes to
+// used=0, life=720, changed-date=0. Emitting it lets the filter probe complete immediately
+// instead of timing out.
+const FILTER_REPLY_HEX = '02ff0400000087fd03010d0200000000d0020000000000003920'
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    ha.on('setProperty', (id: string, prop: string, value: string) => {
+        dev.setProperty(prop, value)
+    })
+    return { ha, thinq, dev }
+}
+
+/** Bring the device through caps -> values -> filter-probe -> initMakeSetConfig using mock
+ *  timers, so the config is installed. Returns with the thinq recorder cleared. */
+function buildReadyDevice(t: import('node:test').TestContext) {
+    enableMockTimers(t)
+    const { ha, thinq, dev } = makeDevice()
+
+    // Constructor sent the queryCaps packet; discard it.
+    thinq.resetRecorder()
+
+    thinq.emit('data', buf(CAPS_RESPONSE_HEX))
+    thinq.emit('data', buf(QUERY_RESPONSE_HEX))
+
+    // valuesReceived arms a 500 ms masking delay, after which the filter probe is sent.
+    tickMockTimers(t, 600)
+    // Answer the probe so config is built now (rather than after the 5-retry fallback).
+    thinq.emit('data', buf(FILTER_REPLY_HEX))
+    tickMockTimers(t, 100)
+
+    thinq.resetRecorder()
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('0xA7 caps response is normalized and triggers the values query', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+
+        thinq.emit('data', buf(CAPS_RESPONSE_HEX))
+
+        // A plain RAC handler would drop the 0xA7 frame and never ask for values.
+        assert.equal(thinq.outbox.length, 1, 'values query sent in response to caps')
+        dev.drop()
+    })
+
+    test('config drops jet/heat and exposes the CST-specific components', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+
+        const device = ha.devices[DEVICE_ID]
+        assert.ok(device, 'HA configuration published')
+        const c = device.config!.components as Record<string, Record<string, unknown>>
+
+        assert.ok(c.climate, 'climate component')
+        assert.equal(c.climate.platform, 'climate')
+
+        // The captured caps had 0x2CD with the jet bits set, yet CST is cooling-only and must
+        // suppress jet — and the old binary auto-dry sensor is replaced by a select.
+        assert.ok(!c.jet, 'no jet switch (suppressed despite 0x2CD jet bits)')
+        assert.ok(!c.autodry, 'no binary auto-dry sensor')
+
+        // HVAC mode list excludes heat.
+        assert.deepEqual(c.climate.modes, ['off', 'cool', 'dry', 'fan_only', 'auto'])
+
+        // Temp range read from caps 0x2E1/0x2E2 (32/60 -> 16/30), not RAC's hardcoded 18.
+        assert.equal(c.climate.min_temp, 16)
+        assert.equal(c.climate.max_temp, 30)
+
+        // Energy saving comes from the 0x2CB feature bitmap (CST's relocated 0x2CC); the binary
+        // auto-dry sensor (0x2CB bit2) is masked because auto-dry is exposed as a select instead.
+        assert.ok(c.energysave, 'energysave present (from 0x2CB bit1)')
+
+        // CST fan scale and on/off swing.
+        assert.deepEqual(c.climate.fan_modes, ['auto', 'very low', 'low', 'medium', 'high', 'power'])
+        assert.deepEqual(c.climate.swing_modes, ['on', 'off'])
+        assert.deepEqual(c.climate.swing_horizontal_modes, ['on', 'off'])
+
+        // Extra components CST adds.
+        assert.equal(c.autodry_setting?.platform, 'select')
+        assert.deepEqual(c.autodry_setting.options, ['off', '10 min', '30 min', '60 min', 'smart'])
+        assert.equal(c.autodryremain?.unit_of_measurement, 'min', 'auto-dry remaining is minutes, not %')
+        assert.equal(c.display?.platform, 'select')
+        assert.equal(c.comfort_saving?.platform, 'switch')
+        assert.equal(c.wind_mode?.platform, 'select')
+        assert.equal(c.humidity?.device_class, 'humidity')
+        assert.equal(c.energy_current?.device_class, 'power', 'power sensor always present, even idle')
+
+        // Energy saving rendered as a plain toggle (no assumed_state buttons).
+        assert.ok(c.energysave, 'energysave present')
+        assert.ok(!('optimistic' in c.energysave), 'energysave optimistic flag removed')
+
+        // Filter probe answered -> filter entities present.
+        assert.ok(c.filterused && c.filterlife, 'filter entities present')
+
+        dev.drop()
+    })
+
+    test('initial values publish the expected HA properties', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        // Re-emit the values frame now that the fields are registered.
+        thinq.emit('data', buf(QUERY_RESPONSE_HEX))
+        tickMockTimers(t, 100)
+
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'mode_state'), 'off') // power 0x1F7=0
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'fan_mode_state'), 'high') // 0x1FA=6
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'current_temperature'), 26) // 0x1FD=52 /2
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'temperature_state'), 24) // 0x1FE=48 /2
+        assert.equal(ha.getProperty(DEVICE_ID, 'humidity', 'state'), 81) // 0x336=811 /10
+        assert.equal(ha.getProperty(DEVICE_ID, 'energy_current', 'state'), 0) // 0x2B3=0
+        assert.equal(ha.getProperty(DEVICE_ID, 'autodry_setting', 'state'), '60 min') // 0x20E=3
+        assert.equal(ha.getProperty(DEVICE_ID, 'autodryremain', 'state'), 30) // 0x225=30
+        assert.equal(ha.getProperty(DEVICE_ID, 'display', 'state'), '100%') // 0x21F=200
+        assert.equal(ha.getProperty(DEVICE_ID, 'comfort_saving', 'state'), 'OFF') // 0x23F=0
+        assert.equal(ha.getProperty(DEVICE_ID, 'wind_mode', 'state'), 'off') // all wind flags 0
+
+        dev.drop()
+    })
+
+    test('HVAC auto mode uses CST wire value 3, not RAC 6', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        // READ: device reports mode wire 3 while powered on -> 'auto'. RAC's table decodes wire 3
+        // as undefined, so without the CST mode table this would publish no valid mode.
+        dev.raw_clip_state[0x1f7] = 1
+        dev.processKeyValue(0x1f9, 3)
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'mode_state'), 'auto')
+
+        // WRITE: selecting 'auto' in HA emits wire value 3 (RAC would send the unsupported 6).
+        ha.setProperty(DEVICE_ID, 'climate', 'mode_command', 'auto')
+        assert.equal(thinq.outbox.length, 1)
+        const frame = thinq.outbox[0]
+        const mode = TLV.parse(frame.subarray(11, frame.length - 2)).find(({ t }) => t === 0x1f9)
+        assert.equal(mode?.v, 3, 'auto writes 0x1f9=3')
+
+        dev.drop()
+    })
+
+    test('writing wind_mode emits an exclusive one-hot TLV', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        ha.setProperty(DEVICE_ID, 'wind_mode', 'command', 'manner')
+
+        assert.equal(thinq.outbox.length, 1, 'one packet sent')
+        const frame = thinq.outbox[0]
+        const tlvs = TLV.parse(frame.subarray(11, frame.length - 2))
+        const map = new Map(tlvs.map(({ t, v }) => [t, v]))
+
+        // manner -> 0x3D6=1, every other wind flag explicitly 0.
+        assert.equal(map.get(0x3d6), 1, 'manner flag set')
+        assert.equal(map.get(0x290), 0)
+        assert.equal(map.get(0x291), 0)
+        assert.equal(map.get(0x3d5), 0)
+        assert.equal(map.get(0x3d7), 0)
+
+        dev.drop()
+    })
+
+    test('constructor sends a queryCaps packet on the wire', () => {
+        const { thinq, dev } = makeDevice()
+        if (dev.query_caps_timeout) {
+            clearInterval(dev.query_caps_timeout)
+            dev.query_caps_timeout = undefined
+        }
+        assert.equal(thinq.outbox.length, 1, 'queryCaps sent from constructor')
+        dev.drop()
+    })
+})


### PR DESCRIPTION
## Summary

Adds MQTT translation for **`CST_570004_WW`**, an LG ceiling-cassette indoor unit
(deviceType 401), typically installed as several IDUs on one multi-split ODU.
Previously these only worked in bridge mode.

It speaks the same DualCool AC TLV protocol as `RAC_056905_WW`, so per the
preferred direction in #73 this **extends `RAC`** rather than duplicating it, and
**drives features from the device's real capability frame wherever possible** —
not hardcoded per-model tables. It does **not** modify `tlv_device.ts`, and
`CST_570004_WW` is a new modelId, so no existing device is affected.

## Why a plain `CST_570004_WW: RAC_056905_WW` alias doesn't work

I tried the alias first (as suggested in #73). It fails because CST diverges from
RAC in ways proven by the capability dump below:

1. **0xA7 framing** — CST sends its async/query TLV frames with UART header
   `byte6 = 0xA7` instead of `0x87`, so `tlv_device` drops every frame. Handled in
   CST's own `processData` (same approach as `POT_056905_WW`), *not* in the shared base.
2. **Feature bitmap moved** — CST omits RAC's `0x2CC` entirely.
3. **Mode table differs** — CST's `auto` is wire value **3**, not RAC's `6`; RAC
   decodes wire 3 as `undefined` (blank mode) and writes `auto` as the unsupported 6.
4. **Filter data lives elsewhere** — RAC reads filter usage from a basic-filter priv-command
   that returns an unpopulated counter on CST (used=0, life=720); the real usage is in value
   tags `0x356` (rated life 2400 h) / `0x355` (remaining).
5. **Fan scale differs**, and RAC would expose a bogus jet switch + a `heat` mode this
   cooling-only unit doesn't have.

## Capability-driven decoding (read, don't hardcode)

Rather than synthesize, the handler reads what CST actually advertises. Aligned caps
dump (RAC's test frame vs a live CST frame):

| tag | RAC | CST | meaning |
|---|---|---|---|
| 0x2C1 | 0x57 = {0,1,2,4,6} | 0x0F = {0,1,2,3} | supported modes (bit N = wire mode N): CST = cool/dry/fan_only/auto, **auto=3** |
| 0x2C2 | 0x17C = {2,3,4,5,6,8} | 0x1D5 = {0,2,4,6,7,8} | supported fan speeds (bit N = wire speed N) |
| 0x2CB | — | 0x1006 = {1,2,12} | **feature bitmap** (CST's relocated 0x2CC): bit1 energy-save, bit2 auto-dry |
| 0x2CC | 0x6 | — | RAC's feature bitmap; absent on CST |
| 0x2CD | 0xF | 0x1FE037 | RAC reads jet/swing here; on CST this holds unrelated data (13 bits set) |
| 0x2D3 | 0x7 | 0x401011 | timers — bit0 sleep + bit4 start/stop read correctly, no change |
| 0x2E1/0x2E2 | — | 32 / 60 | **temp range 16–30 °C** (raw/2) |

Concretely:
- **Energy saving** is read from `0x2CB` (mapped into RAC's `0x2CC` slot, masking bit2
  since CST exposes auto-dry as a duration select), replacing an earlier presence heuristic.
- **Temperature range** is read from `0x2E1/0x2E2`, fulfilling RAC's existing
  `TODO: some devices report these temp ranges via tags 0x2e1 - 0x2ec`, falling back
  to RAC's 18–30 when absent.
- **HVAC modes** use CST's wire table (`auto=3`), confirmed by both `0x2C1` bit3 and a
  live `0x1F9=3` capture.
- **Filter usage** is read from value tags `0x356` (rated life 2400 h) / `0x355` (remaining),
  exposed as a remaining-% and a used-time (h) sensor. RAC's basic-filter priv-command counter
  is unpopulated on CST (used=0, life=720), and this model's app exposes no filter reset or
  last-reset date, so RAC's priv-command filter entities (including the reset button) are dropped.
- **Jet** is suppressed and swing is taken from the real on/off value tags `0x205/0x206`,
  because CST's `0x2CD` is not RAC's jet/swing bitmap. This one genuinely can't be read
  cleanly — documented rather than guessed.

## Extra entities CST exposes

Humidity (`0x336`, raw/10 = %RH), always-on Power (`0x2B3`), auto-dry duration select
(`0x20E`) + remaining sensor (`0x225`, minutes), display brightness (`0x21F`), comfort
energy saving (`0x23F`), and a wind-mode / comfort-airflow select
(`0x290`/`0x291`/`0x3D6`/`0x3D7`, mutually exclusive one-hot flags).

## Testing

- `tests/cloud/devices/CST_570004_WW.test.ts` drives **real captured packets**
  (caps / values / filter reply) through the handler and asserts: 0xA7 normalization,
  caps-derived temp range and energy-save, `auto` wire value 3 (read + write), jet/heat
  suppression, CST fan scale, and the extra components. `npm run test` → 302/302;
  `prettier --check` and `npm run build` clean.
- **Physical verification on 4 live IDUs (LG multi-split):** per-unit humidity matches the
  app; filter remaining/used match the app across all 4 units (2400 h rated); `auto` mode set
  from HA actually engages auto on the unit; power reads 0 W idle and rises while cooling.

## Known limitations (not guessed)

- `0x2C2`'s fan bitmap is understood but has an unresolved off-by-one at CST's lowest speed,
  so the fan list is the hand-verified `{1,2,4,6,7,8}` rather than auto-derived.
- Energy in kWh is cloud-computed (reads 0 locally); derive in HA via a Riemann integral of
  the Power (W) sensor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
