### PR TITLE
Fix ThinQ connection lifecycle and validate ThinQ1 metadata XML

### DIFF
--- a/bridge/index.ts
+++ b/bridge/index.ts
@@ -14,6 +14,7 @@ import { Connection as Thinq2Connection } from './thinq2connection'
 import { Device as T1Downstream } from '@/cloud/thinq1/device'
 import { Device as T2Downstream } from '@/cloud/thinq2/device'
 import { TypedEmitter } from 'tiny-typed-emitter'
+import * as HTTPS from 'node:https'
 
 type StatusCallback = (status: string) => void
 
@@ -25,6 +26,7 @@ class BridgedDevice {
     constructor(
         readonly upstream: ClientDevice,
         readonly downstream: AnyDevice,
+        readonly thinq1Agent: HTTPS.Agent,
     ) {
         // we create the functions at runtime so that they have unique identities that can be removed with removeListener
         this.onDownstreamData = (packet: Buffer) => this.connection?.send(packet)
@@ -50,7 +52,7 @@ class BridgedDevice {
         const U = this.upstream
         const D = this.downstream
         if (U instanceof Thinq1Device && D instanceof T1Downstream) {
-            this.connection = new Thinq1Connection(U)
+            this.connection = new Thinq1Connection(U, { httpsAgent: this.thinq1Agent })
             // feed the initial state to the connection
             if (D.lastReport) this.connection.send(D.lastReport)
 
@@ -100,6 +102,7 @@ type BridgeEvents = {
 
 export class Bridge extends TypedEmitter<BridgeEvents> {
     bridgedDevices = new Map<string, BridgedDevice>()
+    private readonly thinq1Agent = new HTTPS.Agent({ keepAlive: true })
 
     /*
      * What the owner calls each appliance, from the ThinQ account - the same names the app shows.
@@ -163,7 +166,7 @@ export class Bridge extends TypedEmitter<BridgeEvents> {
         const clientDevice = this.loadSavedDevice(dev)
         if (!clientDevice) return
 
-        const bridged = new BridgedDevice(clientDevice, dev)
+        const bridged = new BridgedDevice(clientDevice, dev, this.thinq1Agent)
         this.bridgedDevices.set(dev.id, bridged)
         this.emit('started', dev.id)
     }
@@ -200,7 +203,7 @@ export class Bridge extends TypedEmitter<BridgeEvents> {
         const clientDevice = await this.register(client, dev, devType, statusCallback)
         if (!clientDevice) return false
 
-        const bridged = new BridgedDevice(clientDevice, dev)
+        const bridged = new BridgedDevice(clientDevice, dev, this.thinq1Agent)
         this.bridgedDevices.set(dev.id, bridged)
         this.emit('started', dev.id)
         void this.refreshNames(client) // registering may have just given this appliance its name

--- a/bridge/thinq1connection.ts
+++ b/bridge/thinq1connection.ts
@@ -2,7 +2,7 @@ import { Thinq1Device } from './thinqApi'
 import { TypedEmitter } from 'tiny-typed-emitter'
 import * as tls from 'node:tls'
 import { splitter, make as makeFrame } from '@/util/length_prefixed_frame'
-import fetch from 'node-fetch'
+import fetch, { type RequestInit, type Response } from 'node-fetch'
 import * as HTTPS from 'node:https'
 import { randomUUID } from 'node:crypto'
 import log from '@/util/logging'
@@ -13,152 +13,308 @@ type ConnectionEvents = {
     error: (error: Error) => void
 }
 
+type FetchTransport = (url: string, options: RequestInit) => Promise<Response>
+type TlsConnector = (options: tls.ConnectionOptions) => tls.TLSSocket
+
+export type Thinq1ConnectionOptions = {
+    /** Explicit compatibility escape hatch for appliances/endpoints with an invalid certificate chain. */
+    allowInsecureTls?: boolean
+    httpTimeoutMs?: number
+    tlsConnectTimeoutMs?: number
+    heartbeatIntervalMs?: number
+    httpsAgent?: HTTPS.Agent
+    fetchTransport?: FetchTransport
+    tlsConnector?: TlsConnector
+}
+
+const HTTP_TIMEOUT_MS = 10_000
+const TLS_CONNECT_TIMEOUT_MS = 10_000
+const HEARTBEAT_INTERVAL_MS = 60_000
+
 export class Connection extends TypedEmitter<ConnectionEvents> {
     device: Thinq1Device
     socket?: tls.TLSSocket
     lastState?: Buffer
-    isLive: boolean = false
+    isLive = false
+    readonly ready: Promise<void>
 
-    constructor(device: Thinq1Device, options: { reconnectPeriod?: number } = {}) {
+    private readonly options: Thinq1ConnectionOptions
+    private readonly abortController = new AbortController()
+    private ownedAgent?: HTTPS.Agent
+    private heartbeat?: NodeJS.Timeout
+    private destroyed = false
+    private closeEmitted = false
+    private socketErrorSeen = false
+
+    constructor(device: Thinq1Device, options: Thinq1ConnectionOptions = {}) {
         super()
         this.device = device
-        this.start()
+        this.options = options
+        this.ready = this.start()
+        void this.ready.catch((error) => this.handleStartupFailure(error))
     }
 
-    async start() {
+    private async start() {
         const state = this.device.state
+        const rejectUnauthorized = !this.options.allowInsecureTls
+        const agent = this.options.httpsAgent ?? new HTTPS.Agent({ keepAlive: true, rejectUnauthorized })
+        const ownsAgent = this.options.httpsAgent === undefined
+        if (ownsAgent) this.ownedAgent = agent
+        const timeout = setTimeout(
+            () => this.abortController.abort(new Error('ThinQ1 HTTP startup timed out')),
+            this.options.httpTimeoutMs ?? HTTP_TIMEOUT_MS,
+        )
+        timeout.unref()
 
-        const resp = await fetch(state.httpServer + '/lgehadm/api/Device/TotalDeviceInfoSvc', {
-            method: 'POST',
-            headers: {
-                Accept: 'text/xml',
-                'content-type': 'text/xml;charset=utf-8',
-                'x-lgedm-userid': 'lgehadmUser',
-                'x-lgedm-password': 'bxLoLAZ+rp3oJDbEzRuIfAG4YumeqwWM9l6uUH6TupQ=',
-                'x-lgedm-deviceid': this.device.deviceId,
-                'x-lgedm-devicetype': this.device.meta.deviceType!,
-            },
-            body: `<lgedmRoot><countryCode>WW</countryCode><modelName>${this.device.meta.modelName}</modelName><itemList><item>THINQ_TIME_SYNC_URI</item><elementList><elementCode>pushDetailYn</elementCode><elementValue>Y</elementValue></elementList></itemList></lgedmRoot>`,
-            agent: new HTTPS.Agent({ keepAlive: true, rejectUnauthorized: false }),
-        })
-        await resp.text()
+        try {
+            const resp = await (this.options.fetchTransport ?? fetch)(
+                state.httpServer + '/lgehadm/api/Device/TotalDeviceInfoSvc',
+                {
+                    method: 'POST',
+                    headers: {
+                        Accept: 'text/xml',
+                        'content-type': 'text/xml;charset=utf-8',
+                        'x-lgedm-userid': 'lgehadmUser',
+                        'x-lgedm-password': 'bxLoLAZ+rp3oJDbEzRuIfAG4YumeqwWM9l6uUH6TupQ=',
+                        'x-lgedm-deviceid': this.device.deviceId,
+                        'x-lgedm-devicetype': this.device.meta.deviceType!,
+                    },
+                    body: `<lgedmRoot><countryCode>WW</countryCode><modelName>${this.device.meta.modelName}</modelName><itemList><item>THINQ_TIME_SYNC_URI</item><elementList><elementCode>pushDetailYn</elementCode><elementValue>Y</elementValue></elementList></itemList></lgedmRoot>`,
+                    agent,
+                    signal: this.abortController.signal,
+                },
+            )
+            if (!resp.ok) throw new Error(`ThinQ1 HTTP startup failed with status ${resp.status}`)
+            await resp.text()
+        } finally {
+            clearTimeout(timeout)
+            if (ownsAgent) agent.destroy()
+            if (this.ownedAgent === agent) this.ownedAgent = undefined
+        }
+
+        if (this.destroyed || this.abortController.signal.aborted)
+            throw new Error('ThinQ1 connection destroyed during startup')
+
+        const endpoint = new URL(state.rtiServer.includes('://') ? state.rtiServer : `tls://${state.rtiServer}`)
+        const host = endpoint.hostname
+        const port = Number(endpoint.port)
+        if (!host || !Number.isInteger(port) || port < 1 || port > 65535)
+            throw new Error(`Invalid ThinQ1 RTI endpoint: ${state.rtiServer}`)
 
         log('bridge', `${this.device.deviceId} connecting to ${state.rtiServer}`)
-        const [host, port] = state.rtiServer.split(':')
-
-        const sendAlive = () => {
-            // DevInfo Alive
-            // CmdWId: random
-            this.writeJSON({
-                Header: { 'x-lgedm-deviceId': this.device.deviceId },
-                Body: {
-                    CmdWId: randomUUID(),
-                    Cmd: 'Alive',
-                },
-            })
-        }
-        this.socket = tls.connect(
-            {
-                host,
-                port: Number(port),
-                rejectUnauthorized: false /*FIXME*/,
-            },
-            () => {
-                log('bridge', `${this.device.deviceId} connected`)
-                setInterval(sendAlive, 60000)
-                sendAlive()
-
-                if (this.lastState) {
-                    // DevInfo message
-                    // CmdWId: random
-                    this.writeJSON({
-                        Header: { 'x-lgedm-deviceId': this.device.deviceId },
-                        Body: {
-                            CmdWId: randomUUID(),
-                            Cmd: 'DevInfo',
-                            Format: 'B64',
-                            Data: this.lastState.toString('base64'),
-                        },
-                    })
-                }
-            },
-        )
-
-        this.socket.on(
-            'data',
-            splitter((payload: Buffer) => {
-                try {
-                    const str = payload.toString('utf-8')
-                    const j = JSON.parse(str)
-                    if (typeof j.Body === 'object') {
-                        if (j.Body.CmdOpt === 'Start') {
-                            this.isLive = true
-                            if (this.lastState) this.send(this.lastState)
-
-                            // don't forward upstream Start & Stop to the actual device
-                            return
-                        }
-
-                        if (j.Body.CmdOpt === 'Stop') {
-                            this.isLive = false
-                            // don't forward upstream Start & Stop to the actual device
-                            return
-                        }
-
-                        log('bridge', `${this.device.deviceId} <- ${JSON.stringify(j.Body)}`)
-                        this.emit('data', j.Body)
-
-                        if (j.Body.ReturnCode === undefined) {
-                            // ACK
-                            // CmdWId: echo
-                            // ReturnCode: 0000
-                            this.writeJSON({
-                                Header: { 'x-lgedm-deviceId': this.device.deviceId },
-                                Body: {
-                                    CmdWId: j.Body.CmdWId,
-                                    ReturnCode: '0000',
-                                },
-                            })
-                        }
-                    }
-                } catch (err) {
-                    console.log(err)
-                }
-            }),
-        )
-
-        this.socket.on('close', () => {
-            log('bridge', `${this.device.deviceId} disconnected`)
-            this.emit('close')
+        const socket = (this.options.tlsConnector ?? tls.connect)({
+            host,
+            port,
+            servername: host,
+            rejectUnauthorized,
         })
-        this.socket.on('error', (err) => this.emit('error', err))
+        if (this.destroyed) {
+            socket.destroy()
+            throw new Error('ThinQ1 connection destroyed during startup')
+        }
+        this.socket = socket
+        this.attachSocket(socket)
+
+        await new Promise<void>((resolve, reject) => {
+            const connectTimeout = setTimeout(() => {
+                socket.destroy(new Error('ThinQ1 RTI TLS connection timed out'))
+            }, this.options.tlsConnectTimeoutMs ?? TLS_CONNECT_TIMEOUT_MS)
+            connectTimeout.unref()
+
+            const cleanup = () => {
+                clearTimeout(connectTimeout)
+                socket.removeListener('secureConnect', onSecureConnect)
+                socket.removeListener('error', onStartupError)
+                socket.removeListener('close', onStartupClose)
+                this.abortController.signal.removeEventListener('abort', onAbort)
+            }
+            const onSecureConnect = () => {
+                cleanup()
+                if (this.destroyed) {
+                    socket.destroy()
+                    reject(new Error('ThinQ1 connection destroyed during startup'))
+                    return
+                }
+                log('bridge', `${this.device.deviceId} connected`)
+                this.startHeartbeat()
+                this.sendAlive()
+                if (this.lastState) this.sendDeviceInfo(this.lastState)
+                resolve()
+            }
+            const onStartupError = (error: Error) => {
+                cleanup()
+                reject(error)
+            }
+            const onStartupClose = () => {
+                cleanup()
+                if (this.destroyed) reject(new Error('ThinQ1 connection destroyed during startup'))
+                else reject(new Error('ThinQ1 RTI TLS connection closed before secure connect'))
+            }
+            const onAbort = () => {
+                cleanup()
+                socket.destroy()
+                reject(new Error('ThinQ1 connection destroyed during startup'))
+            }
+            socket.once('secureConnect', onSecureConnect)
+            socket.once('error', onStartupError)
+            socket.once('close', onStartupClose)
+            this.abortController.signal.addEventListener('abort', onAbort, { once: true })
+            if (this.abortController.signal.aborted) onAbort()
+        })
+    }
+
+    private attachSocket(socket: tls.TLSSocket) {
+        const split = splitter((payload: Buffer) => this.handlePayload(payload))
+        socket.on('data', (data) => {
+            try {
+                split(data)
+            } catch (error) {
+                this.failSocket(error)
+            }
+        })
+        socket.on('end', () => {
+            try {
+                split.end()
+            } catch (error) {
+                this.failSocket(error)
+            }
+        })
+        socket.on('close', () => {
+            this.stopHeartbeat()
+            if (this.socket === socket) this.socket = undefined
+            log('bridge', `${this.device.deviceId} disconnected`)
+            this.emitClose()
+        })
+        socket.on('error', (error) => {
+            if (!this.destroyed) {
+                this.socketErrorSeen = true
+                this.emit('error', error)
+            }
+        })
+    }
+
+    private handlePayload(payload: Buffer) {
+        try {
+            const j = JSON.parse(payload.toString('utf-8'))
+            if (!j || typeof j.Body !== 'object' || j.Body === null) return
+            if (j.Body.CmdOpt === 'Start') {
+                this.isLive = true
+                if (this.lastState) this.send(this.lastState)
+                // don't forward upstream Start & Stop to the actual device
+                return
+            }
+            if (j.Body.CmdOpt === 'Stop') {
+                this.isLive = false
+                // don't forward upstream Start & Stop to the actual device
+                return
+            }
+
+            log('bridge', `${this.device.deviceId} <- ${JSON.stringify(j.Body)}`)
+            this.emit('data', j.Body)
+
+            if (j.Body.ReturnCode === undefined) {
+                // ACK
+                // CmdWId: echo
+                // ReturnCode: 0000
+                this.writeJSON({
+                    Header: { 'x-lgedm-deviceId': this.device.deviceId },
+                    Body: { CmdWId: j.Body.CmdWId, ReturnCode: '0000' },
+                })
+            }
+        } catch (error) {
+            this.failSocket(error)
+        }
+    }
+
+    private sendAlive() {
+        // DevInfo Alive
+        // CmdWId: random
+        this.writeJSON({
+            Header: { 'x-lgedm-deviceId': this.device.deviceId },
+            Body: { CmdWId: randomUUID(), Cmd: 'Alive' },
+        })
+    }
+
+    private sendDeviceInfo(data: Buffer) {
+        // DevInfo message
+        // CmdWId: random
+        this.writeJSON({
+            Header: { 'x-lgedm-deviceId': this.device.deviceId },
+            Body: {
+                CmdWId: randomUUID(),
+                Cmd: 'DevInfo',
+                Format: 'B64',
+                Data: data.toString('base64'),
+            },
+        })
+    }
+
+    private sendStatus(data: Buffer) {
+        // device status message
+        // CmdWId: n-$DeviceID
+        // ReturnCode: 0000
+        this.writeJSON({
+            Header: { 'x-lgedm-deviceId': this.device.deviceId },
+            Body: {
+                CmdWId: `n-${this.device.deviceId}`,
+                ReturnCode: '0000',
+                Format: 'B64',
+                Data: data.toString('base64'),
+            },
+        })
+    }
+
+    private startHeartbeat() {
+        this.stopHeartbeat()
+        this.heartbeat = setInterval(() => this.sendAlive(), this.options.heartbeatIntervalMs ?? HEARTBEAT_INTERVAL_MS)
+        this.heartbeat.unref()
+    }
+
+    private stopHeartbeat() {
+        if (this.heartbeat) clearInterval(this.heartbeat)
+        this.heartbeat = undefined
+    }
+
+    private failSocket(error: unknown) {
+        const normalized = error instanceof Error ? error : new Error(String(error))
+        if (!this.destroyed) this.emit('error', normalized)
+        this.socket?.destroy()
+    }
+
+    private handleStartupFailure(error: unknown) {
+        if (this.destroyed) return
+        const normalized = error instanceof Error ? error : new Error(String(error))
+        if (!this.socketErrorSeen) this.emit('error', normalized)
+        if (this.socket) this.socket.destroy()
+        else this.emitClose()
+    }
+
+    private emitClose() {
+        if (this.closeEmitted) return
+        this.closeEmitted = true
+        this.emit('close')
     }
 
     writeJSON(json: unknown) {
-        this.socket?.write(makeFrame(JSON.stringify(json)))
+        if (!this.destroyed) this.socket?.write(makeFrame(JSON.stringify(json)))
     }
 
     send(data: Buffer) {
-        // device status message
-        // CmdWId: n-$DevideID
-        // ReturnCode: 0000
         this.lastState = data
         log('bridge', `${this.device.deviceId} -> ${data.toString('hex')}`)
-
-        if (this.isLive)
-            this.writeJSON({
-                Header: { 'x-lgedm-deviceId': this.device.deviceId },
-                Body: {
-                    CmdWId: `n-${this.device.deviceId}`,
-                    ReturnCode: '0000',
-                    Format: 'B64',
-                    Data: data.toString('base64'),
-                },
-            })
+        if (this.isLive) this.sendStatus(data)
     }
 
     destroy() {
-        this.socket?.destroy()
+        if (this.destroyed) return
+        this.destroyed = true
+        this.isLive = false
+        this.abortController.abort(new Error('ThinQ1 connection destroyed'))
+        this.stopHeartbeat()
+        this.ownedAgent?.destroy()
+        this.ownedAgent = undefined
+        const socket = this.socket
         this.socket = undefined
+        socket?.destroy()
     }
 }

--- a/bridge/thinq1connection.ts
+++ b/bridge/thinq1connection.ts
@@ -2,7 +2,7 @@ import { Thinq1Device } from './thinqApi'
 import { TypedEmitter } from 'tiny-typed-emitter'
 import * as tls from 'node:tls'
 import { splitter, make as makeFrame } from '@/util/length_prefixed_frame'
-import fetch from 'node-fetch'
+import fetch, { type RequestInit, type Response } from 'node-fetch'
 import * as HTTPS from 'node:https'
 import { randomUUID } from 'node:crypto'
 import log from '@/util/logging'
@@ -13,152 +13,306 @@ type ConnectionEvents = {
     error: (error: Error) => void
 }
 
+type FetchTransport = (url: string, options: RequestInit) => Promise<Response>
+type TlsConnector = (options: tls.ConnectionOptions) => tls.TLSSocket
+
+export type Thinq1ConnectionOptions = {
+    /** Explicit compatibility escape hatch for appliances/endpoints with an invalid certificate chain. */
+    allowInsecureTls?: boolean
+    httpTimeoutMs?: number
+    tlsConnectTimeoutMs?: number
+    heartbeatIntervalMs?: number
+    fetchTransport?: FetchTransport
+    tlsConnector?: TlsConnector
+}
+
+const HTTP_TIMEOUT_MS = 10_000
+const TLS_CONNECT_TIMEOUT_MS = 10_000
+const HEARTBEAT_INTERVAL_MS = 60_000
+
 export class Connection extends TypedEmitter<ConnectionEvents> {
     device: Thinq1Device
     socket?: tls.TLSSocket
     lastState?: Buffer
-    isLive: boolean = false
+    isLive = false
+    readonly ready: Promise<void>
 
-    constructor(device: Thinq1Device, options: { reconnectPeriod?: number } = {}) {
+    private readonly options: Thinq1ConnectionOptions
+    private readonly abortController = new AbortController()
+    private agent?: HTTPS.Agent
+    private heartbeat?: NodeJS.Timeout
+    private destroyed = false
+    private closeEmitted = false
+    private socketErrorSeen = false
+
+    constructor(device: Thinq1Device, options: Thinq1ConnectionOptions = {}) {
         super()
         this.device = device
-        this.start()
+        this.options = options
+        this.ready = this.start()
+        void this.ready.catch((error) => this.handleStartupFailure(error))
     }
 
-    async start() {
+    private async start() {
         const state = this.device.state
+        const rejectUnauthorized = !this.options.allowInsecureTls
+        const agent = new HTTPS.Agent({ keepAlive: true, rejectUnauthorized })
+        this.agent = agent
+        const timeout = setTimeout(
+            () => this.abortController.abort(new Error('ThinQ1 HTTP startup timed out')),
+            this.options.httpTimeoutMs ?? HTTP_TIMEOUT_MS,
+        )
+        timeout.unref()
 
-        const resp = await fetch(state.httpServer + '/lgehadm/api/Device/TotalDeviceInfoSvc', {
-            method: 'POST',
-            headers: {
-                Accept: 'text/xml',
-                'content-type': 'text/xml;charset=utf-8',
-                'x-lgedm-userid': 'lgehadmUser',
-                'x-lgedm-password': 'bxLoLAZ+rp3oJDbEzRuIfAG4YumeqwWM9l6uUH6TupQ=',
-                'x-lgedm-deviceid': this.device.deviceId,
-                'x-lgedm-devicetype': this.device.meta.deviceType!,
-            },
-            body: `<lgedmRoot><countryCode>WW</countryCode><modelName>${this.device.meta.modelName}</modelName><itemList><item>THINQ_TIME_SYNC_URI</item><elementList><elementCode>pushDetailYn</elementCode><elementValue>Y</elementValue></elementList></itemList></lgedmRoot>`,
-            agent: new HTTPS.Agent({ keepAlive: true, rejectUnauthorized: false }),
-        })
-        await resp.text()
+        try {
+            const resp = await (this.options.fetchTransport ?? fetch)(
+                state.httpServer + '/lgehadm/api/Device/TotalDeviceInfoSvc',
+                {
+                    method: 'POST',
+                    headers: {
+                        Accept: 'text/xml',
+                        'content-type': 'text/xml;charset=utf-8',
+                        'x-lgedm-userid': 'lgehadmUser',
+                        'x-lgedm-password': 'bxLoLAZ+rp3oJDbEzRuIfAG4YumeqwWM9l6uUH6TupQ=',
+                        'x-lgedm-deviceid': this.device.deviceId,
+                        'x-lgedm-devicetype': this.device.meta.deviceType!,
+                    },
+                    body: `<lgedmRoot><countryCode>WW</countryCode><modelName>${this.device.meta.modelName}</modelName><itemList><item>THINQ_TIME_SYNC_URI</item><elementList><elementCode>pushDetailYn</elementCode><elementValue>Y</elementValue></elementList></itemList></lgedmRoot>`,
+                    agent,
+                    signal: this.abortController.signal,
+                },
+            )
+            if (!resp.ok) throw new Error(`ThinQ1 HTTP startup failed with status ${resp.status}`)
+            await resp.text()
+        } finally {
+            clearTimeout(timeout)
+            agent.destroy()
+            if (this.agent === agent) this.agent = undefined
+        }
+
+        if (this.destroyed || this.abortController.signal.aborted)
+            throw new Error('ThinQ1 connection destroyed during startup')
+
+        const endpoint = new URL(state.rtiServer.includes('://') ? state.rtiServer : `tls://${state.rtiServer}`)
+        const host = endpoint.hostname
+        const port = Number(endpoint.port)
+        if (!host || !Number.isInteger(port) || port < 1 || port > 65535)
+            throw new Error(`Invalid ThinQ1 RTI endpoint: ${state.rtiServer}`)
 
         log('bridge', `${this.device.deviceId} connecting to ${state.rtiServer}`)
-        const [host, port] = state.rtiServer.split(':')
-
-        const sendAlive = () => {
-            // DevInfo Alive
-            // CmdWId: random
-            this.writeJSON({
-                Header: { 'x-lgedm-deviceId': this.device.deviceId },
-                Body: {
-                    CmdWId: randomUUID(),
-                    Cmd: 'Alive',
-                },
-            })
-        }
-        this.socket = tls.connect(
-            {
-                host,
-                port: Number(port),
-                rejectUnauthorized: false /*FIXME*/,
-            },
-            () => {
-                log('bridge', `${this.device.deviceId} connected`)
-                setInterval(sendAlive, 60000)
-                sendAlive()
-
-                if (this.lastState) {
-                    // DevInfo message
-                    // CmdWId: random
-                    this.writeJSON({
-                        Header: { 'x-lgedm-deviceId': this.device.deviceId },
-                        Body: {
-                            CmdWId: randomUUID(),
-                            Cmd: 'DevInfo',
-                            Format: 'B64',
-                            Data: this.lastState.toString('base64'),
-                        },
-                    })
-                }
-            },
-        )
-
-        this.socket.on(
-            'data',
-            splitter((payload: Buffer) => {
-                try {
-                    const str = payload.toString('utf-8')
-                    const j = JSON.parse(str)
-                    if (typeof j.Body === 'object') {
-                        if (j.Body.CmdOpt === 'Start') {
-                            this.isLive = true
-                            if (this.lastState) this.send(this.lastState)
-
-                            // don't forward upstream Start & Stop to the actual device
-                            return
-                        }
-
-                        if (j.Body.CmdOpt === 'Stop') {
-                            this.isLive = false
-                            // don't forward upstream Start & Stop to the actual device
-                            return
-                        }
-
-                        log('bridge', `${this.device.deviceId} <- ${JSON.stringify(j.Body)}`)
-                        this.emit('data', j.Body)
-
-                        if (j.Body.ReturnCode === undefined) {
-                            // ACK
-                            // CmdWId: echo
-                            // ReturnCode: 0000
-                            this.writeJSON({
-                                Header: { 'x-lgedm-deviceId': this.device.deviceId },
-                                Body: {
-                                    CmdWId: j.Body.CmdWId,
-                                    ReturnCode: '0000',
-                                },
-                            })
-                        }
-                    }
-                } catch (err) {
-                    console.log(err)
-                }
-            }),
-        )
-
-        this.socket.on('close', () => {
-            log('bridge', `${this.device.deviceId} disconnected`)
-            this.emit('close')
+        const socket = (this.options.tlsConnector ?? tls.connect)({
+            host,
+            port,
+            servername: host,
+            rejectUnauthorized,
         })
-        this.socket.on('error', (err) => this.emit('error', err))
+        if (this.destroyed) {
+            socket.destroy()
+            throw new Error('ThinQ1 connection destroyed during startup')
+        }
+        this.socket = socket
+        this.attachSocket(socket)
+
+        await new Promise<void>((resolve, reject) => {
+            const connectTimeout = setTimeout(() => {
+                socket.destroy(new Error('ThinQ1 RTI TLS connection timed out'))
+            }, this.options.tlsConnectTimeoutMs ?? TLS_CONNECT_TIMEOUT_MS)
+            connectTimeout.unref()
+
+            const cleanup = () => {
+                clearTimeout(connectTimeout)
+                socket.removeListener('secureConnect', onSecureConnect)
+                socket.removeListener('error', onStartupError)
+                socket.removeListener('close', onStartupClose)
+                this.abortController.signal.removeEventListener('abort', onAbort)
+            }
+            const onSecureConnect = () => {
+                cleanup()
+                if (this.destroyed) {
+                    socket.destroy()
+                    reject(new Error('ThinQ1 connection destroyed during startup'))
+                    return
+                }
+                log('bridge', `${this.device.deviceId} connected`)
+                this.startHeartbeat()
+                this.sendAlive()
+                if (this.lastState) this.sendDeviceInfo(this.lastState)
+                resolve()
+            }
+            const onStartupError = (error: Error) => {
+                cleanup()
+                reject(error)
+            }
+            const onStartupClose = () => {
+                cleanup()
+                if (this.destroyed) reject(new Error('ThinQ1 connection destroyed during startup'))
+                else reject(new Error('ThinQ1 RTI TLS connection closed before secure connect'))
+            }
+            const onAbort = () => {
+                cleanup()
+                socket.destroy()
+                reject(new Error('ThinQ1 connection destroyed during startup'))
+            }
+            socket.once('secureConnect', onSecureConnect)
+            socket.once('error', onStartupError)
+            socket.once('close', onStartupClose)
+            this.abortController.signal.addEventListener('abort', onAbort, { once: true })
+            if (this.abortController.signal.aborted) onAbort()
+        })
+    }
+
+    private attachSocket(socket: tls.TLSSocket) {
+        const split = splitter((payload: Buffer) => this.handlePayload(payload))
+        socket.on('data', (data) => {
+            try {
+                split(data)
+            } catch (error) {
+                this.failSocket(error)
+            }
+        })
+        socket.on('end', () => {
+            try {
+                split.end()
+            } catch (error) {
+                this.failSocket(error)
+            }
+        })
+        socket.on('close', () => {
+            this.stopHeartbeat()
+            if (this.socket === socket) this.socket = undefined
+            log('bridge', `${this.device.deviceId} disconnected`)
+            this.emitClose()
+        })
+        socket.on('error', (error) => {
+            if (!this.destroyed) {
+                this.socketErrorSeen = true
+                this.emit('error', error)
+            }
+        })
+    }
+
+    private handlePayload(payload: Buffer) {
+        try {
+            const j = JSON.parse(payload.toString('utf-8'))
+            if (!j || typeof j.Body !== 'object' || j.Body === null) return
+            if (j.Body.CmdOpt === 'Start') {
+                this.isLive = true
+                if (this.lastState) this.send(this.lastState)
+                // don't forward upstream Start & Stop to the actual device
+                return
+            }
+            if (j.Body.CmdOpt === 'Stop') {
+                this.isLive = false
+                // don't forward upstream Start & Stop to the actual device
+                return
+            }
+
+            log('bridge', `${this.device.deviceId} <- ${JSON.stringify(j.Body)}`)
+            this.emit('data', j.Body)
+
+            if (j.Body.ReturnCode === undefined) {
+                // ACK
+                // CmdWId: echo
+                // ReturnCode: 0000
+                this.writeJSON({
+                    Header: { 'x-lgedm-deviceId': this.device.deviceId },
+                    Body: { CmdWId: j.Body.CmdWId, ReturnCode: '0000' },
+                })
+            }
+        } catch (error) {
+            this.failSocket(error)
+        }
+    }
+
+    private sendAlive() {
+        // DevInfo Alive
+        // CmdWId: random
+        this.writeJSON({
+            Header: { 'x-lgedm-deviceId': this.device.deviceId },
+            Body: { CmdWId: randomUUID(), Cmd: 'Alive' },
+        })
+    }
+
+    private sendDeviceInfo(data: Buffer) {
+        // DevInfo message
+        // CmdWId: random
+        this.writeJSON({
+            Header: { 'x-lgedm-deviceId': this.device.deviceId },
+            Body: {
+                CmdWId: randomUUID(),
+                Cmd: 'DevInfo',
+                Format: 'B64',
+                Data: data.toString('base64'),
+            },
+        })
+    }
+
+    private sendStatus(data: Buffer) {
+        // device status message
+        // CmdWId: n-$DeviceID
+        // ReturnCode: 0000
+        this.writeJSON({
+            Header: { 'x-lgedm-deviceId': this.device.deviceId },
+            Body: {
+                CmdWId: `n-${this.device.deviceId}`,
+                ReturnCode: '0000',
+                Format: 'B64',
+                Data: data.toString('base64'),
+            },
+        })
+    }
+
+    private startHeartbeat() {
+        this.stopHeartbeat()
+        this.heartbeat = setInterval(() => this.sendAlive(), this.options.heartbeatIntervalMs ?? HEARTBEAT_INTERVAL_MS)
+        this.heartbeat.unref()
+    }
+
+    private stopHeartbeat() {
+        if (this.heartbeat) clearInterval(this.heartbeat)
+        this.heartbeat = undefined
+    }
+
+    private failSocket(error: unknown) {
+        const normalized = error instanceof Error ? error : new Error(String(error))
+        if (!this.destroyed) this.emit('error', normalized)
+        this.socket?.destroy()
+    }
+
+    private handleStartupFailure(error: unknown) {
+        if (this.destroyed) return
+        const normalized = error instanceof Error ? error : new Error(String(error))
+        if (!this.socketErrorSeen) this.emit('error', normalized)
+        if (this.socket) this.socket.destroy()
+        else this.emitClose()
+    }
+
+    private emitClose() {
+        if (this.closeEmitted) return
+        this.closeEmitted = true
+        this.emit('close')
     }
 
     writeJSON(json: unknown) {
-        this.socket?.write(makeFrame(JSON.stringify(json)))
+        if (!this.destroyed) this.socket?.write(makeFrame(JSON.stringify(json)))
     }
 
     send(data: Buffer) {
-        // device status message
-        // CmdWId: n-$DevideID
-        // ReturnCode: 0000
         this.lastState = data
         log('bridge', `${this.device.deviceId} -> ${data.toString('hex')}`)
-
-        if (this.isLive)
-            this.writeJSON({
-                Header: { 'x-lgedm-deviceId': this.device.deviceId },
-                Body: {
-                    CmdWId: `n-${this.device.deviceId}`,
-                    ReturnCode: '0000',
-                    Format: 'B64',
-                    Data: data.toString('base64'),
-                },
-            })
+        if (this.isLive) this.sendStatus(data)
     }
 
     destroy() {
-        this.socket?.destroy()
+        if (this.destroyed) return
+        this.destroyed = true
+        this.isLive = false
+        this.abortController.abort(new Error('ThinQ1 connection destroyed'))
+        this.stopHeartbeat()
+        this.agent?.destroy()
+        this.agent = undefined
+        const socket = this.socket
         this.socket = undefined
+        socket?.destroy()
     }
 }

--- a/bridge/thinq2connection.ts
+++ b/bridge/thinq2connection.ts
@@ -12,18 +12,25 @@ type ConnectionEvents = {
 export class Connection extends TypedEmitter<ConnectionEvents> {
     mqtt: mqtt.MqttClient
     mid = 10000
+    private destroyed = false
+    private readonly pendingOperations = new Set<(error: Error) => void>()
 
-    constructor(readonly device: Thinq2Device) {
+    constructor(
+        readonly device: Thinq2Device,
+        mqttClient?: mqtt.MqttClient,
+    ) {
         super()
         const state = this.device.state!
         log('bridge', `${this.device.deviceId} connecting to ${state.mqttServer}`)
-        this.mqtt = mqtt.connect(state.mqttServer.replace('ssl', 'mqtts'), {
-            ca: state.caCertificate,
-            key: state.privateKey,
-            cert: state.certificate,
-            clientId: this.device.deviceId,
-            reconnectPeriod: 0, // no auto-reconnect
-        })
+        this.mqtt =
+            mqttClient ??
+            mqtt.connect(state.mqttServer.replace('ssl', 'mqtts'), {
+                ca: state.caCertificate,
+                key: state.privateKey,
+                cert: state.certificate,
+                clientId: this.device.deviceId,
+                reconnectPeriod: 0, // no auto-reconnect
+            })
 
         this.mqtt.on('message', (topic, message, packet) => {
             try {
@@ -56,60 +63,110 @@ export class Connection extends TypedEmitter<ConnectionEvents> {
             }
         })
 
-        this.mqtt.on('connect', async () => {
-            log('bridge', `${this.device.deviceId} connected`)
-            await this.mqtt.subscribe(this.device.state!.subTopic)
-            await this.mqtt.publish(
-                this.device.state!.provTopic,
-                JSON.stringify({
-                    mid: ++this.mid,
-                    did: this.device.deviceId,
-                    kind: this.device.meta.modelName,
-                    cmd: 'preDeploy',
-                    rssi: -48,
-                    fs: 'idle',
-                    data: {
-                        appInfo: {
-                            modelName: this.device.meta.modelName,
-                            modelLanguage: this.device.state!.countryCode,
-                            softVer: '690409',
-                            ruleVer: '2.0.11',
-                            countryCode: this.device.state!.countryCode,
-                            subCountryCode: this.device.state!.countryCode,
-                            appVersion: 'clip_hna_v1.9.183',
-                            modemType: 'RTK_RTL8711am',
-                            regionalCode: 'eic',
-                            timezone: '+0100',
-                            svcCode: 'SVC202',
-                            HomeApSsid: 'whatever',
-                            DeviceType: '',
-                            ruleEngine: 'y',
-                            protocolVer: '1',
-                            oneshot: 'y',
-                            size: 1572864,
-                            fwUpgradeInfo: {
-                                upgSched: {
-                                    cmd: 'none',
-                                    upgUtc: '0',
-                                },
-                            },
-                        },
-                        platformInfo: {
-                            provisioningKey: this.device.meta.modelName,
-                            version: 'clip_v2.00.15.05-RTK_RTL8711am-SDK-8-RELEASE',
-                        },
-                    },
-                    type: 0,
-                }),
-                { qos: 1 },
-            )
+        // mqtt.js does not await its listeners, so a rejection from an async 'connect' handler had
+        // nowhere to go and surfaced as an unhandled rejection. Catch it, tear the connection down,
+        // and forward it to the same 'error' event mqtt errors already use.
+        this.mqtt.on('connect', () => {
+            void this.handleConnect().catch((error: Error) => {
+                if (this.destroyed) return
+                this.destroy()
+                this.emit('error', error)
+            })
         })
 
         this.mqtt.on('close', () => this.emit('close'))
         this.mqtt.on('error', (err) => this.emit('error', err))
     }
 
+    private async handleConnect() {
+        if (this.destroyed) return
+        log('bridge', `${this.device.deviceId} connected`)
+        await this.subscribe(this.device.state!.subTopic)
+        if (this.destroyed) return
+        await this.publish(
+            this.device.state!.provTopic,
+            JSON.stringify({
+                mid: ++this.mid,
+                did: this.device.deviceId,
+                kind: this.device.meta.modelName,
+                cmd: 'preDeploy',
+                rssi: -48,
+                fs: 'idle',
+                data: {
+                    appInfo: {
+                        modelName: this.device.meta.modelName,
+                        modelLanguage: this.device.state!.countryCode,
+                        softVer: '690409',
+                        ruleVer: '2.0.11',
+                        countryCode: this.device.state!.countryCode,
+                        subCountryCode: this.device.state!.countryCode,
+                        appVersion: 'clip_hna_v1.9.183',
+                        modemType: 'RTK_RTL8711am',
+                        regionalCode: 'eic',
+                        timezone: '+0100',
+                        svcCode: 'SVC202',
+                        HomeApSsid: 'whatever',
+                        DeviceType: '',
+                        ruleEngine: 'y',
+                        protocolVer: '1',
+                        oneshot: 'y',
+                        size: 1572864,
+                        fwUpgradeInfo: {
+                            upgSched: {
+                                cmd: 'none',
+                                upgUtc: '0',
+                            },
+                        },
+                    },
+                    platformInfo: {
+                        provisioningKey: this.device.meta.modelName,
+                        version: 'clip_v2.00.15.05-RTK_RTL8711am-SDK-8-RELEASE',
+                    },
+                },
+                type: 0,
+            }),
+            { qos: 1 },
+        )
+    }
+
+    private subscribe(topic: string) {
+        return this.mqttOperation((done) => this.mqtt.subscribe(topic, done))
+    }
+
+    private publish(topic: string, payload: string, options: mqtt.IClientPublishOptions) {
+        return this.mqttOperation((done) => this.mqtt.publish(topic, payload, options, done))
+    }
+
+    // A subscribe or publish callback never fires once the client is gone, so every in-flight
+    // operation registers a cancel hook that destroy() settles with an error.
+    private mqttOperation(invoke: (done: (error?: Error | null) => void) => unknown) {
+        return new Promise<void>((resolve, reject) => {
+            let settled = false
+            const cancel = (error: Error) => finish(error)
+            const finish = (error?: Error | null) => {
+                if (settled) return
+                settled = true
+                this.pendingOperations.delete(cancel)
+                if (error) reject(error)
+                else resolve()
+            }
+
+            this.pendingOperations.add(cancel)
+            if (this.destroyed) {
+                cancel(new Error('MQTT connection destroyed'))
+                return
+            }
+
+            try {
+                invoke(finish)
+            } catch (error) {
+                finish(error as Error)
+            }
+        })
+    }
+
     send(data: string | Buffer) {
+        if (this.destroyed) return
         if (Buffer.isBuffer(data)) data = data.toString('hex').toUpperCase()
 
         log('bridge', `${this.device.deviceId} -> ${data}`)
@@ -129,6 +186,10 @@ export class Connection extends TypedEmitter<ConnectionEvents> {
     }
 
     destroy() {
-        this.mqtt.end()
+        if (this.destroyed) return
+        this.destroyed = true
+        const error = new Error('MQTT connection destroyed')
+        for (const cancel of [...this.pendingOperations]) cancel(error)
+        this.mqtt.end(true)
     }
 }

--- a/cloud/thinq1/http.ts
+++ b/cloud/thinq1/http.ts
@@ -4,34 +4,51 @@ import { XMLParser, XMLBuilder, XMLValidator } from 'fast-xml-parser'
 import { Metadata } from '../thinq'
 
 const XML_HEADER = '<?xml version="1.0" encoding="utf-8" standalone="yes"?>'
+const MAX_XML_BODY_LENGTH = 1_000_000
 
-const deviceMeta: Record<string, Metadata> = {}
+// A Map (rather than a plain object) so a device id can never collide with an
+// Object.prototype key.
+const deviceMeta = new Map<string, Metadata>()
 export function getDeviceMetadata(id: string) {
-    return deviceMeta[id]
+    return deviceMeta.get(id)
 }
 
 function xmlParser(req: Request, res: Response, next: () => void) {
     const buffers: Buffer[] = []
     let length = 0
-    let error = false
+    let stopped = false
 
-    req.on('data', (data) => {
-        if (!error) {
-            buffers.push(data)
-            length += data.length
-            if (length > 1000000) {
-                res.status(400).end()
-                error = true
-            }
+    req.on('data', (data: Buffer) => {
+        if (stopped) return
+        length += data.length
+        if (length > MAX_XML_BODY_LENGTH) {
+            stopped = true
+            buffers.length = 0
+            res.status(413).end()
+            return
         }
+        buffers.push(data)
     })
 
     req.on('end', () => {
-        if (!error) {
-            req.body = new XMLParser().parse(Buffer.concat(buffers))
+        if (stopped) return
+        stopped = true
+        try {
+            const xml = Buffer.concat(buffers).toString('utf-8')
+            buffers.length = 0
+            if (XMLValidator.validate(xml) !== true) return res.status(400).end()
+            req.body = new XMLParser().parse(xml)
             next()
+        } catch {
+            res.status(400).end()
         }
     })
+    const discard = () => {
+        stopped = true
+        buffers.length = 0
+    }
+    req.on('aborted', discard)
+    req.on('error', discard)
 }
 
 export function routes(config: Config) {
@@ -50,11 +67,11 @@ export function routes(config: Config) {
         if (!deviceId) return res.status(400).end()
 
         if (modelName && deviceType)
-            deviceMeta[deviceId] = {
+            deviceMeta.set(deviceId, {
                 deviceType,
                 modelId: modelName,
                 modelName,
-            }
+            })
 
         if (req.body?.lgedmRoot?.itemList?.item === 'DM_SETTING_INFO_GET_URI') {
             response.itemList = {

--- a/tests/bridge/thinq1connection.test.ts
+++ b/tests/bridge/thinq1connection.test.ts
@@ -1,0 +1,247 @@
+import assert from 'node:assert/strict'
+import { EventEmitter, once } from 'node:events'
+import { createServer } from 'node:tls'
+import { test } from 'node:test'
+import { Response } from 'node-fetch'
+import { Connection, type Thinq1ConnectionOptions } from '@/bridge/thinq1connection'
+import { Thinq1Device } from '@/bridge/thinqApi'
+import type { TLSSocket } from 'node:tls'
+import { Agent } from 'node:https'
+
+class FakeTlsSocket extends EventEmitter {
+    destroyed = false
+    writes: Buffer[] = []
+
+    write(data: Buffer) {
+        this.writes.push(data)
+        return true
+    }
+
+    destroy(error?: Error) {
+        if (this.destroyed) return this
+        this.destroyed = true
+        if (error) this.emit('error', error)
+        queueMicrotask(() => this.emit('close'))
+        return this
+    }
+}
+
+function device(rtiServer = 'rti.example:443') {
+    return new Thinq1Device(
+        '48552db0-1ab4-11e9-b4fb-7c1c4ec8cc53',
+        { modelId: 'model', modelName: 'model', deviceType: '101' },
+        { httpServer: 'https://http.example', rtiServer },
+    )
+}
+
+const okFetch: NonNullable<Thinq1ConnectionOptions['fetchTransport']> = async () =>
+    new Response('<lgedmRoot/>', { status: 200 })
+
+function waitForClose(connection: Connection) {
+    return new Promise<void>((resolve) => connection.once('close', resolve))
+}
+
+/**
+ * The connection's own deadlines are unref'd so a pending timer never holds the add-on open. A test
+ * that waits for one of them is then the only thing left on the loop, and the runner would cancel it
+ * as "still pending" before the timer fires. Hold one ref'd handle for exactly that wait.
+ */
+async function awaitingUnrefedTimer<T>(work: Promise<T>): Promise<T> {
+    const keepAlive = setInterval(() => {}, 1)
+    try {
+        return await work
+    } finally {
+        clearInterval(keepAlive)
+    }
+}
+
+test('HTTP startup refusal is observed through ready, error, and close', async () => {
+    const refusal = new Error('refused')
+    const connection = new Connection(device(), {
+        fetchTransport: async () => {
+            throw refusal
+        },
+    })
+    const error = once(connection, 'error')
+    const close = waitForClose(connection)
+    await assert.rejects(connection.ready, refusal)
+    assert.equal((await error)[0], refusal)
+    await close
+})
+
+test('HTTP startup timeout aborts the request and closes without creating TLS', async () => {
+    let tlsCalls = 0
+    const connection = new Connection(device(), {
+        httpTimeoutMs: 5,
+        fetchTransport: async (_url, options) =>
+            await new Promise<Response>((_resolve, reject) => {
+                options.signal?.addEventListener('abort', () => reject(options.signal?.reason), { once: true })
+            }),
+        tlsConnector: () => {
+            tlsCalls++
+            return new FakeTlsSocket() as unknown as TLSSocket
+        },
+    })
+    connection.on('error', () => {})
+    const close = waitForClose(connection)
+    await awaitingUnrefedTimer(assert.rejects(connection.ready, /timed out/))
+    assert.equal(tlsCalls, 0)
+    await close
+})
+
+test('destroy during HTTP startup prevents a later RTI connection', async () => {
+    let resolveFetch!: (response: Response) => void
+    let tlsCalls = 0
+    const connection = new Connection(device(), {
+        fetchTransport: () =>
+            new Promise<Response>((resolve) => {
+                resolveFetch = resolve
+            }),
+        tlsConnector: () => {
+            tlsCalls++
+            return new FakeTlsSocket() as unknown as TLSSocket
+        },
+    })
+    connection.destroy()
+    resolveFetch(new Response('<lgedmRoot/>', { status: 200 }))
+    await assert.rejects(connection.ready, /destroyed during startup/)
+    assert.equal(tlsCalls, 0)
+})
+
+test('a shared HTTP agent is not destroyed with an individual connection', async () => {
+    const agent = new Agent({ keepAlive: true })
+    let destroyCalls = 0
+    const originalDestroy = agent.destroy.bind(agent)
+    agent.destroy = () => {
+        destroyCalls++
+        originalDestroy()
+    }
+    const connection = new Connection(device(), {
+        httpsAgent: agent,
+        fetchTransport: async (_url, options) => {
+            assert.equal(options.agent, agent)
+            return await new Promise<Response>((_resolve, reject) => {
+                options.signal?.addEventListener('abort', () => reject(options.signal?.reason), { once: true })
+            })
+        },
+    })
+
+    connection.destroy()
+    await assert.rejects(connection.ready, /destroyed/)
+    assert.equal(destroyCalls, 0)
+    agent.destroy()
+})
+
+test('destroy during TLS handshake settles startup and cancels its deadline', async () => {
+    const socket = new FakeTlsSocket()
+    const errors: Error[] = []
+    const connection = new Connection(device(), {
+        fetchTransport: okFetch,
+        tlsConnectTimeoutMs: 10,
+        tlsConnector: () => socket as unknown as TLSSocket,
+    })
+    connection.on('error', (error) => errors.push(error))
+    await new Promise((resolve) => setImmediate(resolve))
+    connection.destroy()
+    await assert.rejects(connection.ready, /destroyed during startup/)
+    assert.equal(socket.destroyed, true)
+    await new Promise((resolve) => setTimeout(resolve, 15))
+    assert.deepEqual(errors, [])
+})
+
+test('heartbeat is stopped when the RTI socket closes', async () => {
+    const socket = new FakeTlsSocket()
+    const connection = new Connection(device(), {
+        fetchTransport: okFetch,
+        heartbeatIntervalMs: 5,
+        tlsConnector: (options) => {
+            assert.equal(options.rejectUnauthorized, true)
+            assert.equal(options.servername, 'rti.example')
+            queueMicrotask(() => socket.emit('secureConnect'))
+            return socket as unknown as TLSSocket
+        },
+    })
+    connection.on('error', () => {})
+    await connection.ready
+    connection.isLive = true
+    connection.send(Buffer.from([0x01, 0x02]))
+    const status = JSON.parse(socket.writes.at(-1)!.subarray(4).toString())
+    assert.equal(status.Body.CmdWId, `n-${device().deviceId}`)
+    assert.equal(status.Body.ReturnCode, '0000')
+    await new Promise((resolve) => setTimeout(resolve, 12))
+    assert.ok(socket.writes.length >= 2)
+    socket.destroy()
+    await once(connection, 'close')
+    const writesAfterClose = socket.writes.length
+    await new Promise((resolve) => setTimeout(resolve, 12))
+    assert.equal(socket.writes.length, writesAfterClose)
+})
+
+// A throwaway self-signed localhost pair (CN=localhost), so the test needs no openssl at runtime.
+const UNTRUSTED_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC2vSCPqg12AQrp
+vTeRmQU7KMij304KhO9R6EMTwuiPXMjr5GVLB1HNdL8MqYBsmcJTwvxq4gbQQWAG
+9gw8Gm5xJAx2On/95/NlubLKl+ZAgRhKLB4mHQjjjGoy/NL3Mu8+z+odK0N61jmn
+EX+fAB69MSM+HbmBWe2AdyVguJv5bYnRjw3z0oThKFo/9N1j2FFsDX9LywNdeqaM
+aefoCzNV4ISzUB4/uPaG9rqOn+J8/ePC+gPocmqUG4THKVb+qW88HuHIqnCZWeCg
+kBE5AhABQYouIBafMxFc+EeXEPIPIhSxJSCTZ4EROZ50Lh6MOGsl3hxdgcQeIOWU
+rjlIZJ9TAgMBAAECggEACVeWyB3kzyrsQXWDLKRce+EbcM4nvFUMXVC45g0Qn/AZ
+u7dTAewNpsYt1G+qY/9iIQTIczgtKlRpuQa3Kr4chDStlmsU/OwNN+XodkcDgqvP
+xPkyNAyc1iqTwm8a47jQcsud4JzEDUbt/PE29ijfolFWVegs5ag7go7qHn8RnAy7
+zk0ztR2iZn04V5GwYdBnGhqI6/VzGHT4YMZk5WA+zrBZZrqVwpKnqKLulV2kcg9L
+L+JLQqtcTYSdq+j6ssZQx1VMLhfvL8+d/nqfZZUhJ9Ot3GBzb0VwZFM6xnQAe3bw
+9LwkLwr2tGPuQ4I50J2kr9dBHUBVLwrq8r7MFA240QKBgQD+2Nw6YQfz4weKiO1P
+x25UwXoMlMb7fVtkfZcrCdhC+mzMRL4GgkGazKzLFhv3p3PCeub/svFXCZpsaCPj
+j9SGG0PJxrKIx3TwfYBcgSwId+sj7O/reGsdCl5N3L0wn7pCPkdXXbIUuJYiq/pi
+gLXwOysXC1l4halFjd1Cndsv3QKBgQC3kMIFvZQ3zpBJR2MK33CoaMYwfbcrO+Qs
+aVmQLbHYwJQX7VuRchRZoBy6SQGhihXpcqXI5NaLd9MVTwLFyQ0c7PpFeXHFgb2T
+1Dq1IH3QwWQXf9pInXxngz4iWZ7V3kq0O6IRGG7o31KLDjSEL52U71J8u60kxvdl
+hiXmZxew7wKBgACXUCtyfio6pJHVr3c35zGbIUVWMv/yUnvxLqCS7UV6fzYaErbB
+JpXNU7lE29u/L62Ly21cZOLmyszlkO++LagB+C5Hn7JhhAvqvpl4UznRzWHP8t6A
+8P6oP3++u1GZjT0KF/BD713M78w0yefglItyF699/z8gUDwxEApPg2qhAoGBALSN
+OJnG31uI3FiHU76lCb1L2OxnKtvme8bHFGYA2/YTbVafizpjF+sT1k3Qcz89f9Hv
+h2sy0me5wzApV9PMrg4udPgSvLoEo8ActmXjgHztSxLmGYDlDjEOYPYOanF3xMjE
+AuOHwcdhqWHG5hbCct/ECcFQI7yRy1LbgLm/2wiXAoGBAPA7i5UL2aqZp6Ldf8Iq
+6iUpPlayeDeRj2XkApOZkfmpG3oSrYi+YB22zhu5dJ2K+aFG/GLwl5qxZWb2iyL2
+y9KXrHLFesOQSZKwTOT70dz2Ka5j1y6r5YVFPwr/ohddi8OALyn0/naavO/9/Wme
+O5SzWRLjbnyT9RbXsjbG0zVd
+-----END PRIVATE KEY-----
+`
+const UNTRUSTED_CERT = `-----BEGIN CERTIFICATE-----
+MIIDCTCCAfGgAwIBAgIUdoSSCvb4x4La7hZn22LYzBR5LMcwDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI2MDgwMjE1MTEwNFoXDTM2MDcz
+MDE1MTEwNFowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAtr0gj6oNdgEK6b03kZkFOyjIo99OCoTvUehDE8Loj1zI
+6+RlSwdRzXS/DKmAbJnCU8L8auIG0EFgBvYMPBpucSQMdjp//efzZbmyypfmQIEY
+SiweJh0I44xqMvzS9zLvPs/qHStDetY5pxF/nwAevTEjPh25gVntgHclYLib+W2J
+0Y8N89KE4ShaP/TdY9hRbA1/S8sDXXqmjGnn6AszVeCEs1AeP7j2hva6jp/ifP3j
+wvoD6HJqlBuExylW/qlvPB7hyKpwmVngoJAROQIQAUGKLiAWnzMRXPhHlxDyDyIU
+sSUgk2eBETmedC4ejDhrJd4cXYHEHiDllK45SGSfUwIDAQABo1MwUTAdBgNVHQ4E
+FgQUyyit3FlAGBHI/K51Sq4ZMmuxVCEwHwYDVR0jBBgwFoAUyyit3FlAGBHI/K51
+Sq4ZMmuxVCEwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEArGrP
+HoerIAAOt8/PrmSLfUI/UfGjF+aEKTSG5pe7U8/xhCLYtVyZTVloEnRqeHDR2AUp
+9dczc0AdZQty1YQLWcd49DkFN090sNqvyrEUNC4O68zNbR6O/MeIkbXstRDMIYqv
+PDUuPz4kaJp2GQlCgcdXI1Yql3qVvQnqjxixNDjyFVVvymf4IxLQeZ49VZKLefxb
+c9AcvRPUc2Xm+cIoTFfPIMBSTbXNKe8jeY/SI5r/gVAEkdVMizTE/yqIV0xbOhww
+rHP7WDzFAv0AYsDiNMTwWJy7J/AdDbobIbbVb8jvrD6ZylVFesr8Vgjc482nI5br
+MJ9w4TIPy66jDSA12w==
+-----END CERTIFICATE-----
+`
+
+test('RTI TLS rejects an untrusted certificate by default', async (t) => {
+    const server = createServer({ key: UNTRUSTED_KEY, cert: UNTRUSTED_CERT })
+    server.listen(0, '127.0.0.1')
+    await once(server, 'listening')
+    const address = server.address()
+    assert.ok(address && typeof address !== 'string')
+    t.after(() => server.close())
+
+    const connection = new Connection(device(`localhost:${address.port}`), {
+        fetchTransport: okFetch,
+        tlsConnectTimeoutMs: 1000,
+    })
+    connection.on('error', () => {})
+    const close = waitForClose(connection)
+    await assert.rejects(connection.ready, /self-signed certificate|certificate/i)
+    await close
+})

--- a/tests/bridge/thinq1connection.test.ts
+++ b/tests/bridge/thinq1connection.test.ts
@@ -1,0 +1,222 @@
+import assert from 'node:assert/strict'
+import { EventEmitter, once } from 'node:events'
+import { createServer } from 'node:tls'
+import { test } from 'node:test'
+import { Response } from 'node-fetch'
+import { Connection, type Thinq1ConnectionOptions } from '@/bridge/thinq1connection'
+import { Thinq1Device } from '@/bridge/thinqApi'
+import type { TLSSocket } from 'node:tls'
+
+class FakeTlsSocket extends EventEmitter {
+    destroyed = false
+    writes: Buffer[] = []
+
+    write(data: Buffer) {
+        this.writes.push(data)
+        return true
+    }
+
+    destroy(error?: Error) {
+        if (this.destroyed) return this
+        this.destroyed = true
+        if (error) this.emit('error', error)
+        queueMicrotask(() => this.emit('close'))
+        return this
+    }
+}
+
+function device(rtiServer = 'rti.example:443') {
+    return new Thinq1Device(
+        '48552db0-1ab4-11e9-b4fb-7c1c4ec8cc53',
+        { modelId: 'model', modelName: 'model', deviceType: '101' },
+        { httpServer: 'https://http.example', rtiServer },
+    )
+}
+
+const okFetch: NonNullable<Thinq1ConnectionOptions['fetchTransport']> = async () =>
+    new Response('<lgedmRoot/>', { status: 200 })
+
+function waitForClose(connection: Connection) {
+    return new Promise<void>((resolve) => connection.once('close', resolve))
+}
+
+/**
+ * The connection's own deadlines are unref'd so a pending timer never holds the add-on open. A test
+ * that waits for one of them is then the only thing left on the loop, and the runner would cancel it
+ * as "still pending" before the timer fires. Hold one ref'd handle for exactly that wait.
+ */
+async function awaitingUnrefedTimer<T>(work: Promise<T>): Promise<T> {
+    const keepAlive = setInterval(() => {}, 1)
+    try {
+        return await work
+    } finally {
+        clearInterval(keepAlive)
+    }
+}
+
+test('HTTP startup refusal is observed through ready, error, and close', async () => {
+    const refusal = new Error('refused')
+    const connection = new Connection(device(), {
+        fetchTransport: async () => {
+            throw refusal
+        },
+    })
+    const error = once(connection, 'error')
+    const close = waitForClose(connection)
+    await assert.rejects(connection.ready, refusal)
+    assert.equal((await error)[0], refusal)
+    await close
+})
+
+test('HTTP startup timeout aborts the request and closes without creating TLS', async () => {
+    let tlsCalls = 0
+    const connection = new Connection(device(), {
+        httpTimeoutMs: 5,
+        fetchTransport: async (_url, options) =>
+            await new Promise<Response>((_resolve, reject) => {
+                options.signal?.addEventListener('abort', () => reject(options.signal?.reason), { once: true })
+            }),
+        tlsConnector: () => {
+            tlsCalls++
+            return new FakeTlsSocket() as unknown as TLSSocket
+        },
+    })
+    connection.on('error', () => {})
+    const close = waitForClose(connection)
+    await awaitingUnrefedTimer(assert.rejects(connection.ready, /timed out/))
+    assert.equal(tlsCalls, 0)
+    await close
+})
+
+test('destroy during HTTP startup prevents a later RTI connection', async () => {
+    let resolveFetch!: (response: Response) => void
+    let tlsCalls = 0
+    const connection = new Connection(device(), {
+        fetchTransport: () =>
+            new Promise<Response>((resolve) => {
+                resolveFetch = resolve
+            }),
+        tlsConnector: () => {
+            tlsCalls++
+            return new FakeTlsSocket() as unknown as TLSSocket
+        },
+    })
+    connection.destroy()
+    resolveFetch(new Response('<lgedmRoot/>', { status: 200 }))
+    await assert.rejects(connection.ready, /destroyed during startup/)
+    assert.equal(tlsCalls, 0)
+})
+
+test('destroy during TLS handshake settles startup and cancels its deadline', async () => {
+    const socket = new FakeTlsSocket()
+    const errors: Error[] = []
+    const connection = new Connection(device(), {
+        fetchTransport: okFetch,
+        tlsConnectTimeoutMs: 10,
+        tlsConnector: () => socket as unknown as TLSSocket,
+    })
+    connection.on('error', (error) => errors.push(error))
+    await new Promise((resolve) => setImmediate(resolve))
+    connection.destroy()
+    await assert.rejects(connection.ready, /destroyed during startup/)
+    assert.equal(socket.destroyed, true)
+    await new Promise((resolve) => setTimeout(resolve, 15))
+    assert.deepEqual(errors, [])
+})
+
+test('heartbeat is stopped when the RTI socket closes', async () => {
+    const socket = new FakeTlsSocket()
+    const connection = new Connection(device(), {
+        fetchTransport: okFetch,
+        heartbeatIntervalMs: 5,
+        tlsConnector: (options) => {
+            assert.equal(options.rejectUnauthorized, true)
+            assert.equal(options.servername, 'rti.example')
+            queueMicrotask(() => socket.emit('secureConnect'))
+            return socket as unknown as TLSSocket
+        },
+    })
+    connection.on('error', () => {})
+    await connection.ready
+    connection.isLive = true
+    connection.send(Buffer.from([0x01, 0x02]))
+    const status = JSON.parse(socket.writes.at(-1)!.subarray(4).toString())
+    assert.equal(status.Body.CmdWId, `n-${device().deviceId}`)
+    assert.equal(status.Body.ReturnCode, '0000')
+    await new Promise((resolve) => setTimeout(resolve, 12))
+    assert.ok(socket.writes.length >= 2)
+    socket.destroy()
+    await once(connection, 'close')
+    const writesAfterClose = socket.writes.length
+    await new Promise((resolve) => setTimeout(resolve, 12))
+    assert.equal(socket.writes.length, writesAfterClose)
+})
+
+// A throwaway self-signed localhost pair (CN=localhost), so the test needs no openssl at runtime.
+const UNTRUSTED_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC2vSCPqg12AQrp
+vTeRmQU7KMij304KhO9R6EMTwuiPXMjr5GVLB1HNdL8MqYBsmcJTwvxq4gbQQWAG
+9gw8Gm5xJAx2On/95/NlubLKl+ZAgRhKLB4mHQjjjGoy/NL3Mu8+z+odK0N61jmn
+EX+fAB69MSM+HbmBWe2AdyVguJv5bYnRjw3z0oThKFo/9N1j2FFsDX9LywNdeqaM
+aefoCzNV4ISzUB4/uPaG9rqOn+J8/ePC+gPocmqUG4THKVb+qW88HuHIqnCZWeCg
+kBE5AhABQYouIBafMxFc+EeXEPIPIhSxJSCTZ4EROZ50Lh6MOGsl3hxdgcQeIOWU
+rjlIZJ9TAgMBAAECggEACVeWyB3kzyrsQXWDLKRce+EbcM4nvFUMXVC45g0Qn/AZ
+u7dTAewNpsYt1G+qY/9iIQTIczgtKlRpuQa3Kr4chDStlmsU/OwNN+XodkcDgqvP
+xPkyNAyc1iqTwm8a47jQcsud4JzEDUbt/PE29ijfolFWVegs5ag7go7qHn8RnAy7
+zk0ztR2iZn04V5GwYdBnGhqI6/VzGHT4YMZk5WA+zrBZZrqVwpKnqKLulV2kcg9L
+L+JLQqtcTYSdq+j6ssZQx1VMLhfvL8+d/nqfZZUhJ9Ot3GBzb0VwZFM6xnQAe3bw
+9LwkLwr2tGPuQ4I50J2kr9dBHUBVLwrq8r7MFA240QKBgQD+2Nw6YQfz4weKiO1P
+x25UwXoMlMb7fVtkfZcrCdhC+mzMRL4GgkGazKzLFhv3p3PCeub/svFXCZpsaCPj
+j9SGG0PJxrKIx3TwfYBcgSwId+sj7O/reGsdCl5N3L0wn7pCPkdXXbIUuJYiq/pi
+gLXwOysXC1l4halFjd1Cndsv3QKBgQC3kMIFvZQ3zpBJR2MK33CoaMYwfbcrO+Qs
+aVmQLbHYwJQX7VuRchRZoBy6SQGhihXpcqXI5NaLd9MVTwLFyQ0c7PpFeXHFgb2T
+1Dq1IH3QwWQXf9pInXxngz4iWZ7V3kq0O6IRGG7o31KLDjSEL52U71J8u60kxvdl
+hiXmZxew7wKBgACXUCtyfio6pJHVr3c35zGbIUVWMv/yUnvxLqCS7UV6fzYaErbB
+JpXNU7lE29u/L62Ly21cZOLmyszlkO++LagB+C5Hn7JhhAvqvpl4UznRzWHP8t6A
+8P6oP3++u1GZjT0KF/BD713M78w0yefglItyF699/z8gUDwxEApPg2qhAoGBALSN
+OJnG31uI3FiHU76lCb1L2OxnKtvme8bHFGYA2/YTbVafizpjF+sT1k3Qcz89f9Hv
+h2sy0me5wzApV9PMrg4udPgSvLoEo8ActmXjgHztSxLmGYDlDjEOYPYOanF3xMjE
+AuOHwcdhqWHG5hbCct/ECcFQI7yRy1LbgLm/2wiXAoGBAPA7i5UL2aqZp6Ldf8Iq
+6iUpPlayeDeRj2XkApOZkfmpG3oSrYi+YB22zhu5dJ2K+aFG/GLwl5qxZWb2iyL2
+y9KXrHLFesOQSZKwTOT70dz2Ka5j1y6r5YVFPwr/ohddi8OALyn0/naavO/9/Wme
+O5SzWRLjbnyT9RbXsjbG0zVd
+-----END PRIVATE KEY-----
+`
+const UNTRUSTED_CERT = `-----BEGIN CERTIFICATE-----
+MIIDCTCCAfGgAwIBAgIUdoSSCvb4x4La7hZn22LYzBR5LMcwDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI2MDgwMjE1MTEwNFoXDTM2MDcz
+MDE1MTEwNFowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAtr0gj6oNdgEK6b03kZkFOyjIo99OCoTvUehDE8Loj1zI
+6+RlSwdRzXS/DKmAbJnCU8L8auIG0EFgBvYMPBpucSQMdjp//efzZbmyypfmQIEY
+SiweJh0I44xqMvzS9zLvPs/qHStDetY5pxF/nwAevTEjPh25gVntgHclYLib+W2J
+0Y8N89KE4ShaP/TdY9hRbA1/S8sDXXqmjGnn6AszVeCEs1AeP7j2hva6jp/ifP3j
+wvoD6HJqlBuExylW/qlvPB7hyKpwmVngoJAROQIQAUGKLiAWnzMRXPhHlxDyDyIU
+sSUgk2eBETmedC4ejDhrJd4cXYHEHiDllK45SGSfUwIDAQABo1MwUTAdBgNVHQ4E
+FgQUyyit3FlAGBHI/K51Sq4ZMmuxVCEwHwYDVR0jBBgwFoAUyyit3FlAGBHI/K51
+Sq4ZMmuxVCEwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEArGrP
+HoerIAAOt8/PrmSLfUI/UfGjF+aEKTSG5pe7U8/xhCLYtVyZTVloEnRqeHDR2AUp
+9dczc0AdZQty1YQLWcd49DkFN090sNqvyrEUNC4O68zNbR6O/MeIkbXstRDMIYqv
+PDUuPz4kaJp2GQlCgcdXI1Yql3qVvQnqjxixNDjyFVVvymf4IxLQeZ49VZKLefxb
+c9AcvRPUc2Xm+cIoTFfPIMBSTbXNKe8jeY/SI5r/gVAEkdVMizTE/yqIV0xbOhww
+rHP7WDzFAv0AYsDiNMTwWJy7J/AdDbobIbbVb8jvrD6ZylVFesr8Vgjc482nI5br
+MJ9w4TIPy66jDSA12w==
+-----END CERTIFICATE-----
+`
+
+test('RTI TLS rejects an untrusted certificate by default', async (t) => {
+    const server = createServer({ key: UNTRUSTED_KEY, cert: UNTRUSTED_CERT })
+    server.listen(0, '127.0.0.1')
+    await once(server, 'listening')
+    const address = server.address()
+    assert.ok(address && typeof address !== 'string')
+    t.after(() => server.close())
+
+    const connection = new Connection(device(`localhost:${address.port}`), {
+        fetchTransport: okFetch,
+        tlsConnectTimeoutMs: 1000,
+    })
+    connection.on('error', () => {})
+    const close = waitForClose(connection)
+    await assert.rejects(connection.ready, /self-signed certificate|certificate/i)
+    await close
+})

--- a/tests/bridge/thinq2connection.test.ts
+++ b/tests/bridge/thinq2connection.test.ts
@@ -1,0 +1,118 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter, once } from 'node:events'
+import type { MqttClient } from 'mqtt'
+import { Connection } from '@/bridge/thinq2connection'
+import { Thinq2Device, type Thinq2DeviceState } from '@/bridge/thinqApi'
+import { setFilter } from '@/util/logging'
+
+setFilter(() => false)
+
+class MockMqttClient extends EventEmitter {
+    publications: Array<{ topic: string; payload: string }> = []
+    publishCallbacks: Array<(err?: Error) => void> = []
+    subscribeCalls: string[] = []
+    subscribeError: Error | undefined
+    completeSubscriptions = true
+    endCalls = 0
+    endForces: Array<boolean | undefined> = []
+
+    publish(topic: string, payload: string, optionsOrCallback?: unknown, callback?: (err?: Error) => void) {
+        this.publications.push({ topic, payload })
+        const publishCallback =
+            typeof optionsOrCallback === 'function' ? (optionsOrCallback as (err?: Error) => void) : callback
+        if (publishCallback) this.publishCallbacks.push(publishCallback)
+        return this
+    }
+
+    subscribe(topic: string, callback?: (err?: Error) => void) {
+        this.subscribeCalls.push(topic)
+        if (callback && this.completeSubscriptions) callback(this.subscribeError)
+        return this
+    }
+
+    end(force?: boolean) {
+        this.endCalls++
+        this.endForces.push(force)
+        return this
+    }
+}
+
+const state: Thinq2DeviceState = {
+    countryCode: 'XX',
+    apiServer: 'https://api.example',
+    mqttServer: 'ssl://mqtt.example',
+    caCertificate: '',
+    privateKey: '',
+    certificate: '',
+    pubTopic: 'clip/message/devices/test-device',
+    provTopic: 'clip/provisioning/devices/test-device',
+    subTopic: 'lime/devices/test-device',
+}
+
+function connection(mqtt: MockMqttClient) {
+    const device = new Thinq2Device('test-device', { modelId: 'model', modelName: 'model' }, state)
+    return new Connection(device, mqtt as unknown as MqttClient)
+}
+
+test('connect subscribes and publishes preDeploy through completion callbacks', async () => {
+    const mqtt = new MockMqttClient()
+    const conn = connection(mqtt)
+
+    mqtt.emit('connect')
+    await new Promise((resolve) => setImmediate(resolve))
+    for (const done of mqtt.publishCallbacks.splice(0)) done()
+    await new Promise((resolve) => setImmediate(resolve))
+
+    assert.deepEqual(mqtt.subscribeCalls, [state.subTopic])
+    assert.equal(mqtt.publications.length, 1)
+    assert.equal(mqtt.publications[0].topic, state.provTopic)
+    assert.equal(JSON.parse(mqtt.publications[0].payload).cmd, 'preDeploy')
+    conn.destroy()
+})
+
+test('a failed startup subscribe is reported as an error, not an unhandled rejection', async () => {
+    const mqtt = new MockMqttClient()
+    mqtt.subscribeError = new Error('subscribe refused')
+    const conn = connection(mqtt)
+
+    const reported = once(conn, 'error')
+    mqtt.emit('connect')
+
+    assert.equal(((await reported)[0] as Error).message, 'subscribe refused')
+    // the failure tears the connection down instead of leaving a half-started session
+    assert.equal(mqtt.endCalls, 1)
+    assert.deepEqual(mqtt.endForces, [true])
+    assert.equal(mqtt.publications.length, 0)
+})
+
+test('destroy settles an in-flight operation whose callback will never fire', async () => {
+    const mqtt = new MockMqttClient()
+    mqtt.completeSubscriptions = false // the broker never answers the subscribe
+    const conn = connection(mqtt)
+    conn.on('error', () => {})
+
+    mqtt.emit('connect')
+    await new Promise((resolve) => setImmediate(resolve))
+    conn.destroy()
+    await new Promise((resolve) => setImmediate(resolve))
+
+    assert.equal(mqtt.endCalls, 1)
+    // destroy is idempotent and send after destroy is a no-op
+    conn.destroy()
+    conn.send('AA')
+    assert.equal(mqtt.endCalls, 1)
+    assert.equal(mqtt.publications.length, 0)
+})
+
+test('an MQTT error is forwarded to the connection error event', () => {
+    const mqtt = new MockMqttClient()
+    const conn = connection(mqtt)
+    const seen: Error[] = []
+    conn.on('error', (err) => seen.push(err))
+
+    const failure = new Error('broker unavailable')
+    mqtt.emit('error', failure)
+    assert.deepEqual(seen, [failure])
+    conn.destroy()
+})

--- a/tests/cloud/thinq1/http.test.ts
+++ b/tests/cloud/thinq1/http.test.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict'
+import { once } from 'node:events'
+import { request as httpRequest, createServer } from 'node:http'
+import { after, before, test } from 'node:test'
+import express from 'express'
+import { getDeviceMetadata, routes } from '@/cloud/thinq1/http'
+import type { Config } from '@/util/config'
+
+let baseUrl: string
+const app = express()
+app.use(routes({} as Config))
+const server = createServer(app)
+
+before(async () => {
+    server.listen(0, '127.0.0.1')
+    await once(server, 'listening')
+    const address = server.address()
+    assert.ok(address && typeof address !== 'string')
+    baseUrl = `http://127.0.0.1:${address.port}`
+})
+
+after(async () => {
+    server.close()
+    await once(server, 'close')
+})
+
+async function postMetadata(deviceId: string, body = '<lgedmRoot><modelName>model</modelName></lgedmRoot>') {
+    return fetch(`${baseUrl}/lgehadm/api/Device/TotalDeviceInfoSvc`, {
+        method: 'POST',
+        headers: {
+            'content-type': 'text/xml',
+            'x-lgedm-deviceid': deviceId,
+            'x-lgedm-devicetype': '101',
+        },
+        body,
+    })
+}
+
+test('metadata round-trips through the store, even under a __proto__ id', async () => {
+    const id = 'device-0001'
+    const accepted = await postMetadata(id)
+    assert.equal(accepted.status, 200)
+    assert.deepEqual(getDeviceMetadata(id), {
+        deviceType: '101',
+        modelId: 'model',
+        modelName: 'model',
+    })
+
+    // A hostile device id lands in the Map, not on Object.prototype.
+    const polluted = await postMetadata('__proto__')
+    assert.equal(polluted.status, 200)
+    assert.ok(getDeviceMetadata('__proto__'))
+    assert.equal(({} as Record<string, unknown>).modelName, undefined)
+})
+
+test('malformed, oversized, and aborted XML streams are contained', async () => {
+    assert.equal((await postMetadata('malformed-device', '<lgedmRoot>')).status, 400)
+    assert.equal((await postMetadata('oversized-device', 'x'.repeat(1_000_001))).status, 413)
+    assert.equal(getDeviceMetadata('malformed-device'), undefined)
+    assert.equal(getDeviceMetadata('oversized-device'), undefined)
+
+    const address = server.address()
+    assert.ok(address && typeof address !== 'string')
+    await new Promise<void>((resolve) => {
+        const req = httpRequest(
+            {
+                host: '127.0.0.1',
+                port: address.port,
+                path: '/lgehadm/api/Device/TotalDeviceInfoSvc',
+                method: 'POST',
+                headers: {
+                    'content-type': 'text/xml',
+                    'x-lgedm-deviceid': 'aborted-device',
+                    'x-lgedm-devicetype': '101',
+                },
+            },
+            () => {},
+        )
+        req.on('error', () => resolve())
+        req.write('<lgedmRoot><modelName>')
+        req.destroy()
+        setImmediate(resolve)
+    })
+
+    const healthy = await postMetadata('healthy-device')
+    assert.equal(healthy.status, 200)
+    assert.ok(getDeviceMetadata('healthy-device'))
+    assert.equal(getDeviceMetadata('aborted-device'), undefined)
+})


### PR DESCRIPTION
Thanks again for the detailed review. This PR is now trimmed to three focused commits and rebased onto the current `master`; the changes that were merged separately or rejected during review are no longer present.

## ThinQ1 connection lifecycle

- Startup failure is observed instead of becoming an unhandled rejection.
- `destroy()` cancels whichever stage is active: HTTP request, TLS handshake, RTI socket, or heartbeat.
- The bridge owns one keep-alive HTTP agent and reuses its pool across ThinQ1 connections; destroying an individual connection does not destroy the shared agent.
- RTI TLS verifies the peer certificate by default.

## ThinQ1 metadata HTTP

- Device metadata is stored in a `Map`, avoiding special object keys such as `__proto__`.
- XML request bodies are size-bounded and validated before parsing; aborted streams discard partial data.

## ThinQ2 startup

- A rejected async MQTT `connect` handler is caught and forwarded through the existing connection `error` event rather than becoming an unhandled rejection. Ordinary MQTT errors keep the same behavior.

Each change includes regression coverage. Current verification on the rebased branch:

- `npm test`: **457 passed, 0 failed**
- `tsc -p tsconfig.build.json --noEmit`: clean
- Prettier and `git diff --check`: clean