### PR TITLE
Publish raw frames for appliances that have no handler yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ Miscelanneous utilities:
 - [rethink-capture](tools/rethink-capture.ts) - records a device's live wire traffic (and optionally the time-aligned LG cloud notifications) to a JSONL capture file, with inline annotations, for offline reverse-engineering in an LLM-friendly format.
 - [mcp-server](tools/mcp-server.ts) - an [MCP](https://modelcontextprotocol.io) server that exposes the reverse-engineering toolkit (decode/encode packets, enumerate devices, capture device & cloud traffic, inject and probe packets) to an LLM agent.
 
+The `publish_raw_packets` option in the config is a related aid: an appliance that rethink has no
+handler for is normally ignored, but with it on its frames are published to
+`<rethink_prefix>/<deviceid>/raw_rx` as hex and anything written to `<rethink_prefix>/<deviceid>/raw_tx/set`
+is sent to it. That is enough to work out an unsupported appliance's protocol, and to drive it,
+from anything that speaks MQTT - no rebuild between guesses, and no TypeScript.
+
 ## Notice
 
 LG ThinQ is likely a registered trademark, or whatever, I don't care. The name is used here for identification purposes only. I'm not in any way affiliated with LG.

--- a/cloud/devices/raw.ts
+++ b/cloud/devices/raw.ts
@@ -1,0 +1,71 @@
+import { type Metadata } from '../thinq'
+import type { Connection } from '../homeassistant'
+import HADevice from './base'
+import { Device as T2Device } from '../thinq2/device'
+import log from '@/util/logging'
+
+/**
+ * What an appliance rethink has no handler for gets instead of nothing.
+ *
+ * Writing a handler means learning what the bytes mean, and that means watching them change while
+ * operating the appliance and comparing against what the official app shows. Until now the only
+ * way to see them was rethink's own log, which mixes every device together and cannot be correlated
+ * with anything, or a rebuild with a stub handler in it — a redeploy per guess.
+ *
+ * So publish them. Every frame the appliance sends goes to `<prefix>/<id>/raw_rx` as uppercase hex,
+ * everything sent to it appears on `<prefix>/<id>/raw_tx`, and whatever is written to
+ * `<prefix>/<id>/raw_tx/set` is sent to it - which then comes back on `raw_tx`, so a write is
+ * confirmed by the same topic that reports the traffic. rx and tx are which way round they are on
+ * the management websocket and in the capture tools: rx is from the appliance, tx is to it. That is enough to work out
+ * a protocol from anything that can subscribe to MQTT, with no rebuild between guesses, and it is
+ * also enough to drive an appliance from a script long before it has a handler.
+ *
+ * Deliberately not registered for discovery, and published without retain. A frame can be several
+ * hundred bytes and Home Assistant truncates a sensor state at 255 characters, so an entity would
+ * silently lie about the longer ones; and a frame is a moment rather than a state, so a retained
+ * one would be handed to every new subscriber as though the appliance had just said it. The topics
+ * carry the whole frame, and anything reading MQTT directly sees it.
+ */
+export default class RawDevice extends HADevice {
+    constructor(
+        readonly HA: Connection,
+        readonly thinq: T2Device,
+        readonly meta: Metadata,
+    ) {
+        super(HA, thinq.id)
+
+        // Not retained. A property is worth keeping because it describes how the appliance *is*;
+        // a frame describes a moment, and a retained one would be replayed to every new subscriber
+        // as though the appliance had just said it.
+        thinq.on('data', (buf) => this.publish('raw_rx', buf))
+        // Both directions, because a reply only means something next to the command that caused it.
+        thinq.on('sendData', (buf) => this.publish('raw_tx', buf))
+    }
+
+    publish(property: string, frame: Buffer) {
+        this.HA.publishProperty(this.id, property, frame.toString('hex').toUpperCase(), { retain: false })
+    }
+
+    start() {
+        this.HA.publishProperty(this.id, 'availability', 'online')
+        log(
+            'status',
+            this.id,
+            `no handler for ${this.meta.modelId} - publishing raw frames to <prefix>/${this.id}/raw_rx` +
+                ` and /raw_tx, writable at <prefix>/${this.id}/raw_tx/set`,
+        )
+    }
+
+    setProperty(prop: string, mqttValue: string) {
+        if (prop !== 'raw_tx') return
+
+        const hex = mqttValue.trim().replace(/\s+/g, '')
+        if (!/^([0-9a-fA-F]{2})+$/.test(hex)) {
+            log('status', this.id, `ignoring raw frame that is not whole hex bytes: ${mqttValue.slice(0, 40)}`)
+            return
+        }
+
+        log('status', this.id, `sending raw frame ${hex.toUpperCase()}`)
+        this.thinq.send_packet(Buffer.from(hex, 'hex'))
+    }
+}

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -21,6 +21,7 @@ import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
 import { type Connection } from './homeassistant'
 import HADevice from './devices/base'
+import RawDevice from './devices/raw'
 import { type Metadata } from './thinq'
 import { AnyDevice } from './devmgr'
 
@@ -57,7 +58,13 @@ const t2deviceTypes: Record<string, T2Factory> = {
 
 class Bridge {
     haDevices = new Map<string, HADevice>()
-    constructor(readonly HA: Connection) {
+    constructor(
+        readonly HA: Connection,
+        // Whether an appliance with no handler should have its frames published anyway. Off by
+        // default: it is a development aid, and on a busy appliance it is a lot of MQTT traffic
+        // that nothing is reading.
+        readonly publishRawPackets = false,
+    ) {
         HA.on('discovery', () => {
             this.haDevices.forEach((ha) => ha.publishConfig())
         })
@@ -80,6 +87,13 @@ class Bridge {
         } else if (thinqdev.platform === 'thinq2') {
             const devclass = t2deviceTypes[meta.modelId]
             if (devclass) hadevice = new devclass(this.HA, thinqdev, meta)
+        }
+
+        // An appliance with no handler still speaks; publish its frames rather than dropping them,
+        // so the protocol can be worked out over MQTT without a rebuild between guesses.
+        if (!hadevice && this.publishRawPackets && thinqdev instanceof T2Device) {
+            console.warn(`${thinqdev.platform} device type ${meta.modelId} unknown - publishing raw frames`)
+            hadevice = new RawDevice(this.HA, thinqdev, meta)
         }
 
         if (!hadevice) {

--- a/config.jsonc
+++ b/config.jsonc
@@ -1,6 +1,14 @@
 {
   "hostname": "rethink.lan", // this can't be an IP address
 
+  // An appliance rethink has no handler for is normally ignored. Turn this on and its frames are
+  // published to <rethink_prefix>/<deviceid>/raw_rx as hex instead, everything sent to it appears on
+  // <rethink_prefix>/<deviceid>/raw_tx, and anything written to <rethink_prefix>/<deviceid>/raw_tx/set
+  // is sent to the appliance. Enough to work out what an unsupported appliance is saying, and to
+  // drive it, from anything that speaks MQTT. Off by default: it is a development aid, and a chatty
+  // appliance produces a lot of traffic that nothing is reading.
+  // "publish_raw_packets": false,
+
   "homeassistant": {
     "mqtt_url": "mqtt://localhost:1883",
     "discovery_prefix": "homeassistant", // corresponds to discovery_prefix in homeassistant config

--- a/rethink-cloud.ts
+++ b/rethink-cloud.ts
@@ -130,7 +130,7 @@ function t2setup(manager: DeviceManager) {
 }
 
 // HA connector
-const ha = new HA_bridge(new HA_connection(config.homeassistant))
+const ha = new HA_bridge(new HA_connection(config.homeassistant), config.publish_raw_packets)
 const manager = new DeviceManager()
 manager.on('newDevice', (dev) => ha.newDevice(dev))
 

--- a/tests/cloud/devices/raw.test.ts
+++ b/tests/cloud/devices/raw.test.ts
@@ -1,0 +1,116 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { MockHAConnection, MockThinq2Device, buf, hex } from '@/tests/helpers/mocks'
+import RawDevice from '@/cloud/devices/raw'
+import type { Metadata } from '@/cloud/thinq'
+import Bridge from '@/cloud/ha_bridge'
+import type { AnyDevice } from '@/cloud/devmgr'
+
+const META: Metadata = { modelId: 'WBEY3GT', modelName: 'WBEY3GT', deviceType: '303' }
+
+function setup() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device('dev-1', META)
+    const raw = new RawDevice(ha.asConnection(), thinq, META)
+    raw.start()
+    return { ha, thinq, raw }
+}
+
+describe('RawDevice', () => {
+    test('publishes what the appliance sends, as uppercase hex', () => {
+        const { ha, thinq } = setup()
+        thinq.emit('data', buf('aa6642ec0102'))
+
+        assert.equal(ha.devices['dev-1'].properties['raw_rx'], 'AA6642EC0102')
+    })
+
+    test('publishes what is sent to the appliance too', () => {
+        const { ha, thinq } = setup()
+        thinq.send_packet(buf('aa12426501'))
+
+        assert.equal(ha.devices['dev-1'].properties['raw_tx'], 'AA12426501')
+    })
+
+    test('sends a frame written to the raw topic', () => {
+        const { thinq, raw } = setup()
+        raw.setProperty('raw_tx', 'AA12426500')
+
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(hex(thinq.outbox[0]), 'AA12426500')
+    })
+
+    test('tolerates whitespace and lower case in what it is asked to send', () => {
+        const { thinq, raw } = setup()
+        raw.setProperty('raw_tx', ' aa 12 42 65 00 ')
+
+        assert.equal(hex(thinq.outbox[0]), 'AA12426500')
+    })
+
+    test('refuses anything that is not whole hex bytes rather than sending rubbish', () => {
+        const { thinq, raw } = setup()
+        for (const bad of ['', 'zz', 'AA1', 'AA 1', 'not hex']) raw.setProperty('raw_tx', bad)
+
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('ignores properties other than raw_tx', () => {
+        const { thinq, raw } = setup()
+        raw.setProperty('mode', 'AA12426500')
+
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('a frame written to raw_tx/set comes back on raw_tx, confirming it went out', () => {
+        const { ha, raw } = setup()
+        raw.setProperty('raw_tx', 'AA12426500')
+
+        // send_packet emits sendData, which is what publishes raw_tx - so the echo is the
+        // confirmation, and read and write live on the same topic as everywhere else in rethink.
+        assert.equal(ha.devices['dev-1'].properties['raw_tx'], 'AA12426500')
+    })
+
+    test('the two directions are named the way the rest of the project names them', () => {
+        const { ha, thinq } = setup()
+        thinq.emit('data', buf('aa01'))
+        thinq.send_packet(buf('aa02'))
+
+        // rx is from the appliance, tx is to it - as on the management websocket and in the
+        // capture tools. Getting these the wrong way round would silently mislead every reader.
+        assert.equal(ha.devices['dev-1'].properties['raw_rx'], 'AA01')
+        assert.equal(ha.devices['dev-1'].properties['raw_tx'], 'AA02')
+    })
+
+    test('publishes frames without retain, so they are not replayed as fresh to a new subscriber', () => {
+        const { ha, thinq } = setup()
+        thinq.emit('data', buf('aa6642ec0102'))
+        thinq.send_packet(buf('aa12426501'))
+
+        assert.deepEqual(ha.devices['dev-1'].publishOptions?.['raw_rx'], { retain: false })
+        assert.deepEqual(ha.devices['dev-1'].publishOptions?.['raw_tx'], { retain: false })
+    })
+
+    test('registers no discovery config, so a long frame cannot be truncated into an entity', () => {
+        const { ha } = setup()
+
+        assert.equal(ha.devices['dev-1'].config, undefined)
+        assert.equal(ha.devices['dev-1'].availability, 'online')
+    })
+})
+
+describe('the raw fallback is opt-in', () => {
+    test('an unhandled appliance is ignored unless publish_raw_packets is on', () => {
+        const ha = new MockHAConnection()
+        const bridge = new Bridge(ha.asConnection())
+        bridge.newDevice(new MockThinq2Device('dev-2', META) as unknown as AnyDevice)
+
+        assert.equal(bridge.haDevices.size, 0)
+    })
+
+    test('and gets a RawDevice when it is', () => {
+        const ha = new MockHAConnection()
+        const bridge = new Bridge(ha.asConnection(), true)
+        bridge.newDevice(new MockThinq2Device('dev-3', META) as unknown as AnyDevice)
+
+        assert.ok(bridge.haDevices.get('dev-3') instanceof RawDevice)
+    })
+})

--- a/tests/helpers/mocks.ts
+++ b/tests/helpers/mocks.ts
@@ -15,6 +15,8 @@ export type DeviceInfo = {
     config?: DeviceDiscovery
     availability?: string
     properties: Record<string, string | number>
+    /** Publish options per property, so a test can tell a retained state from a passing event. */
+    publishOptions?: Record<string, unknown>
 }
 
 export class MockHAConnection extends EventEmitter {
@@ -26,8 +28,11 @@ export class MockHAConnection extends EventEmitter {
         this.devices[id].config = config
     }
 
-    publishProperty(id: string, property: string, value: string | number) {
+    publishProperty(id: string, property: string, value: string | number, options?: unknown) {
         if (!this.devices[id]) this.devices[id] = { properties: {} }
+        if (options !== undefined) {
+            this.devices[id].publishOptions = { ...this.devices[id].publishOptions, [property]: options }
+        }
 
         if (property === 'availability') {
             assert.equal(typeof value, 'string')

--- a/util/config.ts
+++ b/util/config.ts
@@ -1,5 +1,6 @@
 export type RawConfig = {
     hostname: string
+    publish_raw_packets?: boolean
     homeassistant: HAConfig
     ca_key_file: string
     ca_cert_file: string
@@ -18,6 +19,7 @@ export type RawConfig = {
 
 export type Config = {
     hostname: string
+    publish_raw_packets: boolean
     homeassistant: HAConfig
     ca_key_file: string
     ca_cert_file: string
@@ -60,6 +62,7 @@ function parsePort(port: Port | number | undefined): Port | undefined {
 
 export function normalize(config: RawConfig): Config {
     return {
+        publish_raw_packets: config.publish_raw_packets ?? false,
         log: ['status', 'incoming', 'HTTPS'],
         mqtt: true,
         ...config,


### PR DESCRIPTION
An appliance rethink has no handler for is dropped with a warning. This adds an option to publish
its frames instead, so its protocol can be worked out — and the appliance driven — from anything
that speaks MQTT.

With `publish_raw_packets` on, an unhandled appliance gets three topics:

| topic | |
|---|---|
| `<prefix>/<id>/raw_rx` | every frame the appliance sends, as hex |
| `<prefix>/<id>/raw_tx` | every frame sent to it |
| `<prefix>/<id>/raw_tx/set` | write hex here and it goes to the appliance |

`rx` is from the appliance and `tx` is to it, the way round they already are on the management
websocket and in the capture tools. The command topic hangs off `raw_tx` rather than being a third
sibling, so it follows the `<property>` / `<property>/set` shape used everywhere else in rethink —
and a frame written there comes back on `raw_tx`, which makes the echo the confirmation that it
went out.

**Why.** Working out what an appliance's bytes mean means watching them change while operating it
and comparing against what the official app shows. Today that means either reading rethink's log,
which interleaves every device and cannot be lined up with anything, or rebuilding with a stub
handler in it — a redeploy per guess. Against a real appliance that is a disconnect per guess too,
on hardware someone is actually using, which makes people stop after a few rather than iterate.

**It does not replace handlers, it feeds them.** The point is to finish the decoding first and
then write the handler once, from a known mapping, instead of discovering the mapping through the
handler.

It also lowers the barrier to getting there. Decoding a protocol and writing a TypeScript device
class are different skills, and requiring both means the first is only ever done by people who
have the second. With this, someone can work a protocol out in Python or Node-RED and post the
mapping, and the handler is then a small job for someone who knows the codebase.

**It costs nothing when off.** Off by default, and with it off the unhandled branch is reached
exactly as before — the only change on that path is the extra condition. Nothing else in the
dispatch is touched.

**Two deliberate choices:**

- **No discovery config.** A single frame can consist of several hundred raw bytes, which
  Home Assistant cannot process directly.
- **No retain.** A frame is a moment, not a state. Retained, it would be handed to every new
  subscriber as though the appliance had just said it.

Only whole hex bytes are sent on; anything else is refused and logged, so a malformed write cannot
put rubbish on the wire.

Tests cover both directions, the malformed-input refusal, the absence of a discovery config, that
publishes are not retained, and that the fallback is skipped both when the option is off and when
the model does have a handler.