### PR TITLE
Add nine Korean LG appliances, an ac_common base, and persistent driver stores

### DIFF
--- a/bridge/purifier-history-store.ts
+++ b/bridge/purifier-history-store.ts
@@ -1,0 +1,323 @@
+import { readFileSync, readdirSync, renameSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { validDeviceId } from '@/util/device-id'
+
+export type PurifierUsage = {
+    day: string
+    normal: number
+    hot: number
+    cold: number
+    soda: number
+    mineral: number
+    sterilization: number
+}
+
+export type PurifierDailyUsage = Omit<PurifierUsage, 'day'>
+
+export type PurifierSterilizationHistory = {
+    active?: {
+        kind: 'pipe' | 'outlet'
+        startedAt: number
+    }
+    lastPipeAt?: number
+    lastOutletAt?: number
+    countsByMonth: Record<string, number>
+}
+
+export type PurifierScheduleAnchor = {
+    parts: [number, number, number, number]
+    instant: number
+}
+
+export type PurifierHistoryState = {
+    version: 1
+    collectedSince: number
+    usageComplete: boolean
+    usage: PurifierUsage
+    sterilization: PurifierSterilizationHistory
+    schedule?: PurifierScheduleAnchor
+}
+
+export type PurifierHistoryStore = {
+    load(id: string): PurifierHistoryState | undefined
+    save(id: string, state: PurifierHistoryState): void
+}
+
+type PurifierHistoryFileOps = {
+    read(path: string): string
+    write(path: string, data: string, options: { mode: number }): void
+    rename(from: string, to: string): void
+}
+
+type PurifierHistoryWarning = (message: string, error: unknown) => void
+
+const fileOps: PurifierHistoryFileOps = {
+    read: (path) => readFileSync(path, 'utf-8'),
+    write: (path, data, options) => writeFileSync(path, data, options),
+    rename: (from, to) => renameSync(from, to),
+}
+
+const usageFields = ['normal', 'hot', 'cold', 'soda', 'mineral', 'sterilization'] as const
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value != null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isNonnegativeSafeInteger(value: unknown): value is number {
+    return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+}
+
+function isTimestamp(value: unknown): value is number {
+    return typeof value === 'number' && Number.isFinite(value) && value >= 0
+}
+
+function validDay(day: unknown): day is string {
+    if (typeof day !== 'string') return false
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(day)
+    if (!match) return false
+
+    const year = Number(match[1])
+    const month = Number(match[2])
+    const dayOfMonth = Number(match[3])
+    if (month < 1 || month > 12) return false
+
+    const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0)
+    const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    return dayOfMonth >= 1 && dayOfMonth <= daysInMonth[month - 1]!
+}
+
+function validMonth(month: string) {
+    const match = /^(\d{4})-(\d{2})$/.exec(month)
+    if (!match) return false
+    const monthNumber = Number(match[2])
+    return monthNumber >= 1 && monthNumber <= 12
+}
+
+function canonicalSchedule(value: unknown): PurifierScheduleAnchor | undefined {
+    if (!isRecord(value) || !Array.isArray(value.parts) || value.parts.length !== 4 || !isTimestamp(value.instant))
+        return undefined
+
+    const parts = value.parts
+    if (parts.some((part) => typeof part !== 'number' || !Number.isSafeInteger(part) || part < 0 || part > 0xff))
+        return undefined
+
+    const [month, day, hour, minute] = parts as [number, number, number, number]
+    const date = new Date(value.instant)
+    if (
+        date.getUTCMonth() + 1 !== month ||
+        date.getUTCDate() !== day ||
+        date.getUTCHours() !== hour ||
+        date.getUTCMinutes() !== minute ||
+        date.getUTCSeconds() !== 0 ||
+        date.getUTCMilliseconds() !== 0
+    )
+        return undefined
+
+    return { parts: [month, day, hour, minute], instant: value.instant }
+}
+
+function canonicalState(value: unknown): PurifierHistoryState | undefined {
+    if (!isRecord(value) || value.version !== 1 || !isTimestamp(value.collectedSince)) return undefined
+    if (!isRecord(value.usage) || !isRecord(value.sterilization)) return undefined
+
+    if (!validDay(value.usage.day)) return undefined
+    const usage = {
+        day: value.usage.day,
+    } as PurifierUsage
+    if (value.usageComplete !== undefined && typeof value.usageComplete !== 'boolean') return undefined
+    for (const field of usageFields) {
+        const amount = value.usage[field]
+        if (!isNonnegativeSafeInteger(amount)) return undefined
+        usage[field] = amount
+    }
+
+    const storedSterilization = value.sterilization
+    if (!isRecord(storedSterilization.countsByMonth)) return undefined
+
+    const countsByMonth: Record<string, number> = {}
+    for (const [month, count] of Object.entries(storedSterilization.countsByMonth)) {
+        if (!validMonth(month) || !isNonnegativeSafeInteger(count)) return undefined
+        countsByMonth[month] = count
+    }
+
+    const sterilization = {} as PurifierSterilizationHistory
+    if (storedSterilization.active !== undefined) {
+        if (
+            !isRecord(storedSterilization.active) ||
+            (storedSterilization.active.kind !== 'pipe' && storedSterilization.active.kind !== 'outlet') ||
+            !isTimestamp(storedSterilization.active.startedAt)
+        )
+            return undefined
+        sterilization.active = {
+            kind: storedSterilization.active.kind,
+            startedAt: storedSterilization.active.startedAt,
+        }
+    }
+    if (storedSterilization.lastPipeAt !== undefined) {
+        if (!isTimestamp(storedSterilization.lastPipeAt)) return undefined
+        sterilization.lastPipeAt = storedSterilization.lastPipeAt
+    }
+    if (storedSterilization.lastOutletAt !== undefined) {
+        if (!isTimestamp(storedSterilization.lastOutletAt)) return undefined
+        sterilization.lastOutletAt = storedSterilization.lastOutletAt
+    }
+    sterilization.countsByMonth = countsByMonth
+
+    const state: PurifierHistoryState = {
+        version: 1,
+        collectedSince: value.collectedSince,
+        // Version 1 files written before cloud baselining cannot prove that the bridge
+        // observed the whole KST day. Treat them as partial instead of publishing a false zero.
+        usageComplete: value.usageComplete === true,
+        usage,
+        sterilization,
+    }
+    if (value.schedule !== undefined) {
+        const schedule = canonicalSchedule(value.schedule)
+        if (!schedule) return undefined
+        state.schedule = schedule
+    }
+    return state
+}
+
+export class PurifierHistoryJSONStore implements PurifierHistoryStore {
+    private tempSequence = 0
+
+    constructor(
+        readonly basePath: string,
+        private readonly files: PurifierHistoryFileOps = fileOps,
+        private readonly warn: PurifierHistoryWarning = console.warn,
+    ) {}
+
+    private path(id: string) {
+        if (!validDeviceId(id)) return undefined
+        return join(this.basePath, `purifier_${id}.json`)
+    }
+
+    private stateForDay(id: string, day: string, now: number, reportLoadFailure = true) {
+        const existing = reportLoadFailure ? this.load(id) : this.loadWithoutWarning(id)
+        if (existing) {
+            return {
+                ...existing,
+                usage:
+                    existing.usage.day === day
+                        ? { ...existing.usage }
+                        : {
+                              day,
+                              normal: 0,
+                              hot: 0,
+                              cold: 0,
+                              soda: 0,
+                              mineral: 0,
+                              sterilization: 0,
+                          },
+            }
+        }
+        return {
+            version: 1 as const,
+            collectedSince: now,
+            usageComplete: false,
+            usage: {
+                day,
+                normal: 0,
+                hot: 0,
+                cold: 0,
+                soda: 0,
+                mineral: 0,
+                sterilization: 0,
+            },
+            sterilization: { countsByMonth: {} },
+        }
+    }
+
+    markAllDailyUsageIncomplete(day: string, now: number) {
+        let filenames: string[]
+        try {
+            filenames = readdirSync(this.basePath)
+        } catch (error) {
+            this.warn('Unable to enumerate purifier history for daily usage preparation', this.safeError(error))
+            return []
+        }
+        const deviceIds: string[] = []
+        for (const filename of filenames) {
+            const match = /^purifier_(.+)\.json$/.exec(filename)
+            if (!match || !validDeviceId(match[1]!)) continue
+            deviceIds.push(match[1]!)
+            try {
+                const state = this.stateForDay(match[1]!, day, now, false)
+                state.usageComplete = false
+                this.save(match[1]!, state)
+            } catch (error) {
+                this.warn('Unable to prepare one purifier history for daily usage', this.safeError(error))
+            }
+        }
+        return deviceIds
+    }
+
+    private safeError(error: unknown) {
+        return { error: error instanceof Error ? error.name : 'UnknownError' }
+    }
+
+    private loadWithoutWarning(id: string) {
+        const path = this.path(id)
+        if (!path) return undefined
+        let serialized: string
+        try {
+            serialized = this.files.read(path)
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') return undefined
+            throw error
+        }
+        const state = canonicalState(JSON.parse(serialized) as unknown)
+        if (!state) throw new Error('purifier history has an invalid schema')
+        return state
+    }
+
+    prepareDailyUsage(id: string, day: string, now: number) {
+        const state = this.stateForDay(id, day, now, false)
+        state.usageComplete = false
+        this.save(id, state)
+    }
+
+    applyDailyUsageBaseline(id: string, day: string, usage: PurifierDailyUsage, now: number) {
+        const state = this.stateForDay(id, day, now, false)
+        state.usageComplete = true
+        state.usage = { day, ...usage }
+        this.save(id, state)
+    }
+
+    load(id: string): PurifierHistoryState | undefined {
+        const path = this.path(id)
+        if (!path) return undefined
+
+        let serialized: string
+        try {
+            serialized = this.files.read(path)
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') return undefined
+            this.warn(`Unable to read purifier history ${path}`, error)
+            throw error
+        }
+
+        try {
+            const state = canonicalState(JSON.parse(serialized) as unknown)
+            if (!state) throw new Error('purifier history has an invalid schema')
+            return state
+        } catch (error) {
+            this.warn(`Unable to load corrupt purifier history ${path}`, error)
+            throw error
+        }
+    }
+
+    save(id: string, state: PurifierHistoryState): void {
+        const path = this.path(id)
+        if (!path) return
+
+        const canonical = canonicalState(state)
+        if (!canonical) throw new TypeError('purifier history has an invalid schema')
+
+        const tempPath = `${path}.${process.pid}.${this.tempSequence++}.tmp`
+        this.files.write(tempPath, JSON.stringify(canonical), { mode: 0o600 })
+        this.files.rename(tempPath, path)
+    }
+}

--- a/cloud/devices/1WPU4CIGCR__2.ts
+++ b/cloud/devices/1WPU4CIGCR__2.ts
@@ -1,0 +1,1031 @@
+import { Device as Thinq2Device } from '../thinq2/device'
+import { DeviceDiscovery, type ComponentInfo, type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import HADevice from './base'
+import AABBDevice from './aabb_device'
+import type {
+    PurifierDailyUsage,
+    PurifierHistoryState,
+    PurifierHistoryStore,
+    PurifierUsage,
+} from '@/bridge/purifier-history-store'
+
+/*
+ * LG PuriCare Water Purifier (ATOM-U STS T20 Cold/Hot/Purified/Steril), ThinQ model 1WPU4CIGCR__2, deviceType 103.
+ *
+ * THE COMMAND FRAME, AND WHY IT LOOKED LIKE THERE WASN'T ONE
+ * ----------------------------------------------------------
+ * The first pass here concluded this appliance could not be controlled at all: its
+ * modelJSON says `Config.supportControl: false`, its `ControlWifi` block is
+ * `{"basicCtrl": {"command": "Set", "data": {}}}` — an empty command set — and LG's
+ * cloud answers 9006 to a control request. Every one of those observations is about
+ * LG's LEGACY control path, which LG has since retired. The capability API that
+ * replaced it (`dataops/v1/s2p/backend/convert/control`) does control this unit, and
+ * its `convert/capabilitySchema` lists the setters plainly:
+ *
+ *   dispenserDefaultWater      setDispenserDefaultWaterType / …AmountMode
+ *   waterPurifierNotUseNotice  setNotUseNotice
+ *   waterPurifierSterilize     setAutoCareState / setSterilizeReservation
+ *
+ * That matters here because LG's server converts a capability command into the
+ * appliance's own protocol and sends it down — and rethink relays it. So the
+ * cloud→appliance command frame can be MADE to exist without touching the appliance,
+ * which is how every frame below was captured (2026-07-28), each one answered CL-0000:
+ *
+ *   aa 20 f0 17 | <26-byte record, 0xff = leave this field alone> | ck bb
+ *
+ * The record is the SAME 26-byte layout the appliance reports, so the read map below
+ * doubles as the write map. The captured commands landed on the offsets the read probes
+ * had predicted:
+ *
+ *   setDispenserDefaultWaterAmountMode 120/250/500 -> record[11]  1/2/3
+ *   setDispenserDefaultWaterType coldWater         -> record[10]  3
+ *   setNotUseNotice on                             -> record[8]   1
+ *   setAutoCareState off                           -> record[20]  0
+ *   setSterilizeReservation raw 21:45 (06:45 KST) -> record[17]=21 record[18]=45
+ *
+ * The reservation command is intentionally not exposed as a write. A live round-trip on
+ * 2026-07-29 proved that the appliance replaces its month/day anchor when it receives the
+ * time-only frame, moving the weekly sterilization to another weekday. LG's capability
+ * schema accepts only `sterilizeStartTime`, so there is no verified way to preserve that
+ * weekday. The time remains visible from the appliance's four-field schedule report.
+ *
+ * `f0 17` as the set-state opcode is not specific to this model — the fridge drivers in
+ * this repo build the same `F0 17 FF FF …` frame with 0xff for untouched fields.
+ *
+ * Not everything this model declares actually takes: `setButtonSoundState` answers
+ * CL-0003 on this unit, so Button sound stays a read-only sensor rather than a switch that
+ * silently does nothing.
+ *
+ * WHERE THE BYTE OFFSETS COME FROM
+ * --------------------------------
+ * modelJSON gives the field names and every enum code (`MonitoringValue.*.valueMapping`),
+ * but no offsets: this is an AA..BB appliance, so the layout lives in the Wi-Fi module and
+ * in LG's server. It was recovered on 2026-07-28 by making LG's cloud decode frames we
+ * chose — rethink relays what the appliance sends, and the management API can inject a
+ * frame as if the appliance had sent it (tools/lg-oracle.mjs).
+ *
+ * The probe that settled it re-injected the appliance's own captured state frame with
+ * EXACTLY ONE byte changed, then read LG's snapshot back. That is sharper than a ramp:
+ * a ramp names numeric fields but leaves every enum at IGNORE, because byte[i]=i is not a
+ * valid code for a 0..2 enum. Three passes were run (fill 3, fill 0, fill 1/2) so each
+ * field was seen moving at least twice — once when its own probe set it, once when the
+ * next probe reverted it.
+ *
+ * Base frame (real, captured 2026-07-28):
+ *   aa3a12ec02 0102010101ffff00ff010101ffff071c121eff01ff030000010200
+ *              02010101ffff00ff010101ffff071c121eff01ff03000001 ccbb
+ *
+ * THIS FRAME CARRIES THE STATE TWICE, AND LG READS THE LAST COPY.
+ * Bytes 4..29 and 30..55 are two 26-byte records with the same field order (the halves are
+ * byte-identical in a quiet frame, which is why this is easy to miss). Probing the FIRST
+ * record never moved a field to the probe value — every field came back holding the second
+ * record's value instead — so the decoder reads the trailing record. The same
+ * old-record/new-record shape appears on the AA..BB washers in this repo.
+ *
+ * Confirmed layout, as offsets into the record (and, in brackets, absolute offsets into the
+ * 58-byte frame, which is how the probes recorded them):
+ *
+ *    0 monStatus      [30]    1 cockState            [31]    2 waterSelection    [32]
+ *    3 waterAmountMode[33]    4 tempUnit             [34]    5 amountUnit        [35]
+ *    6 hotWaterTemp   [36]    7 voiceMode            [37]    8 notUseNotice      [38]
+ *    9 autoElevation  [39]   10 defaultWaterSet      [40]   11 defaultWaterAmountMode [41]
+ *   12 buttonSoundOnOff[42]  13 voiceOnOff           [43]   14 voiceVolume       [44]
+ *   15 sterilizeInitMonth[45] 16 sterilizeInitDay    [46]   17 sterilizeInitHour [47]
+ *   18 sterilizeInitMin[48]  19 cleanMode            [49]   20 autoCareOnOff     [50]
+ *   21 energySavingMode[51]  22 monDataRefresh       [52]   23 highSterilizeState[53]
+ *   24 filterFlushingState[54] 25 appVersion         [55]
+ *
+ * 26 bytes, 26 fields, one-for-one with the 26 `wpState.*` keys LG publishes for this unit.
+ *
+ * THE RECORD COUNT VARIES, SO IT IS COUNTED RATHER THAN ASSUMED.
+ * The appliance also sends a 32-byte single-record form, `aa 20 12 eb …`, and that is the one
+ * it sends most of the time — seen live at 2026-07-28 09:46, its 26 payload bytes equal to the
+ * 58-byte frame's SECOND record exactly (they differ only in the record's own index byte, 01
+ * on the leading record and 00 on the trailing one). A decoder keyed on "58 bytes, tag 0xec"
+ * therefore ignores the appliance's usual frame and leaves every entity unknown — which is
+ * what the first live rebuild showed. So the payload is measured instead: header 4 bytes,
+ * trailer 2, and whatever is between must be a whole number of 26-byte records; the last one
+ * is the current state. That accepts both forms and rejects the two heartbeats
+ * (`aa0912af0d…`, `aa0a12e24a…`), whose payloads are 3 and 4 bytes.
+ *
+ * WHAT THIS UNIT DOES NOT HAVE
+ * ----------------------------
+ * voiceMode, voiceOnOff, voiceVolume, cleanMode, energySavingMode and autoElevation read
+ * 0xff = IGNORE in every captured frame, and the model's Config agrees: supportSoundSetting
+ * false, supportCleanMode false, supportEnergySaving false. No entity is published for them
+ * — the same rule the dehumidifier learned (an entity for a field the appliance never
+ * reports is a permanently-unknown entity).
+ */
+
+/** `aa <len> 12 <tag> …<records>… <ck> bb` — 4 header bytes, 2 trailer bytes. */
+const HEADER_LEN = 4
+const TRAILER_LEN = 2
+/** buf[2] on every frame this appliance sends, state and heartbeat alike. */
+const CLASS_TAG = 0x12
+/** One state record. The frame holds one or two of them; the last is current. */
+const RECORD_LEN = 26
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000
+const MAX_TIMEOUT_MS = 0x7fffffff
+const HISTORY_RETRY_MS = 5 * 1000
+const HISTORY_PROPERTIES = [
+    'water_usage_today',
+    'water_usage_normal',
+    'water_usage_cold',
+    'water_usage_hot',
+    'water_usage_sterilization',
+    'sterilize_pipe_last_at',
+    'sterilize_outlet_last_at',
+    'sterilize_previous_month_count',
+] as const
+
+type Timer = ReturnType<typeof setTimeout>
+type SterilizationActive = PurifierHistoryState['sterilization']['active']
+type UsageDelta = Omit<PurifierUsage, 'day'>
+type PendingUsage = { day: string; delta: UsageDelta }
+type Clock = {
+    now: () => number
+    setTimeout: (callback: () => void, delay: number) => Timer
+    clearTimeout: (timer: Timer | undefined) => void
+}
+
+const systemClock: Clock = {
+    now: Date.now,
+    setTimeout: (callback, delay) => setTimeout(callback, delay),
+    clearTimeout: (timer) => clearTimeout(timer),
+}
+
+const pad2 = (n: number) => String(n).padStart(2, '0')
+const kstParts = (time: number) => {
+    const date = new Date(time + KST_OFFSET_MS)
+    return {
+        year: date.getUTCFullYear(),
+        month: date.getUTCMonth() + 1,
+        day: date.getUTCDate(),
+        hour: date.getUTCHours(),
+        minute: date.getUTCMinutes(),
+    }
+}
+const kstDay = (time: number) => {
+    const p = kstParts(time)
+    return `${p.year}-${pad2(p.month)}-${pad2(p.day)}`
+}
+const kstMonth = (time: number) => {
+    const p = kstParts(time)
+    return `${p.year}-${pad2(p.month)}`
+}
+const previousKstMonth = (time: number) => {
+    const p = kstParts(time)
+    return kstMonth(Date.UTC(p.year, p.month - 2, 15) - KST_OFFSET_MS)
+}
+const previousKstMonthStart = (time: number) => {
+    const p = kstParts(time)
+    return Date.UTC(p.year, p.month - 2, 1) - KST_OFFSET_MS
+}
+const nextKstMidnight = (time: number) => {
+    const shifted = new Date(time + KST_OFFSET_MS)
+    return Date.UTC(shifted.getUTCFullYear(), shifted.getUTCMonth(), shifted.getUTCDate() + 1) - KST_OFFSET_MS
+}
+const formatClock = (hour: number, minute: number) => {
+    const period = hour < 12 ? 'AM' : 'PM'
+    return `${hour % 12 || 12}:${pad2(minute)} ${period}`
+}
+const formatKst = (time: number | undefined) => {
+    // This bridge can only attest to completions it observed. An absent timestamp does not
+    // prove the appliance has never completed a cycle before collection began.
+    if (time == null) return 'Not yet observed'
+    const p = kstParts(time)
+    return `${p.year}-${pad2(p.month)}-${pad2(p.day)} ${pad2(p.hour)}:${pad2(p.minute)}`
+}
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const
+const scheduleAnchor = (parts: number[], time: number) => {
+    if (parts.some((part) => part === IGNORE)) return undefined
+    const [month, day, hour, minute] = parts
+    if (month < 1 || month > 12 || day < 1 || hour > 23 || minute > 59) return undefined
+
+    // The record omits the year. A weekly "next run" is close to now, so the nearest valid
+    // occurrence across the current year boundary is the unambiguous one.
+    const currentYear = new Date(time).getUTCFullYear()
+    const candidates = [currentYear - 1, currentYear, currentYear + 1]
+        .map((year) => {
+            const instant = Date.UTC(year, month - 1, day, hour, minute)
+            const date = new Date(instant)
+            return date.getUTCFullYear() === year &&
+                date.getUTCMonth() === month - 1 &&
+                date.getUTCDate() === day &&
+                date.getUTCHours() === hour &&
+                date.getUTCMinutes() === minute
+                ? instant
+                : undefined
+        })
+        .filter((instant): instant is number => instant !== undefined)
+    if (!candidates.length) return undefined
+
+    return candidates.reduce((closest, candidate) =>
+        Math.abs(candidate - time) < Math.abs(closest - time) ? candidate : closest,
+    )
+}
+const scheduleInKst = (anchor: number, time: number) => {
+    let instant = anchor
+    if (instant < time) instant += Math.ceil((time - instant) / WEEK_MS) * WEEK_MS
+    return { ...kstParts(instant), instant }
+}
+type SterilizationSchedule = ReturnType<typeof scheduleInKst> | undefined
+const formatSterilizationSchedule = (local: SterilizationSchedule) => {
+    if (!local) return 'Not set'
+    return `${local.month}.${local.day} ${formatClock(local.hour, local.minute)}`
+}
+const formatWeeklySchedule = (local: SterilizationSchedule) => {
+    if (!local) return 'Not set'
+    const weekday = new Date(Date.UTC(local.year, local.month - 1, local.day, local.hour, local.minute)).getUTCDay()
+    return `Weekly ${WEEKDAYS[weekday]} ${formatClock(local.hour, local.minute)}`
+}
+const isValidAABBFrame = (buf: Buffer) => {
+    if (buf.length < 4 || buf.length > 0xff || buf[0] !== 0xaa || buf[1] !== buf.length || buf[buf.length - 1] !== 0xbb)
+        return false
+    let sum = 0
+    for (let i = 0; i < buf.length - TRAILER_LEN; i++) sum += buf[i]
+    return buf[buf.length - 2] === ((sum & 0xff) ^ 0x55)
+}
+const emptyUsage = (day: string): PurifierUsage => ({
+    day,
+    normal: 0,
+    hot: 0,
+    cold: 0,
+    soda: 0,
+    mineral: 0,
+    sterilization: 0,
+})
+const copyHistory = (state: PurifierHistoryState): PurifierHistoryState => ({
+    ...state,
+    usage: { ...state.usage },
+    schedule: state.schedule
+        ? {
+              parts: [
+                  state.schedule.parts[0],
+                  state.schedule.parts[1],
+                  state.schedule.parts[2],
+                  state.schedule.parts[3],
+              ],
+              instant: state.schedule.instant,
+          }
+        : undefined,
+    sterilization: {
+        ...state.sterilization,
+        active: state.sterilization.active ? { ...state.sterilization.active } : undefined,
+        countsByMonth: { ...state.sterilization.countsByMonth },
+    },
+})
+
+/** Offsets WITHIN a record. Add the record's start to get the absolute offset. */
+const OFF = {
+    monStatus: 0,
+    cockState: 1,
+    waterSelection: 2,
+    waterAmountMode: 3,
+    tempUnit: 4,
+    amountUnit: 5,
+    hotWaterTemp: 6,
+    notUseNotice: 8,
+    defaultWaterSet: 10,
+    defaultWaterAmountMode: 11,
+    buttonSoundOnOff: 12,
+    sterilizeInitMonth: 15,
+    sterilizeInitDay: 16,
+    sterilizeInitHour: 17,
+    sterilizeInitMin: 18,
+    autoCareOnOff: 20,
+    monDataRefresh: 22,
+    highSterilizeState: 23,
+    filterFlushingState: 24,
+    appVersion: 25,
+} as const
+
+/** `IGNORE` — LG's own sentinel for "this unit does not report the field", and, in a
+ *  command frame, for "leave this field alone". */
+const IGNORE = 0xff
+
+/** Command frame opcode: `aa <len> f0 17 <record> <ck> bb`. See the header note. */
+const SET_STATE = [0xf0, 0x17]
+
+/** Volumes the appliance accepts as the default dispense, in mL (LG's own enum). */
+const DEFAULT_AMOUNTS: [string, number][] = [
+    ['120 mL', 1],
+    ['250 mL', 2],
+    ['500 mL', 3],
+]
+
+// Every enum below is modelJSON `MonitoringValue.<field>.valueMapping`, with English labels
+// taken from this model's ko-KR language pack (@WP_* keys). Where LG left the label blank or
+// reused another field's key, the mapping's own `_comment` is used instead.
+
+/** wpState.monStatus */
+const MON_STATUS: Record<number, string> = { 0: 'Fault', 1: 'Not operating', 2: 'Normal' }
+
+/** wpState.cockState. COCK_MANUAL_ON is the manual-dispense hold. */
+const COCK_STATE: Record<number, string> = { 0: 'Standby', 1: 'UVnano Sterilizing', 2: 'Manual dispensing' }
+
+/** wpState.waterSelection — which tap was used last. */
+const WATER_SELECTION: Record<number, string> = {
+    1: 'Hot water',
+    2: 'Purified',
+    3: 'Cold water',
+    4: 'Sterilized water',
+}
+
+/** wpState.waterAmountMode / defaultWaterAmountMode, in the unit wpState.amountUnit reports.
+ *  Code 4 (Continuous) exists only for the live selection, not for the default. */
+const WATER_AMOUNT: Record<number, string> = { 1: '120', 2: '250', 3: '500', 4: 'Continuous' }
+
+/** wpState.hotWaterTemp — a code, not a temperature. `hotWaterTemp_C` maps it. */
+const HOT_WATER_TEMP: Record<number, number> = { 1: 40, 2: 75, 3: 85 }
+
+/** wpState.defaultWaterSet */
+const DEFAULT_WATER: Record<number, string> = { 1: 'Last used', 2: 'Purified', 3: 'Cold water' }
+
+/** wpState.highSterilizeState */
+const STERILIZE_STATE: Record<number, string> = {
+    0: 'Standby',
+    1: 'Water line sterilizing',
+    2: 'Water line sterilizing',
+    3: 'Water line sterilizing',
+    4: 'Outlet sterilizing',
+    5: 'Cancelling sterilize',
+}
+
+/** wpState.filterFlushingState */
+const FILTER_FLUSH: Record<number, string> = { 0: 'Off', 1: 'Filter replacement' }
+
+/** wpState.tempUnit / amountUnit — settings the panel owns; diagnostic only. */
+const TEMP_UNIT: Record<number, string> = { 0: '°F', 1: '°C' }
+const AMOUNT_UNIT: Record<number, string> = { 0: 'oz', 1: 'mL' }
+
+const enumOf = (table: Record<number, string>, raw: number) => table[raw] ?? `Code ${raw}`
+
+export default class Device extends AABBDevice {
+    private readonly legacyPlatformCleanup: DeviceDiscovery
+    private historyStore: PurifierHistoryStore | undefined
+    private history: PurifierHistoryState | undefined
+    private historyUnavailable = false
+    private midnightTimer: Timer | undefined
+    private historyRetryTimer: Timer | undefined
+    private sterilizationScheduleTimer: Timer | undefined
+    private sterilizationScheduleParts: number[] | undefined
+    private sterilizationScheduleKey: string | undefined
+    private sterilizationScheduleAnchor: number | undefined
+    private sterilizationScheduleObserved = false
+    private historyPublishCache: Record<string, string | number> = {}
+    private pendingUsage: PendingUsage | undefined
+    private pendingSterilization: { active: SterilizationActive } | undefined
+    private observedSterilizationKind: NonNullable<SterilizationActive>['kind'] | undefined
+    private readonly clock: Clock
+
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata, clock: Partial<Clock> = {}) {
+        super(HA, thinq)
+        this.clock = { ...systemClock, ...clock }
+
+        const sensor = (id: string, name: string, extra: object = {}) => ({
+            platform: 'sensor',
+            unique_id: `$deviceid-${id}`,
+            state_topic: `$this/${id}`,
+            name,
+            ...extra,
+        })
+
+        const config: DeviceDiscovery = allowExtendedType({
+            ...HADevice.config(meta, { name: 'LG Water Purifier' }),
+            components: {
+                status: sensor('status', 'State', { icon: 'mdi:water-check' }),
+                water_selection: sensor('water_selection', 'Last dispense', { icon: 'mdi:water' }),
+                water_amount: sensor('water_amount', 'Dispense volume', { icon: 'mdi:cup-water' }),
+                hot_water_temp: sensor('hot_water_temp', 'Hot water temp', {
+                    device_class: 'temperature',
+                    unit_of_measurement: '°C',
+                    suggested_display_precision: 0,
+                    // 0xff (IGNORE) publishes nothing, so the entity must tolerate a gap.
+                    value_template: "{{ value if value | is_number else 'None' }}",
+                }),
+                cock_state: sensor('cock_state', 'Outlet state', { icon: 'mdi:shield-sun-outline' }),
+                sterilize_state: sensor('sterilize_state', 'Sterilize state', { icon: 'mdi:shield-sun' }),
+                filter_flushing: sensor('filter_flushing', 'Filter cleaning', { icon: 'mdi:air-filter' }),
+                sterilize_reserved_at: sensor('sterilize_reserved_at', 'Sterilize schedule time', {
+                    icon: 'mdi:calendar-clock',
+                }),
+                sterilize_weekly_schedule: sensor('sterilize_weekly_schedule', 'Weekly sterilize schedule', {
+                    icon: 'mdi:calendar-week',
+                }),
+                sterilize_time: sensor('sterilize_time', 'Sterilize schedule time', {
+                    icon: 'mdi:clock-outline',
+                }),
+                default_water: {
+                    platform: 'select',
+                    unique_id: '$deviceid-default_water',
+                    state_topic: '$this/default_water',
+                    command_topic: '$this/default_water/set',
+                    name: 'Default dispense',
+                    icon: 'mdi:water-outline',
+                    options: Object.values(DEFAULT_WATER),
+                },
+                default_water_amount: {
+                    platform: 'select',
+                    unique_id: '$deviceid-default_water_amount',
+                    state_topic: '$this/default_water_amount',
+                    command_topic: '$this/default_water_amount/set',
+                    name: 'Default dispense volume',
+                    icon: 'mdi:cup-outline',
+                    options: DEFAULT_AMOUNTS.map(([label]) => label),
+                },
+                button_sound: {
+                    platform: 'binary_sensor',
+                    unique_id: '$deviceid-button-sound',
+                    state_topic: '$this/button_sound',
+                    name: 'Button sound',
+                    icon: 'mdi:volume-high',
+                    payload_on: 'ON',
+                    payload_off: 'OFF',
+                },
+                auto_care: {
+                    platform: 'switch',
+                    unique_id: '$deviceid-auto-care',
+                    state_topic: '$this/auto_care',
+                    command_topic: '$this/auto_care/set',
+                    name: 'High-temp sterilize schedule',
+                    icon: 'mdi:shield-check',
+                    payload_on: 'ON',
+                    payload_off: 'OFF',
+                },
+                not_use_notice: {
+                    platform: 'switch',
+                    unique_id: '$deviceid-not-use-notice',
+                    state_topic: '$this/not_use_notice',
+                    command_topic: '$this/not_use_notice/set',
+                    name: 'Disuse alert',
+                    icon: 'mdi:bell-outline',
+                    payload_on: 'ON',
+                    payload_off: 'OFF',
+                },
+                temp_unit: sensor('temp_unit', 'Temperature unit', {
+                    icon: 'mdi:thermometer',
+                    entity_category: 'diagnostic',
+                }),
+                amount_unit: sensor('amount_unit', 'Volume unit', {
+                    icon: 'mdi:beaker',
+                    entity_category: 'diagnostic',
+                }),
+                app_version: sensor('app_version', 'App version', { icon: 'mdi:tag', entity_category: 'diagnostic' }),
+                data_refresh: sensor('data_refresh', 'Data refresh interval', {
+                    icon: 'mdi:timer-outline',
+                    entity_category: 'diagnostic',
+                }),
+                water_usage_today: sensor('water_usage_today', 'Today usage', {
+                    device_class: 'volume',
+                    unit_of_measurement: 'L',
+                    state_class: 'measurement',
+                    suggested_display_precision: 1,
+                }),
+                water_usage_normal: sensor('water_usage_normal', 'Today purified', {
+                    device_class: 'volume',
+                    unit_of_measurement: 'L',
+                    state_class: 'measurement',
+                    suggested_display_precision: 1,
+                }),
+                water_usage_cold: sensor('water_usage_cold', 'Today cold water', {
+                    device_class: 'volume',
+                    unit_of_measurement: 'L',
+                    state_class: 'measurement',
+                    suggested_display_precision: 1,
+                }),
+                water_usage_hot: sensor('water_usage_hot', 'Today hot water', {
+                    device_class: 'volume',
+                    unit_of_measurement: 'L',
+                    state_class: 'measurement',
+                    suggested_display_precision: 1,
+                }),
+                water_usage_sterilization: sensor('water_usage_sterilization', 'Today rinse water', {
+                    device_class: 'volume',
+                    unit_of_measurement: 'L',
+                    state_class: 'measurement',
+                    suggested_display_precision: 1,
+                }),
+                sterilize_pipe_last_at: sensor('sterilize_pipe_last_at', 'Last water-line sterilize', {
+                    icon: 'mdi:pipe',
+                }),
+                sterilize_outlet_last_at: sensor('sterilize_outlet_last_at', 'Last outlet sterilize', {
+                    icon: 'mdi:water-pump',
+                }),
+                sterilize_previous_month_count: sensor(
+                    'sterilize_previous_month_count',
+                    'Last month high-temp sterilize count',
+                    {
+                        icon: 'mdi:calendar-check',
+                        unit_of_measurement: 'x',
+                        // Keep the descriptive MQTT payload ("Before collection"), while exposing a native
+                        // unknown state instead of making the unit-bearing sensor unavailable.
+                        value_template: "{{ value if value | is_number else 'None' }}",
+                    },
+                ),
+            },
+        })
+
+        // Home Assistant keys a device-discovery component by both component id and platform.
+        // Removing the former platform first prevents the old sensor/binary_sensor registry
+        // entries from surviving beside their select/switch replacements. Keep this cleanup
+        // payload so every discovery replay (including a simultaneous HA/add-on restart) sends
+        // the tombstones before the replacement config.
+        this.legacyPlatformCleanup = allowExtendedType({
+            ...HADevice.config(meta, { name: 'LG Water Purifier' }),
+            components: {
+                default_water: { platform: 'sensor' } as ComponentInfo,
+                default_water_amount: { platform: 'sensor' } as ComponentInfo,
+                auto_care: { platform: 'binary_sensor' } as ComponentInfo,
+                not_use_notice: { platform: 'binary_sensor' } as ComponentInfo,
+                sterilize_time: { platform: 'text' } as ComponentInfo,
+            },
+        })
+
+        this.setConfig(config)
+    }
+
+    publishConfig() {
+        if (this.legacyPlatformCleanup) this.HA.publishConfig(this.id, this.legacyPlatformCleanup)
+        super.publishConfig()
+    }
+
+    setPurifierHistoryStore(store: PurifierHistoryStore) {
+        this.historyStore = store
+    }
+
+    applyPurifierUsageBaseline(day: string, baseline: PurifierDailyUsage) {
+        if (!this.history || this.historyUnavailable || day !== kstDay(this.clock.now())) return false
+
+        const next = copyHistory(this.history)
+        if (next.usage.day !== day) next.usage = emptyUsage(day)
+
+        const pendingUsage = this.pendingUsage
+        const localUsage = { ...next.usage }
+        if (pendingUsage?.day === day) {
+            for (const key of Object.keys(pendingUsage.delta) as (keyof UsageDelta)[])
+                localUsage[key] += pendingUsage.delta[key]
+        }
+        for (const key of Object.keys(baseline) as (keyof PurifierDailyUsage)[])
+            next.usage[key] = Math.max(localUsage[key], baseline[key])
+        next.usageComplete = true
+
+        // The live driver is the sole owner of both its memory snapshot and JSON file.
+        // Suppress saveHistory's normal pending-delta fold because it is already included
+        // in localUsage above; restore it if the atomic save fails.
+        this.pendingUsage = undefined
+        if (!this.saveHistory(next)) {
+            this.pendingUsage = pendingUsage
+            return false
+        }
+        this.history = next
+        this.publishHistory()
+        return true
+    }
+
+    start() {
+        super.start()
+        if (!this.historyStore || this.historyUnavailable) return
+
+        try {
+            const now = this.clock.now()
+            let state = this.historyStore.load(this.id)
+            if (!state) {
+                state = {
+                    version: 1,
+                    collectedSince: now,
+                    usageComplete: false,
+                    usage: emptyUsage(kstDay(now)),
+                    sterilization: { countsByMonth: {} },
+                }
+                this.historyStore.save(this.id, state)
+            }
+            this.history = state
+            if (this.rollover(now)) this.publishHistory()
+            this.scheduleMidnight()
+        } catch (error) {
+            this.enterHistoryUnavailable('Cannot load purifier history', error)
+        }
+    }
+
+    drop() {
+        this.clock.clearTimeout(this.midnightTimer)
+        this.midnightTimer = undefined
+        this.clock.clearTimeout(this.historyRetryTimer)
+        this.historyRetryTimer = undefined
+        this.clock.clearTimeout(this.sterilizationScheduleTimer)
+        this.sterilizationScheduleTimer = undefined
+        this.sterilizationScheduleParts = undefined
+        this.sterilizationScheduleKey = undefined
+        this.sterilizationScheduleAnchor = undefined
+        this.sterilizationScheduleObserved = false
+        super.drop()
+    }
+
+    /*
+     * The base class strips the AA/length prefix before handing the body on, but every offset
+     * above is stated against the WHOLE frame — that is how the probes recorded them, and
+     * keeping the two in the same coordinate system is what makes the map checkable. So the
+     * frame is taken here, unstripped.
+     */
+    processData(buf: Buffer) {
+        if (!isValidAABBFrame(buf)) return
+        if (this.processUsage(buf)) {
+            if (this.historyRetryTimer) this.publishHistory()
+            return
+        }
+        if (buf[2] !== CLASS_TAG) return
+        const payload = buf.length - HEADER_LEN - TRAILER_LEN
+        if (payload <= 0 || payload % RECORD_LEN !== 0) return
+
+        // A valid appliance state frame is also an opportunity to drain a failed HA history publish.
+        if (this.historyRetryTimer) this.publishHistory()
+
+        // The trailing record is the current state; a leading one, when present, is the previous.
+        const record = buf.length - TRAILER_LEN - RECORD_LEN
+        const at = (o: number) => buf[record + o]
+        this.processSterilization(at(OFF.highSterilizeState))
+
+        this.publishProperty('status', enumOf(MON_STATUS, at(OFF.monStatus)))
+        this.publishProperty('cock_state', enumOf(COCK_STATE, at(OFF.cockState)))
+        this.publishProperty('water_selection', enumOf(WATER_SELECTION, at(OFF.waterSelection)))
+        this.publishProperty('sterilize_state', enumOf(STERILIZE_STATE, at(OFF.highSterilizeState)))
+        this.publishProperty('filter_flushing', enumOf(FILTER_FLUSH, at(OFF.filterFlushingState)))
+        this.publishProperty('default_water', enumOf(DEFAULT_WATER, at(OFF.defaultWaterSet)))
+        this.publishProperty('temp_unit', enumOf(TEMP_UNIT, at(OFF.tempUnit)))
+        this.publishProperty('amount_unit', enumOf(AMOUNT_UNIT, at(OFF.amountUnit)))
+
+        // Volumes read in whatever unit wpState.amountUnit reports, so the unit travels with the value.
+        const unit = AMOUNT_UNIT[at(OFF.amountUnit)] ?? 'mL'
+        const amount = WATER_AMOUNT[at(OFF.waterAmountMode)]
+        this.publishProperty(
+            'water_amount',
+            amount ? (amount === 'Continuous' ? amount : `${amount} ${unit}`) : 'Unknown',
+        )
+        // The DEFAULT volume is a select, so its state has to be one of the option strings —
+        // and LG's setter enum for it is mL-only, unlike the live reading above.
+        const dflt = DEFAULT_AMOUNTS.find(([, code]) => code === at(OFF.defaultWaterAmountMode))
+        this.publishProperty('default_water_amount', dflt ? dflt[0] : 'Unknown')
+
+        // hotWaterTemp is a 1/2/3 code, and 0xff means this unit is not reporting one.
+        const hot = HOT_WATER_TEMP[at(OFF.hotWaterTemp)]
+        this.publishProperty('hot_water_temp', hot ?? '')
+
+        // Empty retained payload removes a previously retained state. Only the model's
+        // documented 0/1 codes may become OFF/ON; IGNORE and future codes stay unknown.
+        const binaryState = (raw: number) => (raw === 0 ? 'OFF' : raw === 1 ? 'ON' : '')
+        this.publishProperty('button_sound', binaryState(at(OFF.buttonSoundOnOff)))
+        this.publishProperty('auto_care', binaryState(at(OFF.autoCareOnOff)))
+        this.publishProperty('not_use_notice', binaryState(at(OFF.notUseNotice)))
+
+        // The sterilisation reservation is four UTC bytes (month, day, hour, minute). ThinQ renders
+        // that moment in KST; 0xff in any field means "not set".
+        const parts = [OFF.sterilizeInitMonth, OFF.sterilizeInitDay, OFF.sterilizeInitHour, OFF.sterilizeInitMin].map(
+            at,
+        )
+        this.publishSterilizationSchedule(parts)
+
+        this.publishProperty('app_version', at(OFF.appVersion))
+        this.publishProperty('data_refresh', at(OFF.monDataRefresh))
+    }
+
+    private publishSterilizationSchedule(parts: number[]) {
+        this.sterilizationScheduleParts = [...parts]
+        this.clock.clearTimeout(this.sterilizationScheduleTimer)
+        this.sterilizationScheduleTimer = undefined
+
+        const now = this.clock.now()
+        const key = parts.join(',')
+        const firstObservation = !this.sterilizationScheduleObserved
+        this.sterilizationScheduleObserved = true
+        if (key !== this.sterilizationScheduleKey) {
+            this.sterilizationScheduleKey = key
+            const stored = firstObservation ? this.history?.schedule : undefined
+            this.sterilizationScheduleAnchor =
+                stored?.parts.join(',') === key ? stored.instant : scheduleAnchor(parts, now)
+        }
+        this.persistSterilizationSchedule(parts, this.sterilizationScheduleAnchor)
+        const schedule =
+            this.sterilizationScheduleAnchor === undefined
+                ? undefined
+                : scheduleInKst(this.sterilizationScheduleAnchor, now)
+        this.publishProperty('sterilize_reserved_at', formatSterilizationSchedule(schedule))
+        this.publishProperty('sterilize_weekly_schedule', formatWeeklySchedule(schedule))
+
+        // Read-only clock view of the four-field reservation. ThinQ displays the UTC record in
+        // KST; writing its time would also replace the appliance-owned weekly day anchor.
+        this.publishProperty('sterilize_time', schedule ? `${pad2(schedule.hour)}:${pad2(schedule.minute)}` : '')
+        if (!schedule) return
+
+        // The appliance may retain the original weekly anchor after that occurrence passes.
+        // Advance Home Assistant at the boundary even when no new state frame arrives.
+        this.sterilizationScheduleTimer = this.clock.setTimeout(
+            () => {
+                this.sterilizationScheduleTimer = undefined
+                if (this.sterilizationScheduleParts) this.publishSterilizationSchedule(this.sterilizationScheduleParts)
+            },
+            Math.min(MAX_TIMEOUT_MS, Math.max(1, schedule.instant - now + 1)),
+        )
+        this.unref(this.sterilizationScheduleTimer)
+    }
+
+    private persistSterilizationSchedule(parts: number[], anchor: number | undefined) {
+        if (!this.history || this.historyUnavailable) return
+        if (anchor === undefined) {
+            if (!this.history.schedule) return
+            const next = copyHistory(this.history)
+            delete next.schedule
+            if (this.saveHistory(next)) this.history = next
+            return
+        }
+        if (this.history.schedule?.instant === anchor && this.history.schedule.parts.join(',') === parts.join(','))
+            return
+
+        const next = copyHistory(this.history)
+        next.schedule = {
+            parts: [parts[0]!, parts[1]!, parts[2]!, parts[3]!],
+            instant: anchor,
+        }
+        if (this.saveHistory(next)) this.history = next
+    }
+
+    private processUsage(buf: Buffer) {
+        if (
+            buf.length !== 18 ||
+            buf[0] !== 0xaa ||
+            buf[1] !== 0x12 ||
+            buf[2] !== CLASS_TAG ||
+            buf[3] !== 0x1f ||
+            buf[4] !== 0x00 ||
+            buf[17] !== 0xbb
+        )
+            return false
+
+        const delta = {
+            normal: buf[5],
+            hot: buf.readUInt16BE(6),
+            cold: buf.readUInt16BE(8),
+            soda: buf.readUInt16BE(10),
+            mineral: buf.readUInt16BE(12),
+            sterilization: buf.readUInt16BE(14),
+        }
+        if (!Object.values(delta).some(Boolean)) return true
+        const now = this.clock.now()
+        if (!this.history || this.historyUnavailable) return true
+
+        const previousDay = this.history.usage.day
+        const next = copyHistory(this.history)
+        const day = kstDay(now)
+        if (next.usage.day !== day) {
+            next.usage = emptyUsage(day)
+            next.usageComplete = true
+        }
+        for (const key of Object.keys(delta) as (keyof typeof delta)[]) next.usage[key] += delta[key]
+        if (this.saveHistory(next)) {
+            this.history = next
+            this.publishHistory()
+            if (day !== previousDay) this.scheduleMidnight()
+        } else {
+            this.retainUsage(day, delta)
+        }
+        return true
+    }
+
+    private retainUsage(day: string, delta: UsageDelta) {
+        if (this.pendingUsage?.day !== day) {
+            this.pendingUsage = { day, delta: { ...delta } }
+            return
+        }
+        for (const key of Object.keys(delta) as (keyof UsageDelta)[]) this.pendingUsage.delta[key] += delta[key]
+    }
+
+    private processSterilization(phase: number) {
+        if (!this.history || this.historyUnavailable) return
+        const now = this.clock.now()
+        if (!this.prepareHistoryAt(now)) return
+
+        if (this.pendingSterilization && !this.updateSterilization(this.pendingSterilization.active)) return
+
+        const current = this.history!.sterilization.active
+        const kind = phase >= 1 && phase <= 3 ? 'pipe' : phase === 4 ? 'outlet' : undefined
+        if (phase === 5) {
+            this.observedSterilizationKind = undefined
+            if (current) this.updateSterilization(undefined)
+            return
+        }
+        if (kind) {
+            this.observedSterilizationKind = kind
+            if (current?.kind === kind) return
+            this.updateSterilization({ kind, startedAt: now })
+            return
+        }
+        if (phase !== 0 || !current) return
+        if (this.observedSterilizationKind !== current.kind) {
+            // A persisted active marker only says the previous process saw a start. If the
+            // first state after restart is idle, completion happened while we were offline
+            // (or the marker is stale), so clear it without inventing a completion timestamp.
+            this.observedSterilizationKind = undefined
+            this.updateSterilization(undefined)
+            return
+        }
+
+        const next = copyHistory(this.history!)
+        next.sterilization.active = undefined
+        if (current.kind === 'pipe') next.sterilization.lastPipeAt = now
+        else next.sterilization.lastOutletAt = now
+        const month = kstMonth(now)
+        next.sterilization.countsByMonth[month] = (next.sterilization.countsByMonth[month] ?? 0) + 1
+        if (this.saveHistory(next)) {
+            this.history = next
+            this.observedSterilizationKind = undefined
+            this.publishHistory()
+        }
+    }
+
+    private updateSterilization(active: SterilizationActive) {
+        const next = copyHistory(this.history!)
+        next.sterilization.active = active
+        if (this.saveHistory(next)) {
+            this.history = next
+            this.publishHistory()
+            return true
+        }
+        this.pendingSterilization = { active }
+        return false
+    }
+
+    private prepareHistoryAt(now: number) {
+        if (!this.history || this.historyUnavailable) return false
+        const previousDay = this.history.usage.day
+        const rolled = this.rollover(now, true)
+        if (rolled && this.history?.usage.day !== previousDay) this.scheduleMidnight()
+        return rolled
+    }
+
+    private rollover(now: number, completeNewDay = false) {
+        if (!this.history || this.historyUnavailable) return false
+        const day = kstDay(now)
+        if (this.history.usage.day === day) return true
+        const next = copyHistory(this.history)
+        next.usage = emptyUsage(day)
+        next.usageComplete = completeNewDay
+        if (!this.saveHistory(next)) return false
+        this.history = next
+        this.publishHistory()
+        return true
+    }
+
+    private saveHistory(next: PurifierHistoryState) {
+        try {
+            if (this.pendingUsage?.day === next.usage.day) {
+                for (const key of Object.keys(this.pendingUsage.delta) as (keyof UsageDelta)[])
+                    next.usage[key] += this.pendingUsage.delta[key]
+            }
+            if (this.pendingSterilization) next.sterilization.active = this.pendingSterilization.active
+            const now = this.clock.now()
+            const retainedMonths = new Set([kstMonth(now), previousKstMonth(now)])
+            next.sterilization.countsByMonth = Object.fromEntries(
+                Object.entries(next.sterilization.countsByMonth).filter(([month]) => retainedMonths.has(month)),
+            )
+            this.historyStore!.save(this.id, next)
+            this.pendingUsage = undefined
+            this.pendingSterilization = undefined
+            return true
+        } catch (error) {
+            console.warn('Cannot save purifier history', error)
+            return false
+        }
+    }
+
+    private historySnapshot() {
+        const state = this.history!
+        const usage = state.usage
+        const total = usage.normal + usage.hot + usage.cold + usage.soda + usage.mineral + usage.sterilization
+        const now = this.clock.now()
+        const previous = previousKstMonth(now)
+        const collected = state.collectedSince <= previousKstMonthStart(now)
+        const usageValue = (value: number) => (state.usageComplete ? value / 1000 : '')
+        return {
+            water_usage_today: usageValue(total),
+            water_usage_normal: usageValue(usage.normal),
+            water_usage_cold: usageValue(usage.cold),
+            water_usage_hot: usageValue(usage.hot),
+            water_usage_sterilization: usageValue(usage.sterilization),
+            sterilize_pipe_last_at: formatKst(state.sterilization.lastPipeAt),
+            sterilize_outlet_last_at: formatKst(state.sterilization.lastOutletAt),
+            sterilize_previous_month_count: collected
+                ? (state.sterilization.countsByMonth[previous] ?? 0)
+                : 'Before collection',
+        }
+    }
+
+    private publishHistory() {
+        if (!this.history || this.historyUnavailable) return
+        let failed = false
+        for (const [property, value] of Object.entries(this.historySnapshot())) {
+            if (this.historyPublishCache[property] === value) continue
+            try {
+                this.HA.publishProperty(this.id, property, value)
+                this.historyPublishCache[property] = value
+            } catch (error) {
+                failed = true
+                console.warn(`Purifier history '${property}' Publish failed`, error)
+            }
+        }
+        if (failed) this.scheduleHistoryRetry()
+        else {
+            this.clock.clearTimeout(this.historyRetryTimer)
+            this.historyRetryTimer = undefined
+        }
+    }
+
+    private scheduleHistoryRetry() {
+        if (this.historyRetryTimer || this.historyUnavailable) return
+        this.historyRetryTimer = this.clock.setTimeout(() => {
+            this.historyRetryTimer = undefined
+            this.publishHistory()
+        }, HISTORY_RETRY_MS)
+        this.unref(this.historyRetryTimer)
+    }
+
+    private scheduleMidnight() {
+        if (!this.history || this.historyUnavailable) return
+        this.clock.clearTimeout(this.midnightTimer)
+        const now = this.clock.now()
+        this.midnightTimer = this.clock.setTimeout(
+            () => {
+                this.midnightTimer = undefined
+                if (this.rollover(this.clock.now(), true)) this.publishHistory()
+                this.scheduleMidnight()
+            },
+            Math.max(0, nextKstMidnight(now) - now),
+        )
+        this.unref(this.midnightTimer)
+    }
+
+    private unref(timer: Timer) {
+        ;(timer as unknown as { unref?: () => void }).unref?.()
+    }
+
+    private enterHistoryUnavailable(message: string, error: unknown) {
+        console.warn(message, error)
+        this.historyUnavailable = true
+        this.history = undefined
+        this.pendingUsage = undefined
+        this.pendingSterilization = undefined
+        this.clock.clearTimeout(this.midnightTimer)
+        this.midnightTimer = undefined
+        this.clock.clearTimeout(this.historyRetryTimer)
+        this.historyRetryTimer = undefined
+        for (const property of HISTORY_PROPERTIES) {
+            try {
+                // Empty retained MQTT payloads remove the old retained state instead of presenting
+                // stale history as current while persistence is unavailable.
+                this.HA.publishProperty(this.id, property, '')
+            } catch (clearError) {
+                console.warn(`Purifier history '${property}' Init failed`, clearError)
+            }
+        }
+    }
+
+    /**
+     * Build and send a set-state frame: `aa <len> f0 17 <26-byte record> <ck> bb`, with every
+     * field this command is not changing left at 0xff.
+     *
+     * The base class's `send` supplies the AA/length prefix and the checksum, so what goes in
+     * is `f0 17` plus the record — which reproduces the captured frames byte for byte.
+     */
+    private setField(offset: number, value: number) {
+        const record = Buffer.alloc(RECORD_LEN, IGNORE)
+        record[offset] = value
+        this.send(Buffer.concat([Buffer.from(SET_STATE), record]))
+    }
+
+    setProperty(prop: string, mqttValue: string) {
+        switch (prop) {
+            case 'default_water': {
+                const code = Object.entries(DEFAULT_WATER).find(([, label]) => label === mqttValue)?.[0]
+                if (code === undefined) return console.warn(`Water Purifier: Unknown default dispense '${mqttValue}'`)
+                return this.setField(OFF.defaultWaterSet, Number(code))
+            }
+            case 'default_water_amount': {
+                const hit = DEFAULT_AMOUNTS.find(([label]) => label === mqttValue)
+                if (!hit) return console.warn(`Water Purifier: Unknown default dispense volume '${mqttValue}'`)
+                return this.setField(OFF.defaultWaterAmountMode, hit[1])
+            }
+            case 'auto_care':
+                if (mqttValue !== 'ON' && mqttValue !== 'OFF')
+                    return console.warn(`Water Purifier: Invalid high-temp sterilize schedule value '${mqttValue}'`)
+                return this.setField(OFF.autoCareOnOff, mqttValue === 'ON' ? 1 : 0)
+            case 'not_use_notice':
+                if (mqttValue !== 'ON' && mqttValue !== 'OFF')
+                    return console.warn(`Water Purifier: Invalid disuse-alert value '${mqttValue}'`)
+                return this.setField(OFF.notUseNotice, mqttValue === 'ON' ? 1 : 0)
+            default:
+                console.warn(`Water Purifier: Item does not support writing ${prop}`)
+        }
+    }
+}

--- a/cloud/devices/BDH_D39301_KR.ts
+++ b/cloud/devices/BDH_D39301_KR.ts
@@ -1,0 +1,11 @@
+import { Device as Thinq2Device } from '../thinq2/device'
+import { type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import WashTowerDevice, { DRYER_MODEL } from './washtower_common'
+
+/** LG WashTower upper dryer, ThinQ deviceType 222. */
+export default class BDH_D39301_KR extends WashTowerDevice {
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq, meta, DRYER_MODEL)
+    }
+}

--- a/cloud/devices/DHUM_056905_WW.ts
+++ b/cloud/devices/DHUM_056905_WW.ts
@@ -1,0 +1,744 @@
+import TLVDevice from './tlv_device'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { DeviceDiscovery, type ComponentInfo, type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import * as TLV from '@/util/tlv'
+import HADevice from './base'
+
+/** TLV tags present in capability (0xA7/0x01) packets — store state but do not publish as entity values. */
+const CAPS_ONLY_TAGS = new Set([0x2d5, 0x2d6, 0x336, 0x2e5, 0x2e6, 0x2da])
+
+/** Switches only some units on this platform have, by the tag that proves it. */
+const OPTIONAL_COMPONENTS: Record<number, string> = {
+    0x2a2: 'uv_nano',
+    0x360: 'ionizer',
+    // Declared by LG's modelJSON for the platform, so held back the same way: the declaration is
+    // per-platform, not per-unit, and an appliance that never reports the tag has no such control.
+    0x17c: 'ban_disturb_sleep',
+    0x185: 'watertank_light_brightness',
+    0x186: 'watertank_state',
+    0x189: 'swing',
+    0x18f: 'fan_when_full',
+    0x1fd: 'temperature',
+    0x20e: 'auto_dry',
+    0x21f: 'display',
+    0x221: 'error',
+    0x225: 'auto_dry_remain',
+    0x337: 'sensor_mon',
+    0x357: 'safe_op_remain',
+    0x392: 'discharge_clean',
+    0x3a0: 'bell_sound',
+    0x3b9: 'melody',
+    0x3e0: 'mood_color',
+}
+
+/** Observed on bucket-empty notify when the tank is reinstalled (0x2b1=256, 0x2b2=0). */
+const BUCKET_EMPTIED_EVENT = 256
+
+/** Entering these modes resets fan speed to low (high remains user-selectable). */
+const SILENT_MODES = new Set([2, 19])
+
+const HA_MODES = ['Smart', 'Jet', 'Silent', 'Intensive', 'Laundry'] as const
+
+const CLIP_TO_HA_MODE: Record<number, string> = {
+    0: 'Smart',
+    1: 'Jet',
+    2: 'Silent',
+    4: 'Intensive',
+    5: 'Laundry',
+    17: 'Smart',
+    18: 'Jet',
+    19: 'Silent',
+    20: 'Intensive',
+    21: 'Laundry',
+}
+
+const HA_TO_CLIP_MODE: Record<string, number> = {
+    Smart: 17,
+    Jet: 18,
+    Silent: 19,
+    Intensive: 20,
+    Laundry: 21,
+}
+
+/**
+ * Mode tables live on the class, not in module scope, so a sibling model on the
+ * same platform can reuse this whole implementation and override just the enum.
+ * Reads go through `this.modes()`, which resolves against the *actual* class —
+ * subclass statics included. Necessary because these codes are model-specific:
+ * DHUM_231006_WW shares 19/20 with this model but uses 85/86 where this one
+ * uses 17/21.
+ */
+export type ModeTables = {
+    haModes: readonly string[]
+    clipToHa: Record<number, string>
+    haToClip: Record<string, number>
+    silent: ReadonlySet<number>
+    /** Fan-speed labels shown in HA, and their clip codes. */
+    fanOptions: readonly string[]
+    fanToHa: Record<number, string>
+    fanToClip: Record<string, number>
+    /** Label + code used when a silent mode forces the fan down. */
+    lowFan: string
+    lowFanClip: number
+    /** Clip codes this model actually accepts for a fan write. */
+    fanClipValues: ReadonlySet<number>
+    /**
+     * Per-mode fan-memory triplets to emit alongside 0x1fa, as [mode, fan].
+     * The 056905 panel writes the whole table on every fan change; models with
+     * no captured evidence of that should return an empty list and send 0x1fa
+     * alone rather than guess at mode codes they may not have.
+     */
+    fanPerMode: (fan: number) => [number, number][]
+}
+
+function normalizeHaMode(val: string): string {
+    return val.replace(/\S+/g, (w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+}
+
+/**
+ * LG Dehumidifier DHUM_056905_WW (e.g. models using 056905 platform, deviceType 403)
+ */
+export default class Device extends TLVDevice {
+    /** Override in a subclass for a model whose mode codes differ. */
+    static modeTables: ModeTables = {
+        haModes: HA_MODES,
+        clipToHa: CLIP_TO_HA_MODE,
+        haToClip: HA_TO_CLIP_MODE,
+        silent: SILENT_MODES,
+        fanOptions: ['Low', 'High'],
+        fanToHa: { 2: 'Low', 6: 'High' },
+        fanToClip: { Low: 2, High: 6 },
+        lowFan: 'Low',
+        lowFanClip: 2,
+        fanClipValues: new Set([2, 6]),
+        fanPerMode: (fan) =>
+            fan === 2
+                ? [
+                      [17, 2],
+                      [18, 2],
+                      [20, 2],
+                      [21, 6],
+                      [22, 2],
+                  ]
+                : [
+                      [17, 6],
+                      [18, 6],
+                      [20, 6],
+                      [21, 6],
+                      [22, 6],
+                  ],
+    }
+
+    /** Resolves against the real class, so subclass overrides win. */
+    modes(): ModeTables {
+        return (this.constructor as typeof Device).modeTables
+    }
+
+    powerStatePrev?: boolean
+    modePrev?: string
+    modeClipPrev?: number
+    initialValuesReceived = false
+    /** Last bucket-full state published to HA (retained). */
+    bucketFullHaState?: boolean
+
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        const config: DeviceDiscovery = allowExtendedType({
+            ...HADevice.config(meta, { name: 'LG Dehumidifier' }),
+            components: {
+                humidifier: {
+                    platform: 'humidifier',
+                    unique_id: '$deviceid-humidifier',
+                    name: null,
+                    device_class: 'dehumidifier',
+                    modes: [...this.modes().haModes],
+                    min_humidity: 30,
+                    max_humidity: 70,
+                },
+                ionizer: {
+                    platform: 'switch',
+                    unique_id: '$deviceid-ionizer',
+                    name: 'Ionizer',
+                    icon: 'mdi:air-filter',
+                },
+                uv_nano: {
+                    platform: 'switch',
+                    unique_id: '$deviceid-uv_nano',
+                    name: 'UVnano',
+                    icon: 'mdi:lightbulb',
+                },
+                bucket_light: {
+                    platform: 'switch',
+                    unique_id: '$deviceid-bucket_light',
+                    name: 'Bucket Light',
+                    icon: 'mdi:lightbulb-on',
+                },
+                // MQTT humidifier platform has no fan_mode support; use a select entity instead.
+                fan_speed: {
+                    platform: 'select',
+                    unique_id: '$deviceid-fan_speed',
+                    name: 'Fan speed',
+                    icon: 'mdi:fan',
+                    options: [...this.modes().fanOptions],
+                },
+                current_humidity: {
+                    platform: 'sensor',
+                    unique_id: '$deviceid-current_humidity',
+                    name: 'Current humidity',
+                    device_class: 'humidity',
+                    unit_of_measurement: '%',
+                    state_class: 'measurement',
+                    state_topic: '$this/humidifier-current_humidity',
+                },
+                bucket_full: {
+                    platform: 'binary_sensor',
+                    unique_id: '$deviceid-bucket_full',
+                    name: 'Bucket full',
+                    icon: 'mdi:water-alert',
+                    device_class: 'problem',
+                    payload_on: 'ON',
+                    payload_off: 'OFF',
+                    state_topic: '$this/bucket_full-',
+                },
+            },
+        })
+
+        // power (0x1f7) - registered as humidifier-power; we wire bare state/command below
+        this.addField(
+            config,
+            {
+                id: 0x1f7,
+                name: 'power',
+                comp: 'humidifier',
+                write_xform: (val) => (val === 'ON' ? 1 : 0),
+                write_attach: (raw) => (raw ? [0x1f9] : []),
+                read_xform: (raw) => (raw ? 'ON' : 'OFF'),
+                read_callback: (val) => {
+                    const powerState = val === 'ON'
+                    if (this.powerStatePrev !== powerState) {
+                        // future hooks
+                    }
+                    this.powerStatePrev = powerState
+                    return true // allow the power state publish
+                },
+            },
+            false,
+        )
+
+        // mode / op mode
+        this.addField(config, {
+            id: 0x1f9,
+            name: 'mode',
+            comp: 'humidifier',
+            read_xform: (raw) => this.modes().clipToHa[raw] ?? `mode${raw}`,
+            read_callback: () => {
+                const mode = this.raw_clip_state[0x1f9]
+                if (
+                    mode != null &&
+                    this.modes().silent.has(mode) &&
+                    (this.modeClipPrev == null || !this.modes().silent.has(this.modeClipPrev))
+                ) {
+                    this.publishFanSpeedState(this.modes().lowFan)
+                }
+                if (mode != null) this.modeClipPrev = mode
+                return true
+            },
+            write_xform: (val) => {
+                if (val === 'off' || val === undefined) {
+                    this.setProperty('humidifier-power', 'OFF')
+                    return undefined
+                } else {
+                    this.setProperty('humidifier-power', 'ON')
+                }
+                const mode = normalizeHaMode(val)
+                const clip = this.modes().haToClip[mode] ?? Number(val)
+                if (
+                    typeof clip === 'number' &&
+                    this.modes().silent.has(clip) &&
+                    (this.modeClipPrev == null || !this.modes().silent.has(this.modeClipPrev))
+                ) {
+                    this.raw_clip_state[0x1fa] = this.modes().lowFanClip
+                    this.publishFanSpeedState(this.modes().lowFan)
+                }
+                if (typeof clip === 'number') this.modeClipPrev = clip
+                return clip
+            },
+            write_attach: [0x1f7],
+        })
+
+        this.addField(config, {
+            id: 0x1fa,
+            name: '',
+            comp: 'fan_speed',
+            read_xform: (raw) => {
+                return this.modes().fanToHa[raw] ?? raw.toString()
+            },
+            read_callback: (val) => {
+                this.publishFanSpeedState(typeof val === 'string' ? val : String(val))
+                return false
+            },
+            write_xform: (val) => {
+                return this.modes().fanToClip[val] ?? Number(val)
+            },
+            write_callback: (val) => {
+                if (typeof val !== 'number' || !this.modes().fanClipValues.has(val)) return false
+                this.sendFanSpeedTlvs(val)
+                return false
+            },
+        })
+
+        /*
+         * Current humidity is 0x336, in whole %RH.
+         *
+         * It used to be read off 0x1fd, which published a room humidity of 238 %
+         * for a live DHUM_056905_WW. 0x1fd is the current *temperature* tag on
+         * this whole TLV family — ac_common calls it TAG_TEMP_CURRENT, and
+         * WIN/POT/RAC_056905_WW all read it as one. Checked against the LG
+         * cloud's own decode of the same appliance while bridged, 2026-07-28:
+         *
+         *   0x336 = 55        airState.humidity.current = 55
+         *   0x1fd = 238       airState.tempState.current = -18   (int8 of 238)
+         *
+         * so the cloud reads the two tags exactly the other way round from what
+         * this driver did. 0x1fd is left unpublished rather than exposed as a
+         * temperature: this unit reports -18/-20 degC indoors and LG's cloud
+         * shows that same nonsense, so the sensor is not worth an entity until
+         * a model on this platform is seen reporting a plausible one.
+         *
+         * The reading that produced the old mapping — 48 on 0x1fd, taken for
+         * 48 % — is a room temperature under whichever scale this platform uses,
+         * not a humidity.
+         */
+        this.addField(config, {
+            id: 0x336,
+            name: 'current_humidity',
+            comp: 'humidifier',
+            state_topic: 'topic',
+            writable: false,
+        })
+
+        // target humidity setpoint (0x253 on live A7/0x04 notify packets, e.g. v=35)
+        this.addField(config, {
+            id: 0x253,
+            name: 'target_humidity',
+            comp: 'humidifier',
+            read_xform: (raw) => raw,
+            read_callback: (val) => {
+                const n = typeof val === 'number' ? val : Number(val)
+                return n >= 30 && n <= 70
+            },
+            write_xform: (valStr) => {
+                let val = Number(valStr)
+                if (val < 30) val = 30
+                if (val > 70) val = 70
+                val = Math.round(val)
+                this.raw_clip_state[0x1f7] = 1
+                return val
+            },
+            write_attach: [0x1f7, 0x1f9],
+        })
+
+        // ionizer on/off (0x360 on live notify packets: 0=OFF, 1=ON)
+        this.addField(config, {
+            id: 0x360,
+            name: '',
+            comp: 'ionizer',
+            read_xform: (raw) => (raw ? 'ON' : 'OFF'),
+            write_xform: (val) => (val === 'ON' ? 1 : 0),
+            write_attach: [0x1f7, 0x1f9],
+        })
+
+        // UVnano (0x2a2 on live notify packets: 0=OFF, 1=ON)
+        this.addField(config, {
+            id: 0x2a2,
+            name: '',
+            comp: 'uv_nano',
+            read_xform: (raw) => (raw ? 'ON' : 'OFF'),
+            write_xform: (val) => (val === 'ON' ? 1 : 0),
+            write_attach: [0x1f7, 0x1f9],
+        })
+
+        // bucket light (0x21e on live notify packets: 0=OFF, 1=ON)
+        this.addField(config, {
+            id: 0x21e,
+            name: '',
+            comp: 'bucket_light',
+            read_xform: (raw) => (raw ? 'ON' : 'OFF'),
+            write_xform: (val) => (val === 'ON' ? 1 : 0),
+        })
+
+        this.addTimerField(config, 0x21b, 'off_timer', 'Sleep timer', 'mdi:bed-clock', 9)
+
+        // Wire bare state_topic/command_topic (expected by humidifier platform) to our 'power' property
+        const hum = (config.components as any).humidifier
+        hum.state_topic = '$this/humidifier-power'
+        hum.command_topic = '$this/humidifier-power/set'
+
+        this.addLGDeclaredFields(config)
+
+        this.holdOptionalComponents(config)
+        this.setConfig(config)
+    }
+
+    /*
+     * Not every unit on this platform has every extra. Hold those switches back
+     * until the appliance itself has reported their tag, so a unit without the
+     * hardware does not get a control that does nothing.
+     *
+     * Measured on a DHUM_056905_WW, 2026-07-28: 0x2a2 was never reported at all
+     * and a write to it drew no reply, while 0x360 reports 0 but ignores every
+     * write — tried in Silent, Smart, Jet and Laundry, with the LG cloud's
+     * airState.miscFuncState.extraOp never moving off 0. LG's own control list
+     * for this model (basicCtrl, reservationCtrl, remoteMon, diagData,
+     * energyStateCtrl) offers neither. Upstream PR #64 was written against a
+     * unit that has them, so they stay for appliances that report them.
+     */
+    private heldComponents: Record<number, { name: string; component: ComponentInfo }> = {}
+
+    private holdOptionalComponents(config: DeviceDiscovery) {
+        for (const [tag, name] of Object.entries(OPTIONAL_COMPONENTS)) {
+            const component = config.components[name]
+            if (!component) continue
+            this.heldComponents[Number(tag)] = { name, component }
+            delete config.components[name]
+        }
+    }
+
+    /** Publish a held switch the moment its tag arrives. */
+    private releaseOptionalComponent(tag: number) {
+        const held = this.heldComponents[tag]
+        if (!held || !this.config) return
+        delete this.heldComponents[tag]
+        this.config.components[held.name] = held.component
+        this.publishConfig()
+    }
+
+    /*
+     * A component carrying nothing but its `platform` is how device discovery
+     * says "this entity is gone"; omitting it only stops Home Assistant
+     * creating a new one. Both are needed: the omission keeps a fresh install
+     * clean, and the removal clears the entity an earlier version of this
+     * driver already created.
+     *
+     * It has to be exactly that, not an empty object. `platform` is required by
+     * DEVICE_DISCOVERY_SCHEMA, and Home Assistant rejects the *whole device
+     * payload* without it — "required key not provided @
+     * data['components'][...]['platform']" — so one malformed removal silently
+     * freezes discovery for every entity on the appliance. Home Assistant then
+     * pops `platform` and treats the now-empty config as the removal
+     * (`mqtt/discovery.py`, `_parse_device_payload`).
+     */
+    private dropUnreportedComponents() {
+        let changed = false
+        for (const [tag, held] of Object.entries(this.heldComponents)) {
+            if (this.raw_clip_state[Number(tag)] !== undefined) continue
+            if (!this.config) continue
+            this.config.components[held.name] = { platform: held.component.platform } as ComponentInfo
+            changed = true
+        }
+        // The entries stay held rather than being forgotten: an appliance that
+        // reports the tag later still gets its switch, and releasing it
+        // overwrites the removal with the real component.
+        if (changed) this.publishConfig()
+    }
+
+    /*
+     * The rest of what this platform declares.
+     *
+     * PR #64 covered the controls its author could reach from the appliance's panel. LG's own
+     * modelJSON for both dehumidifiers here labels every state field with its clip tag —
+     * `waterTankFull_state_tlv_390`, `swing_state_tlv_393`, `melody_state_tlv_953` and so on —
+     * and the two models declare an identical set, so these belong on the shared base class.
+     *
+     * They go through the same hold-back path as the ionizer and UVnano switches: a unit that
+     * never reports the tag does not get the entity. That matters here, because this list is
+     * LG's declaration for the platform rather than a per-unit capability read.
+     *
+     * Two are inverted against every other flag on the appliance — LG's own value_mapping has
+     * 0 = ON for both the display and the buzzer — so they are written as explicit tables rather
+     * than truthiness, which is exactly the sort of thing that later reads as a bug.
+     *
+     * 0x1fd finally gets an entity. It was left unpublished when the humidity mix-up was fixed,
+     * because the only unit measured then (DHUM_056905_WW) reported -18 degC indoors and LG's
+     * cloud agreed with that nonsense. DHUM_231006_WW settles the scale: it reported 0x1fd = 58
+     * while the cloud read 29.0 degC off the same appliance at the same moment, i.e. half-degrees,
+     * the same convention ac_common uses for TAG_TEMP_CURRENT. The older unit's sensor is simply
+     * broken, in the driver and in LG's cloud alike.
+     */
+    private addLGDeclaredFields(config: DeviceDiscovery) {
+        this.addLevelSelect(config, 0x189, 'swing', 'Airflow direction', 'mdi:arrow-oscillating', [
+            ['Level 1', 0],
+            ['Level 2', 1],
+            ['Level 3', 2],
+            ['Up-down swing', 3],
+        ])
+        this.addLevelSelect(config, 0x20e, 'auto_dry', 'Auto dry', 'mdi:hair-dryer', [
+            ['Off', 0],
+            ['Level 1', 1],
+            ['Level 2', 2],
+            ['Level 3', 3],
+            ['Level 4', 4],
+            ['Smart dry', 253],
+        ])
+        this.addLevelSelect(config, 0x21f, 'display', 'Display', 'mdi:brightness-6', [
+            ['On', 0],
+            ['Off', 1],
+        ])
+        this.addLevelSelect(config, 0x3a0, 'bell_sound', 'Notification sound', 'mdi:bell', [
+            ['On', 0],
+            ['Off', 1],
+        ])
+        this.addLevelSelect(config, 0x337, 'sensor_mon', 'Air quality sensor', 'mdi:motion-sensor', [
+            ['While running only', 0],
+            ['Always', 1],
+        ])
+        this.addLevelSelect(config, 0x3b9, 'melody', 'Melody', 'mdi:music-note', [
+            ['Default melody', 0],
+            ['Vivaldi Winter', 1],
+            ['Jingle Bells (chorus)', 2],
+            ['We Wish You a Merry Christmas', 3],
+            ['Beethoven Pastoral', 4],
+            ['Vivaldi Spring', 5],
+            ['Dvorak Humoresque', 6],
+            ["Elgar Salut d'Amour", 7],
+            ['Vivaldi Autumn', 8],
+            ['Tchaikovsky Sugar Plum Fairy', 9],
+            ['Radetzky March', 10],
+            ['Jingle Bells (intro)', 11],
+        ])
+        this.addLevelSelect(config, 0x3e0, 'mood_color', 'Mood light color', 'mdi:palette', [
+            ['Pure White', 0],
+            ['Very Peri', 1],
+            ['Lime', 2],
+            ['Salmon Pink', 3],
+            ['Lavender', 4],
+            ['Santorini', 5],
+            ['Sunlight', 6],
+            ['Rose', 7],
+        ])
+
+        this.addFlagSwitch(config, 0x17c, 'ban_disturb_sleep', 'Do not disturb while sleeping', 'mdi:sleep')
+        this.addFlagSwitch(config, 0x18f, 'fan_when_full', 'Fan when tank full', 'mdi:fan-alert')
+        this.addFlagSwitch(config, 0x392, 'discharge_clean', 'Vent clean', 'mdi:air-purifier')
+
+        this.addReadSensor(config, 0x1fd, 'temperature', 'Current temperature', 'mdi:thermometer', (raw) => raw / 2, {
+            device_class: 'temperature',
+            unit_of_measurement: '°C',
+            state_class: 'measurement',
+        })
+        this.addReadSensor(
+            config,
+            0x186,
+            'watertank_state',
+            'Tank state',
+            'mdi:cup-water',
+            (raw) => ({ 0: 'Normal', 1: 'Full (stopped)', 2: 'Full (fan)' })[raw] ?? `State${raw}`,
+        )
+        this.addReadSensor(config, 0x221, 'error', 'Error code', 'mdi:alert-circle-outline', (raw) =>
+            raw === 0 ? 'Normal' : `E${String(raw).padStart(2, '0')}`,
+        )
+        this.addReadSensor(config, 0x225, 'auto_dry_remain', 'Auto dry remaining', 'mdi:timer-sand', (raw) => raw)
+        this.addReadSensor(
+            config,
+            0x357,
+            'safe_op_remain',
+            'Safe operation remaining',
+            'mdi:shield-clock',
+            (raw) => raw,
+        )
+
+        config['components']['watertank_light_brightness'] = allowExtendedType({
+            platform: 'number',
+            unique_id: '$deviceid-watertank_light_brightness',
+            name: 'Tank light brightness',
+            icon: 'mdi:lightbulb-on-outline',
+            min: 0,
+            max: 4000,
+            step: 1,
+            mode: 'box',
+        })
+        this.addField(config, {
+            id: 0x185,
+            name: '',
+            comp: 'watertank_light_brightness',
+            write_xform: (val) => Math.round(Number(val)),
+        })
+    }
+
+    private addLevelSelect(
+        config: DeviceDiscovery,
+        id: number,
+        comp: string,
+        desc: string,
+        icon: string,
+        levels: readonly (readonly [string, number])[],
+    ) {
+        config['components'][comp] = allowExtendedType({
+            platform: 'select',
+            unique_id: `$deviceid-${comp}`,
+            name: desc,
+            icon,
+            options: levels.map(([label]) => label),
+        })
+        this.addField(config, {
+            id,
+            name: '',
+            comp,
+            read_xform: (raw) => levels.find(([, wire]) => wire === raw)?.[0],
+            write_xform: (val) => levels.find(([label]) => label === val)?.[1],
+        })
+    }
+
+    private addFlagSwitch(config: DeviceDiscovery, id: number, comp: string, desc: string, icon: string) {
+        config['components'][comp] = allowExtendedType({
+            platform: 'switch',
+            unique_id: `$deviceid-${comp}`,
+            name: desc,
+            icon,
+        })
+        this.addField(config, {
+            id,
+            name: '',
+            comp,
+            read_xform: (raw) => (raw ? 'ON' : 'OFF'),
+            write_xform: (val) => (val === 'ON' ? 1 : 0),
+        })
+    }
+
+    private addReadSensor(
+        config: DeviceDiscovery,
+        id: number,
+        comp: string,
+        desc: string,
+        icon: string,
+        read_xform: (raw: number) => string | number,
+        extra: Record<string, unknown> = {},
+    ) {
+        config['components'][comp] = allowExtendedType({
+            platform: 'sensor',
+            unique_id: `$deviceid-${comp}`,
+            name: desc,
+            icon,
+            ...extra,
+        })
+        this.addField(config, { id, name: '', comp, writable: false, read_xform })
+    }
+
+    addTimerField(config: DeviceDiscovery, id: number, name: string, desc: string, icon: string, max: number) {
+        const step = 1
+        const comp = {
+            platform: 'number',
+            unique_id: '$deviceid-' + name,
+            name: desc,
+            icon: icon,
+            device_class: 'duration',
+            unit_of_measurement: 'h',
+            min: 0,
+            max: max,
+            step: step,
+            mode: 'slider',
+        } as const
+        config['components'][name] = comp
+
+        /*
+         * Setpoint is hours×60 (minutes) in tlv, same as RAC timers on 0x21b.
+         * While counting down, notifies send remaining time in seconds.
+         */
+        this.addField(config, {
+            id: id,
+            name: '',
+            comp: name,
+            read_xform: (raw) => Math.ceil(raw / 60 / step) * step,
+            write_xform: (val) => Math.round(Number(val) * 60),
+        })
+    }
+
+    private fanSpeedFromClip(raw?: number): string {
+        const v = raw ?? this.raw_clip_state[0x1fa]
+        // Through the mode table rather than a hard-coded pair: DHUM_231006_WW has five speeds,
+        // and both models' labels are the appliance's own.
+        return this.modes().fanToHa[v] ?? (v != null ? String(v) : this.modes().lowFan)
+    }
+
+    private publishFanSpeedState(override?: string) {
+        const state = override ?? this.fanSpeedFromClip()
+        this.HA.publishProperty(this.id, 'fan_speed-', state)
+    }
+
+    /** Fan speed writes carry per-mode 0x2d7/0x2d8/0x2d9 triplets (see panel notify captures). */
+    private buildFanSpeedTlvs(fan: number): TLV.TLV[] {
+        const modeFan = (mode: number, fanSpeed: number) => [
+            { t: 0x2d7, v: mode },
+            { t: 0x2d8, v: 0 },
+            { t: 0x2d9, v: fanSpeed },
+        ]
+        const modes = this.modes().fanPerMode(fan)
+        const tlvs = [{ t: 0x1fa, v: fan }, ...modes.flatMap(([m, f]) => modeFan(m, f))]
+        for (const { t, v } of tlvs) this.raw_clip_state[t] = v
+        return tlvs
+    }
+
+    private sendFanSpeedTlvs(fan: number) {
+        this.send([1, 1, 2, 1, 1], this.buildFanSpeedTlvs(fan))
+    }
+
+    private publishBucketFullState(full: boolean) {
+        if (this.bucketFullHaState === full) return
+        this.bucketFullHaState = full
+        this.HA.publishProperty(this.id, 'bucket_full-', full ? 'ON' : 'OFF', { retain: true })
+    }
+
+    processKeyValue(k: number, v: number) {
+        if (this.query_caps_timeout !== undefined && CAPS_ONLY_TAGS.has(k)) {
+            this.raw_clip_state[k] = v
+            return
+        }
+        // The tag arriving is the appliance saying it has the feature; publish
+        // the switch before the value that follows.
+        if (k in this.heldComponents) this.releaseOptionalComponent(k)
+        if (k === 0x2b1) {
+            this.raw_clip_state[k] = v
+            if (v === BUCKET_EMPTIED_EVENT) this.publishBucketFullState(false)
+            return
+        }
+        if (k === 0x2b2) {
+            this.raw_clip_state[k] = v
+            this.publishBucketFullState(v !== 0)
+            return
+        }
+        super.processKeyValue(k, v)
+    }
+
+    isCapsResponse(tlvArray: TLV.TLV[]) {
+        return tlvArray.some(({ t }) => t === 0x2da)
+    }
+
+    isValuesResponse(tlvArray: TLV.TLV[]) {
+        return tlvArray.some(
+            ({ t }) =>
+                t === 0x1f7 ||
+                t === 0x1f9 ||
+                t === 0x1fa ||
+                t === 0x1fd ||
+                t === 0x21b ||
+                t === 0x21e ||
+                t === 0x2b2 ||
+                t === 0x253 ||
+                t === 0x2a2 ||
+                t === 0x360,
+        )
+    }
+
+    valuesReceived() {
+        if (this.initialValuesReceived) return
+        this.initialValuesReceived = true
+
+        // The values response is the appliance's full inventory. Anything still
+        // held back after it is something this unit does not have.
+        this.dropUnreportedComponents()
+
+        this.thinq.send('setMaskingInfo', 0, { blacklist_tlv: '1200' })
+    }
+}

--- a/cloud/devices/DHUM_231006_WW.ts
+++ b/cloud/devices/DHUM_231006_WW.ts
@@ -1,0 +1,73 @@
+import Device056905, { type ModeTables } from './DHUM_056905_WW'
+
+/**
+ * LG Dehumidifier DHUM_231006_WW (deviceType 403, BEKEN_BK7234 module,
+ * protocolVer 7 — a newer generation than the RTL8720cm the wiki documents).
+ *
+ * Shares the 056905 TLV map. Verified against the LG cloud's own decode of the
+ * same unit while bridged, every field agreeing:
+ *
+ *   0x1f7 power             airState.operation 1        -> ON
+ *   0x253 target humidity   tracked 45 / 55 / 65 exactly on each write
+ *   0x1fa fan speed         airState.windStrength
+ *   0x1f9 mode              airState.opMode
+ *   ionizer / UVnano / bucket light matched airState.* one for one
+ *
+ * Only the two enums differ, so that is all this overrides.
+ *
+ * Labels are Korean because this model is sold in Korea and its panel, the LG
+ * app, and the cloud integration all use these names — matching them keeps one
+ * vocabulary across the local and cloud paths instead of inventing a second.
+ *
+ * Codes were measured by driving each option through the cloud integration and
+ * reading back the corresponding airState field:
+ *
+ *   mode   Silent 19 · Intensive 20 · Quick 85 · Smart Plus 86
+ *   fan    Mid 4 · High 6 · Turbo 7 · Auto 8
+ *
+ * 19/20 coincide with the 056905's Silent/Spot; 85/86 are where this model
+ * diverges (056905 uses 21/17). There is no Jet equivalent here, so it is left
+ * out rather than offered and silently rejected.
+ *
+ * Low = 2 is carried over from the 056905's `low`: a direct write of it read
+ * back as 8, but only while in Smart Plus, where the appliance forces the fan
+ * to automatic — so the read was the coercion, not the code. Worth re-checking
+ * from a manual mode if Low ever misbehaves.
+ */
+export default class Device extends Device056905 {
+    static modeTables: ModeTables = {
+        haModes: ['Smart Plus', 'Silent', 'Intensive', 'Quick'],
+        clipToHa: {
+            19: 'Silent',
+            20: 'Intensive',
+            85: 'Quick',
+            86: 'Smart Plus',
+        },
+        haToClip: {
+            'Smart Plus': 86,
+            Silent: 19,
+            Intensive: 20,
+            Quick: 85,
+        },
+        // Entering Silent drops the fan to its lowest setting, the same
+        // behaviour the 056905 has for its silent mode.
+        silent: new Set([19]),
+
+        fanOptions: ['Auto', 'Low', 'Mid', 'High', 'Turbo'],
+        fanToHa: { 2: 'Low', 4: 'Mid', 6: 'High', 7: 'Turbo', 8: 'Auto' },
+        fanToClip: { Low: 2, Mid: 4, High: 6, Turbo: 7, Auto: 8 },
+        lowFan: 'Low',
+        lowFanClip: 2,
+
+        // Five speeds, not the 056905's two. The base class used to hard-reject
+        // anything but 2/6, which silently dropped Mid/Turbo/Auto writes.
+        fanClipValues: new Set([2, 4, 6, 7, 8]),
+
+        // The 056905 rewrites its whole per-mode fan-memory table on every fan
+        // change. No capture shows this model doing that, and its mode codes are
+        // different anyway (19/20/85/86 vs 17/18/20/21/22), so emitting that
+        // table here would be inventing traffic. Send 0x1fa alone until a panel
+        // capture says otherwise.
+        fanPerMode: () => [],
+    }
+}

--- a/cloud/devices/FAKPK21021.ts
+++ b/cloud/devices/FAKPK21021.ts
@@ -1,0 +1,11 @@
+import { Device as Thinq2Device } from '../thinq2/device'
+import { type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import WashTowerDevice, { WASHER_MODEL } from './washtower_common'
+
+/** LG WashTower lower washer, ThinQ deviceType 221. */
+export default class FAKPK21021 extends WashTowerDevice {
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq, meta, WASHER_MODEL)
+    }
+}

--- a/cloud/devices/HUM_056905_WW.ts
+++ b/cloud/devices/HUM_056905_WW.ts
@@ -1,0 +1,376 @@
+import TLVDevice from './tlv_device'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { DeviceDiscovery, type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import * as TLV from '@/util/tlv'
+import HADevice from './base'
+
+/*
+ * LG PuriCare air-purifying humidifier, ThinQ model HUM_056905_WW, deviceType 404.
+ *
+ * WHERE THE WIRE MAP COMES FROM
+ * -----------------------------
+ * Unlike the dehumidifier and the air conditioners, none of this was guessed from packet
+ * diffs. This model's own modelJSON labels every state field with its clip tag —
+ * "targetHumidity_state_tlv_595", "windStrength_state_tlv_506", and so on for all 38 fields
+ * — so LG publishes the exact mapping. Each id below is that label, and each enum is that
+ * field's `value_mapping` with English labels for LG's ko-KR language-pack entries.
+ *
+ * Nine of them were then confirmed on the wire, by driving the appliance from LG's cloud
+ * (through the bridge) and watching what rethink relayed:
+ *
+ *   0x1f7 power        0/1                     0x1f9 opMode   Air Clean=5 Humidify+Clean=12 Humidify=24
+ *   0x1fa windStrength Low=2 Mid=4 High=6 Turbo=7      0x253 target humidity, percent
+ *   0x109 Night mode     0x1e4 Sleep mode  0x1e6 Auto operation
+ *
+ * The rest are LG's own declarations, published because the appliance reports them: every
+ * id here appeared in the device's answer to a values query (0x1f5=2), so nothing below is
+ * an entity for a field this unit does not have.
+ *
+ * 0x1fd is half-degrees, like the AC family: wire 55 = 27.5 degC, matching what the cloud
+ * read from the same appliance at the same moment. 0x336 (humidity) is one-for-one.
+ */
+
+/** Half-degree tags — the AC family's convention, and this model shares it. */
+const HALF_DEGREE = 2
+
+/** 0x20e reports 252, not 1, for "on" — LG's own value_mapping says so. */
+const AUTO_DRY_ON = 252
+
+const OP_MODES = [
+    ['Air Clean', 5],
+    ['Humidify+Clean', 12],
+    ['Humidify', 24],
+] as const
+
+const FAN_LEVELS = [
+    ['Auto', 8],
+    ['Low', 2],
+    ['Mid', 4],
+    ['High', 6],
+    ['Turbo', 7],
+] as const
+
+const HYGIENE_DRY = [
+    ['Off', 0],
+    ['Gentle', 1],
+    ['Quiet', 2],
+    ['Quick', 3],
+    ['Focus', 4],
+    ['Default', 5],
+] as const
+
+const STANDBY_STERILIZE = [
+    ['Rapid', 0],
+    ['Normal', 1],
+    ['Silent', 2],
+    ['Power', 3],
+] as const
+
+const DISPLAY_BRIGHTNESS = [
+    ['Off', 0],
+    ['1Level', 8],
+    ['2Level', 9],
+    ['3Level', 10],
+] as const
+
+const SENSOR_MON = [
+    ['While running only', 0],
+    ['Always', 1],
+] as const
+
+/** 0x1e3, LG's humidifier.productStatus. */
+const PRODUCT_STATUS: Record<number, string> = {
+    0: 'Normal',
+    1: 'No tank',
+    2: 'Low water',
+    3: 'Sterilizing',
+    4: 'Drying',
+    5: 'Boiling',
+    6: 'Boiling (low)',
+}
+
+/** 0x3e0, LG's mood-light palette. Only the colours this model names are offered. */
+const MOOD_COLORS: [string, number][] = [
+    ['Blue', 1],
+    ['Green', 2],
+    ['Red', 3],
+    ['Purple', 4],
+    ['Yellow', 6],
+    ['Pink', 7],
+    ['Pure White', 8],
+    ['Aquarium', 9],
+    ['Candlelight', 10],
+    ['Sunlight', 11],
+    ['Rose', 12],
+    ['Mint', 13],
+    ['Lime', 14],
+    ['Very Peri', 15],
+    ['Warm White', 16],
+    ['Cool White', 17],
+    ['Sapphire', 18],
+    ['Rainbow', 19],
+]
+
+type Levels = readonly (readonly [string, number])[]
+
+export default class Device extends TLVDevice {
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+
+        const config: DeviceDiscovery = allowExtendedType({
+            ...HADevice.config(meta, { name: 'LG Humidifying Air Purifier' }),
+            components: {
+                humidifier: {
+                    platform: 'humidifier',
+                    unique_id: '$deviceid-humidifier',
+                    name: null,
+                    device_class: 'humidifier',
+                    modes: OP_MODES.map(([label]) => label),
+                    // LG's own value_validation for airState.humidity.desired.
+                    min_humidity: 0,
+                    max_humidity: 100,
+                },
+            },
+        })
+
+        // Power (0x1f7). The humidifier platform's bare state/command topics are wired to it below.
+        this.addField(
+            config,
+            {
+                id: 0x1f7,
+                name: 'power',
+                comp: 'humidifier',
+                read_xform: (raw) => (raw ? 'ON' : 'OFF'),
+                write_xform: (val) => (val === 'ON' ? 1 : 0),
+            },
+            false,
+        )
+
+        // Operating mode (0x1f9) — the humidifier entity's `mode`.
+        this.addField(config, {
+            id: 0x1f9,
+            name: 'mode',
+            comp: 'humidifier',
+            read_xform: (raw) => OP_MODES.find(([, wire]) => wire === raw)?.[0] ?? `mode${raw}`,
+            write_xform: (val) => {
+                const hit = OP_MODES.find(([label]) => label === val)
+                if (!hit) return undefined
+                // Selecting a mode while off is how the LG app turns it on.
+                this.raw_clip_state[0x1f7] = 1
+                return hit[1]
+            },
+            write_attach: [0x1f7],
+        })
+
+        // Target humidity (0x253) — the humidifier entity's target.
+        this.addField(config, {
+            id: 0x253,
+            name: 'target_humidity',
+            comp: 'humidifier',
+            write_xform: (val) => Math.round(Number(val) / 5) * 5,
+        })
+
+        // Current humidity (0x336) — read-only, its own sensor as well as the humidifier attribute.
+        this.addSensor(config, 0x336, 'current_humidity', 'Current humidity', {
+            device_class: 'humidity',
+            unit_of_measurement: '%',
+            state_class: 'measurement',
+        })
+        ;(config.components as any).humidifier.current_humidity_topic = '$this/current_humidity-'
+
+        this.addSelect(config, 0x1fa, 'fan_speed', 'Fan speed', 'mdi:fan', FAN_LEVELS)
+        this.addSelect(config, 0x1e9, 'hygiene_dry', 'Sanitary dry', 'mdi:hair-dryer', HYGIENE_DRY)
+        this.addSelect(config, 0x164, 'standby_sterilize', 'Standby sterilize', 'mdi:shimmer', STANDBY_STERILIZE)
+        this.addSelect(config, 0x21f, 'display', 'Screen brightness', 'mdi:brightness-6', DISPLAY_BRIGHTNESS)
+        this.addSelect(config, 0x337, 'sensor_mon', 'Air quality sensor', 'mdi:motion-sensor', SENSOR_MON)
+        this.addSelect(config, 0x3e0, 'mood_color', 'Mood light color', 'mdi:palette', MOOD_COLORS)
+
+        this.addSwitch(config, 0x109, 'night_mode', 'Night mode', 'mdi:weather-night')
+        this.addSwitch(config, 0x1e4, 'sleep_mode', 'Sleep mode', 'mdi:power-sleep')
+        this.addSwitch(config, 0x1e6, 'auto_strength', 'Auto operation', 'mdi:autorenew')
+        this.addSwitch(config, 0x1e7, 'humidify', 'Humidify', 'mdi:water')
+        this.addSwitch(config, 0x117, 'over_prevention', 'Over-humidification prevention', 'mdi:water-alert')
+        this.addSwitch(config, 0x161, 'anti_glare', 'Anti-glare', 'mdi:eye-off')
+        this.addSwitch(config, 0x1b8, 'mood_light', 'Mood light', 'mdi:lightbulb-on')
+        this.addSwitch(config, 0x3a0, 'bell_sound', 'Notification sound', 'mdi:bell')
+        this.addSwitch(config, 0x20e, 'auto_dry', 'Auto dry', 'mdi:fan-auto', AUTO_DRY_ON)
+
+        this.addNumber(config, 0x21e, 'watertank_light', 'Tank light brightness', 'mdi:lightbulb', 0, 200, 1)
+        this.addNumber(config, 0x21b, 'off_timer', 'Off timer (min)', 'mdi:timer-off', 0, 720, 10)
+        this.addNumber(config, 0x35a, 'start_time', 'Scheduled on time(HHMM)', 'mdi:clock-start', 0, 2400, 10)
+        this.addNumber(config, 0x35b, 'stop_time', 'Scheduled off time(HHMM)', 'mdi:clock-end', 0, 2400, 10)
+
+        this.addSensor(config, 0x1fd, 'temperature', 'Current temperature', {
+            device_class: 'temperature',
+            unit_of_measurement: '°C',
+            state_class: 'measurement',
+            read_xform: (raw: number) => raw / HALF_DEGREE,
+        })
+        this.addSensor(config, 0x333, 'pm1', 'PM1.0', {
+            device_class: 'pm1',
+            unit_of_measurement: 'µg/m³',
+            state_class: 'measurement',
+        })
+        this.addSensor(config, 0x334, 'pm25', 'PM2.5', {
+            device_class: 'pm25',
+            unit_of_measurement: 'µg/m³',
+            state_class: 'measurement',
+        })
+        this.addSensor(config, 0x335, 'pm10', 'PM10', {
+            device_class: 'pm10',
+            unit_of_measurement: 'µg/m³',
+            state_class: 'measurement',
+        })
+        this.addSensor(config, 0x240, 'air_quality', 'Overall air quality', {
+            icon: 'mdi:air-filter',
+            state_class: 'measurement',
+        })
+        this.addSensor(config, 0x1ee, 'watertank_remain', 'Tank level', {
+            icon: 'mdi:cup-water',
+            unit_of_measurement: '%',
+            state_class: 'measurement',
+        })
+        this.addSensor(config, 0x2ad, 'watertank_time', 'Tank time remaining', {
+            icon: 'mdi:timer-sand',
+            unit_of_measurement: 'min',
+        })
+        this.addSensor(config, 0x1ed, 'water_filter', 'Water filter level', {
+            icon: 'mdi:filter',
+            unit_of_measurement: '%',
+            state_class: 'measurement',
+        })
+        this.addSensor(config, 0x355, 'filter_used', 'Filter usage hours', {
+            icon: 'mdi:filter-outline',
+            entity_category: 'diagnostic',
+        })
+        this.addSensor(config, 0x356, 'filter_max', 'Filter replacement cycle', {
+            icon: 'mdi:filter-cog',
+            entity_category: 'diagnostic',
+        })
+        this.addSensor(config, 0x225, 'auto_dry_remain', 'Auto dry remaining', {
+            icon: 'mdi:timer-sand',
+            unit_of_measurement: 'min',
+        })
+        this.addSensor(config, 0x1e3, 'status', 'Operating state', {
+            icon: 'mdi:information-outline',
+            read_xform: (raw: number) => PRODUCT_STATUS[raw] ?? `State${raw}`,
+        })
+        this.addSensor(config, 0x221, 'error', 'Error code', {
+            icon: 'mdi:alert-circle-outline',
+            entity_category: 'diagnostic',
+        })
+
+        /*
+         * Low water as its own alert. Only productStatus 2 (WATER_LACK) raises it: 1 (BUCKET_OFF)
+         * is what the appliance reports whenever the tank is simply not seated, which it is not
+         * while it runs as a plain air purifier, and an alarm for that would cry wolf. That state
+         * stays visible on the Operating statesensor.
+         */
+        ;(config.components as any).water_lack = {
+            platform: 'binary_sensor',
+            unique_id: '$deviceid-water_lack',
+            name: 'Low water',
+            device_class: 'problem',
+            icon: 'mdi:water-off',
+            payload_on: 'ON',
+            payload_off: 'OFF',
+            state_topic: '$this/water_lack-',
+        }
+
+        const hum = (config.components as any).humidifier
+        hum.state_topic = '$this/humidifier-power'
+        hum.command_topic = '$this/humidifier-power/set'
+
+        this.setConfig(config)
+    }
+
+    /** A select whose options are English labels and whose wire values are LG's enum codes. */
+    private addSelect(config: DeviceDiscovery, id: number, comp: string, desc: string, icon: string, levels: Levels) {
+        config['components'][comp] = {
+            platform: 'select',
+            unique_id: `$deviceid-${comp}`,
+            name: desc,
+            icon,
+            options: levels.map(([label]) => label),
+        } as any
+        this.addField(config, {
+            id,
+            name: '',
+            comp,
+            read_xform: (raw) => levels.find(([, wire]) => wire === raw)?.[0],
+            write_xform: (val) => levels.find(([label]) => label === val)?.[1],
+        })
+    }
+
+    private addSwitch(config: DeviceDiscovery, id: number, comp: string, desc: string, icon: string, onValue = 1) {
+        config['components'][comp] = {
+            platform: 'switch',
+            unique_id: `$deviceid-${comp}`,
+            name: desc,
+            icon,
+        } as any
+        this.addField(config, {
+            id,
+            name: '',
+            comp,
+            read_xform: (raw) => (raw === onValue ? 'ON' : 'OFF'),
+            write_xform: (val) => (val === 'ON' ? onValue : 0),
+        })
+    }
+
+    private addNumber(
+        config: DeviceDiscovery,
+        id: number,
+        comp: string,
+        desc: string,
+        icon: string,
+        min: number,
+        max: number,
+        step: number,
+    ) {
+        config['components'][comp] = {
+            platform: 'number',
+            unique_id: `$deviceid-${comp}`,
+            name: desc,
+            icon,
+            min,
+            max,
+            step,
+            mode: 'box',
+        } as any
+        this.addField(config, { id, name: '', comp, write_xform: (val) => Math.round(Number(val)) })
+    }
+
+    private addSensor(
+        config: DeviceDiscovery,
+        id: number,
+        comp: string,
+        desc: string,
+        opts: Record<string, unknown> & { read_xform?: (raw: number) => string | number },
+    ) {
+        const { read_xform, ...attrs } = opts
+        config['components'][comp] = {
+            platform: 'sensor',
+            unique_id: `$deviceid-${comp}`,
+            name: desc,
+            ...attrs,
+        } as any
+        this.addField(config, { id, name: '', comp, writable: false, read_xform })
+    }
+
+    processKeyValue(k: number, v: number) {
+        if (k === 0x1e3) this.HA.publishProperty(this.id, 'water_lack-', v === 2 ? 'ON' : 'OFF')
+        super.processKeyValue(k, v)
+    }
+
+    /* 0x3e8 is reported only in the answer to a capabilities query (0x1f5=1) on this model. */
+    isCapsResponse(tlvArray: TLV.TLV[]) {
+        return tlvArray.some(({ t }) => t === 0x3e8)
+    }
+
+    isValuesResponse(tlvArray: TLV.TLV[]) {
+        return tlvArray.some(({ t }) => t === 0x1f7 || t === 0x1f9 || t === 0x1fa)
+    }
+}

--- a/cloud/devices/HWWA9K_F2.ts
+++ b/cloud/devices/HWWA9K_F2.ts
@@ -1,0 +1,340 @@
+import { Device as Thinq2Device } from '../thinq2/device'
+import { DeviceDiscovery, type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import HADevice from './base'
+import AABBDevice from './aabb_device'
+
+/*
+ * LG CordZero A9 Stick Vacuum, ThinQ model HWWA9K_F2, deviceType 504.
+ *
+ * WHERE THE BYTE OFFSETS COME FROM
+ * --------------------------------
+ * modelJSON hands over every field name and every enum code
+ * (`MonitoringValue.<field>.valueMapping[*].index`) but no offsets — this is an AA..BB
+ * appliance, so the layout is only in the Wi-Fi module and in LG's server.
+ *
+ * Recovered 2026-07-28 with tools/lg-oracle.mjs: rethink relays what the appliance sends,
+ * and the management API can inject a frame as if the appliance had sent it, so LG's own
+ * cloud can be made to decode a frame of our choosing. The probe re-injected the
+ * appliance's real state frame with EXACTLY ONE byte changed and read the snapshot back;
+ * every offset below therefore has a direct observation behind it, and each was seen twice
+ * (once when its probe set it, once when the next probe reverted it):
+ *
+ *   byte[6]=3  -> monStatus CHARGING(3)        byte[7]=3  -> cleanMode HIGH(3)
+ *   byte[8]=3  -> filterState 3               byte[9]=3  -> passageClogged 3
+ *   byte[10]=3 -> nozzle WATER_MOP(3)         byte[11]=3 -> batteryLevel LOW(3)
+ *   byte[12]=3 -> mopWithSucking 3            byte[13]=3 -> completeClean 3
+ *   byte[14]=3 -> suctionForce TURBO(3)       byte[15]=3 -> chargingMelody MELODY_3(3)
+ *   byte[16]=3 -> volume LOW(3)               byte[17]=2 -> brightness HIGH(2)
+ *
+ * Base frame (real, captured 2026-07-28):
+ *   aa14d2eb00 0c 04 01 01 01 ff 00 01 01 02 01 01 03 c3bb
+ *
+ * byte[5] = 0x0c = 12 = the number of fields that follow, and twelve is exactly how many
+ * `qmState.*` keys LG publishes for this unit. One byte per field, no padding.
+ *
+ * The other frame this appliance sends, `aa ff d2 0a 00 2c 00 …` (44 bytes), announces which
+ * settings exist: a count of 4 followed by `[len]["VC-n"][value]` records, and modelJSON's own
+ * comments name suctionForce, chargingMelody, volume and brightness as "VC-1".."VC-4". Its
+ * values are NOT the live settings — every record reads 01 in captures where the state frame
+ * says suction 2 and brightness 3 — so it is a capability list and is deliberately ignored.
+ *
+ * WRITE DIRECTION
+ * ---------------
+ * modelJSON declares five commands (MOP_SETTING, SUCTION_FORCE, CHARGING_MELODY, VOLUME,
+ * BRIGHTNESS), each `controlDataValueLength: 1`, and all five were captured on 2026-07-28 —
+ * every option of every one, seventeen frames, recorded in
+ * `/share/local_addons/rethink/captures/styler-vacuum-commands-20260728.md`.
+ *
+ * They came from LG's own cloud. `convert/control` converts a capability command into this
+ * appliance's protocol and sends it down, and rethink relays it, so the frame below is LG's
+ * encoding rather than this driver's guess:
+ *
+ *   aa 09 f0 24 <controlDataType> <valueLength = 1> <value> <ck> bb
+ *
+ *   01 MOP_SETTING     off -> 1   on -> 2
+ *   02 SUCTION_FORCE   normal 1   high 2   turbo 3
+ *   03 CHARGING_MELODY lucky 1    bead 2   ice 3   brisa 4   nebula 5
+ *   04 VOLUME          high 1     medium 2 low 3
+ *   05 BRIGHTNESS      veryHigh 1 high 2   medium 3 low 4   off 5
+ *
+ * THE VALUE IS THE READ MAP'S OWN CODE, in every case — so the write map and the read map
+ * check each other, and the appliance's echo (below) confirms it a third time.
+ *
+ * The earlier note here said control was refused. It was: with the argument names the aircon
+ * uses (`{"setOnOff":{"onOff":"on"}}`). This family wants what `convert/capabilitySchema`
+ * declares, and answers CL-0000 once asked that way.
+ *
+ * `entity_category: 'config'` is used ONLY on the settings that are now selects.
+ * Home Assistant accepts that category only on a platform that can change something. On a
+ * sensor or binary_sensor it writes the entity into the registry and then never brings it up:
+ * the first live rebuild of these drivers lost ten entities that way, across this model and the
+ * styler, registered but missing from the state machine and silent in the log. Read-only
+ * settings use 'diagnostic'. The test suite asserts it, because nothing on the add-on side can.
+ */
+
+/** `aa <len> d2 <tag> …<records>… <ck> bb` — 4 header bytes, 2 trailer bytes. */
+const HEADER_LEN = 4
+const TRAILER_LEN = 2
+/** buf[2] on the frames this appliance sends. */
+const CLASS_TAG = 0xd2
+/**
+ * One state record: `<index> <field count> <12 field bytes>`.
+ *
+ * THE RECORD COUNT VARIES, SO IT IS COUNTED RATHER THAN ASSUMED.
+ * At rest the appliance sends ONE record (20-byte frame, tag `d2 eb`). Right after a setting
+ * changes it sends TWO (34-byte frame, tag `d2 ec`) — previous record, then current:
+ *
+ *   aa22d2ec00 0c 04 01 01 01 ff 00 02 01 01 03 03 04
+ *              00 0c 04 01 01 01 ff 00 02 01 02 03 03 04 9ebb
+ *
+ * That is the same eb/ec convention the water purifier and the styler use in this repo, and
+ * the same trap: a decoder keyed on "20 bytes, tag eb" ignores the echo and so goes blind at
+ * exactly the moment a write lands. Measured 2026-07-28 — the frame above is the appliance's
+ * answer to five commands this driver had just sent.
+ */
+const RECORD_LEN = 14
+/** Fields start 2 bytes into the record, after its index and field-count bytes. */
+const FIELDS_OFF = 2
+const FIELD_COUNT = 12
+
+/** Offsets WITHIN a record. On the 20-byte single-record frame the record starts at 4, which
+ *  is why the header comment states these as byte[6]..byte[17] — that is how the probes
+ *  recorded them. */
+const OFF = {
+    monStatus: 2,
+    cleanMode: 3,
+    filterState: 4,
+    passageClogged: 5,
+    nozzle: 6,
+    batteryLevel: 7,
+    mopWithSucking: 8,
+    completeClean: 9,
+    suctionForce: 10,
+    chargingMelody: 11,
+    volume: 12,
+    brightness: 13,
+} as const
+
+/** Command frame opcode: `aa 09 f0 24 <type> 01 <value> <ck> bb`. See the header note. */
+const SET_STATE = [0xf0, 0x24]
+
+/** modelJSON `ControlWifi` controlDataType ids, as the captured frames carry them. */
+const CTRL = {
+    mopSetting: 0x01,
+    suctionForce: 0x02,
+    chargingMelody: 0x03,
+    volume: 0x04,
+    brightness: 0x05,
+} as const
+
+// Every table below is modelJSON `MonitoringValue.<field>.valueMapping`, code for code, with
+// English labels for the text resolved from this model's ko-KR language pack. Where LG's `label` is blank
+// or points at another field's key (cleanMode OFF and NORMAL share @HS_TREM_NOR_W; filterState
+// and passageClogged and batteryLevel have literal English labels), the mapping's own
+// `_comment` is used instead — that is LG's text either way.
+
+/** qmState.monStatus */
+const MON_STATUS: Record<number, string> = { 1: 'Standby', 2: 'Cleaning', 3: 'Charging', 4: 'Charging complete' }
+
+/** qmState.cleanMode — the suction level actually running right now. */
+const CLEAN_MODE: Record<number, string> = { 1: 'Off', 2: 'Standard', 3: 'High', 4: 'Turbo', 5: 'Mop', 6: 'Auto' }
+
+/** qmState.filterState */
+const FILTER_STATE: Record<number, string> = { 1: 'Normal', 2: 'Cleaning needed' }
+
+/** qmState.passageClogged */
+const PASSAGE: Record<number, string> = { 1: 'Normal', 2: 'Check for debris' }
+
+/** qmState.nozzle — which head is attached. */
+const NOZZLE: Record<number, string> = {
+    0: 'Auxiliary inlet',
+    1: 'PowerDrive Floor',
+    2: 'PowerDrive Carpet',
+    3: 'PowerDrive Mop',
+}
+
+/** qmState.batteryLevel. This unit reports 0 while docked, which LG surfaces as NOT_USE. */
+const BATTERY: Record<number, string> = { 0: 'Off', 1: 'High', 2: 'Mid', 3: 'Low', 4: 'Warning' }
+
+/** qmState.mopWithSucking */
+const MOP_WITH_SUCKING: Record<number, string> = { 1: 'Mop only', 2: 'Mop and suction together' }
+
+/** qmState.suctionForce — the default suction level the product starts at (LG's "VC-1"). */
+const SUCTION_FORCE: Record<number, string> = { 1: 'Standard', 2: 'High', 3: 'Turbo' }
+
+/** qmState.chargingMelody (LG's "VC-2"); names from @HS_UX30_CHARGING_MELODY_n_W. */
+const CHARGING_MELODY: Record<number, string> = {
+    1: 'Lucky',
+    2: 'Marble',
+    3: 'Ice',
+    4: 'Breeze',
+    5: 'Nebula',
+}
+
+/** qmState.volume (LG's "VC-3") */
+const VOLUME: Record<number, string> = { 1: 'High', 2: 'Normal', 3: 'Low' }
+
+/** qmState.brightness (LG's "VC-4"). Code 5 is OFF; LG's own label key for it is missing
+ *  from this model's pack, so the mapping's `_comment` ("LED Brightness off") supplies the text. */
+const BRIGHTNESS: Record<number, string> = {
+    1: 'Very bright',
+    2: 'Bright',
+    3: 'Normal',
+    4: 'Dim',
+    5: 'Off',
+}
+
+/** LG's sentinel for "not reported": 0 on most of this model's enums, 255 on nozzle. */
+const enumOf = (table: Record<number, string>, raw: number) =>
+    table[raw] ?? (raw === 0 || raw === 0xff ? 'Unknown' : `Code ${raw}`)
+
+export default class Device extends AABBDevice {
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+
+        const sensor = (id: string, name: string, extra: object = {}) => ({
+            platform: 'sensor',
+            unique_id: `$deviceid-${id}`,
+            state_topic: `$this/${id}`,
+            name,
+            ...extra,
+        })
+
+        /** A setting the appliance takes a command for: the options are the English labels of
+         *  its own read table, so the state it reports is always one of them. */
+        const select = (id: string, name: string, table: Record<number, string>, extra: object = {}) => ({
+            platform: 'select',
+            unique_id: `$deviceid-${id}`,
+            state_topic: `$this/${id}`,
+            command_topic: `$this/${id}/set`,
+            name,
+            options: Object.values(table),
+            ...extra,
+        })
+
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: 'LG Stick Vacuum' }),
+                components: {
+                    status: sensor('status', 'State', { icon: 'mdi:robot-vacuum' }),
+                    clean_mode: sensor('clean_mode', 'Operation level', { icon: 'mdi:fan' }),
+                    suction_force: select('suction_force', 'Default suction power', SUCTION_FORCE, {
+                        icon: 'mdi:weather-windy',
+                    }),
+                    battery: sensor('battery', 'Battery', { icon: 'mdi:battery' }),
+                    nozzle: sensor('nozzle', 'Attached nozzle', { icon: 'mdi:vacuum' }),
+                    filter_state: sensor('filter_state', 'Filter state', { icon: 'mdi:air-filter' }),
+                    passage: sensor('passage', 'Inlet blocked', { icon: 'mdi:pipe-disconnected' }),
+                    mop_with_sucking: select('mop_with_sucking', 'Mop usage mode', MOP_WITH_SUCKING, {
+                        icon: 'mdi:water',
+                    }),
+                    charging_melody: select('charging_melody', 'Charging melody', CHARGING_MELODY, {
+                        icon: 'mdi:music-note',
+                        entity_category: 'config',
+                    }),
+                    volume: select('volume', 'Volume', VOLUME, {
+                        icon: 'mdi:volume-high',
+                        entity_category: 'config',
+                    }),
+                    brightness: select('brightness', 'LED Brightness', BRIGHTNESS, {
+                        icon: 'mdi:brightness-6',
+                        entity_category: 'config',
+                    }),
+                    complete_clean: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-complete-clean',
+                        state_topic: '$this/complete_clean',
+                        name: 'Cleaning complete',
+                        icon: 'mdi:check-circle-outline',
+                        payload_on: 'ON',
+                        payload_off: 'OFF',
+                    },
+                },
+            }),
+        )
+    }
+
+    /*
+     * The base class strips the AA/length prefix before handing the body on, but every offset
+     * above is stated against the whole frame, the way the probes recorded them, so the frame is
+     * taken here unstripped.
+     */
+    processData(buf: Buffer) {
+        if (buf[0] !== 0xaa || buf[buf.length - 1] !== 0xbb) return
+        // The short AA form states its own total length in byte 1. That is what separates a state
+        // frame from the `aa ff d2 0a …` capability list, which uses a 16-bit length instead.
+        if (buf[1] !== buf.length) return
+        if (buf[2] !== CLASS_TAG) return
+        const payload = buf.length - HEADER_LEN - TRAILER_LEN
+        if (payload <= 0 || payload % RECORD_LEN !== 0) return
+
+        // The trailing record is the current state; a leading one, when present, is the previous.
+        const record = buf.length - TRAILER_LEN - RECORD_LEN
+        // A different count would mean a different record shape; decoding it with this map would
+        // publish nonsense, so leave the previous values standing instead.
+        if (buf[record + 1] !== FIELD_COUNT) return
+
+        const at = (o: number) => buf[record + o]
+
+        this.publishProperty('status', enumOf(MON_STATUS, at(OFF.monStatus)))
+        this.publishProperty('clean_mode', enumOf(CLEAN_MODE, at(OFF.cleanMode)))
+        this.publishProperty('battery', enumOf(BATTERY, at(OFF.batteryLevel)))
+        this.publishProperty('nozzle', enumOf(NOZZLE, at(OFF.nozzle)))
+        this.publishProperty('filter_state', enumOf(FILTER_STATE, at(OFF.filterState)))
+        this.publishProperty('passage', enumOf(PASSAGE, at(OFF.passageClogged)))
+        // completeClean: 1 = not finished, 2 = finished (LG's own polarity, not a 0/1 flag).
+        this.publishProperty('complete_clean', at(OFF.completeClean) === 2 ? 'ON' : 'OFF')
+
+        // The five settings are selects, and a select's state has to be one of its options —
+        // publishing 'Unknown' for a code outside the table would make Home Assistant reject
+        // the state and log it, so an unreported code leaves the previous value standing.
+        this.publishOption('suction_force', SUCTION_FORCE, at(OFF.suctionForce))
+        this.publishOption('mop_with_sucking', MOP_WITH_SUCKING, at(OFF.mopWithSucking))
+        this.publishOption('charging_melody', CHARGING_MELODY, at(OFF.chargingMelody))
+        this.publishOption('volume', VOLUME, at(OFF.volume))
+        this.publishOption('brightness', BRIGHTNESS, at(OFF.brightness))
+    }
+
+    private publishOption(prop: string, table: Record<number, string>, raw: number) {
+        const label = table[raw]
+        if (label !== undefined) this.publishProperty(prop, label)
+    }
+
+    /**
+     * Build and send a command frame: `aa 09 f0 24 <type> 01 <value> <ck> bb`.
+     *
+     * The base class's `send` supplies the AA/length prefix and the checksum, so what goes in is
+     * `f0 24` plus the three-byte body — which reproduces the captured frames byte for byte.
+     */
+    private setField(type: number, value: number) {
+        this.send(Buffer.from([...SET_STATE, type, 0x01, value]))
+    }
+
+    setProperty(prop: string, mqttValue: string) {
+        const write = (type: number, table: Record<number, string>, what: string) => {
+            const code = Object.entries(table).find(([, label]) => label === mqttValue)?.[0]
+            if (code === undefined) return console.warn(`Stick Vacuum: Unknown ${what} '${mqttValue}'`)
+            this.setField(type, Number(code))
+            // The appliance echoes a two-record state frame within a second, so the entity
+            // settles on what it actually took; this only keeps the UI from snapping back first.
+            this.publishProperty(prop, mqttValue)
+        }
+
+        switch (prop) {
+            case 'suction_force':
+                return write(CTRL.suctionForce, SUCTION_FORCE, 'Default suction power')
+            case 'mop_with_sucking':
+                return write(CTRL.mopSetting, MOP_WITH_SUCKING, 'Mop usage mode')
+            case 'charging_melody':
+                return write(CTRL.chargingMelody, CHARGING_MELODY, 'Charging melody')
+            case 'volume':
+                return write(CTRL.volume, VOLUME, 'Volume')
+            case 'brightness':
+                return write(CTRL.brightness, BRIGHTNESS, 'LED Brightness')
+            default:
+                console.warn(`Stick Vacuum: Item does not support writing ${prop}`)
+        }
+    }
+}

--- a/cloud/devices/ST_B_E4H01Y_APL.ts
+++ b/cloud/devices/ST_B_E4H01Y_APL.ts
@@ -1,0 +1,828 @@
+import { Device as Thinq2Device } from '../thinq2/device'
+import { DeviceDiscovery, type ComponentInfo, type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import HADevice from './base'
+import AABBDevice from './aabb_device'
+
+/*
+ * LG Styler (KR Baron Plus, S5BBP), ThinQ model ST_B_E4H01Y_APL, deviceType 203.
+ *
+ * WHERE THE BYTE OFFSETS COME FROM
+ * --------------------------------
+ * This model's modelJSON has no tlv_* labels (unlike the clip/TLV humidifier and
+ * dehumidifiers) — it is an AA..BB appliance, so the byte layout lives only in the Wi-Fi
+ * module's firmware and on LG's server.
+ *
+ * Recovered 2026-07-28 with tools/lg-oracle.mjs, which makes LG's own cloud do the decode:
+ * rethink relays what the appliance sends, and the management API can inject a frame as if
+ * the appliance had sent it. Each probe re-injected the appliance's real state frame with
+ * EXACTLY ONE byte changed and read LG's snapshot back, so every offset below rests on a
+ * direct observation, seen twice (once when its probe set it, once when the next probe
+ * reverted it). A plain ramp was not enough here: byte[i]=i is not a valid code for most of
+ * these enums, and three of the bytes turn out to be bitfields, which a ramp cannot separate.
+ *
+ * Base frame (real, captured 2026-07-28):
+ *   aaff310a00 3a00 53ea 000100eb0028 00000000 010001000001 000000000000200000000000000000
+ *   014e420000040300000000000000 25 7205bb
+ *
+ * Frame shape: `aa ff 31 0a 00 | <len16 LE> | <seq16> | …payload… | <crc16 XMODEM> bb`.
+ * Confirmed layout, absolute offsets into the whole 58-byte frame:
+ *
+ *   17 state              18 remainTimeHour     19 remainTimeMinute
+ *   20 initialTimeHour    21 initialTimeMinute  22 course
+ *   23 error              24 preState
+ *   29 reserveTimeHour    30 reserveTimeMinute
+ *   31 flags  0x01 childLock  0x02 nightDry  0x04 initialBit  0x08 remoteStart
+ *   34..35 energyMonitoring, big-endian 16-bit (byte34=0x01 read back 256; byte35=0x01 read 1)
+ *   37 smartCourse
+ *   40 currentDownloadCourseCount   41..44 currentDownloadCourse1..4
+ *   45 buzzer
+ *   46 flags  0x01 applyRemoteMaintain  0x02 applyBuzzer  0x04 remoteMaintain
+ *   47 endMelody          48 internalLightingTime
+ *   49 flags  0x01 isLastCourse  0x02 smartCareFineDust  0x04 smartCareHumidity
+ *             0x08 smartCareNightCare  0x10 smartPairing  0x20 currentTimeDisplay
+ *   50 nightCareStartTime_Hour  51 nightCareStartTime_Minute
+ *   52 nightCareEndTime_Hour    53 nightCareEndTime_Minute
+ *   54 TCLCount
+ *
+ * That is all 38 `styler.*` keys LG publishes for this unit, and nothing is left over.
+ * The three flag bytes were split bit by bit (0x01, 0x02, 0x04, … one injection each);
+ * byte 31 bit 0x20 and byte 49 bits 0x40/0x80 move no field and are left alone.
+ *
+ * THE OTHER FRAMES THIS APPLIANCE SENDS ARE NOT STATE.
+ * `aa ff 31 0a 00 23 00 …` (35 B) looks like a status frame but is not one: every byte from
+ * 9 to 31 was probed with 0xff and not one field in LG's snapshot moved. The 112/113-byte
+ * frames are the downloadable-course name list (ASCII "203-1", "ST-4"…), and `aa 07 31 c3 02`
+ * is a heartbeat. Only the 58-byte frame is decoded here.
+ *
+ * WRITE DIRECTION
+ * ---------------
+ * Eleven commands were captured on 2026-07-28 — every option of every one, thirty-one frames,
+ * recorded in `/share/local_addons/rethink/captures/styler-vacuum-commands-20260728.md`.
+ *
+ * They came from LG's own cloud, not from reading the read map backwards:
+ * `dataops/v1/s2p/backend/convert/control` converts a capability command into this appliance's
+ * protocol and sends it down, and rethink relays it. Every frame below answered CL-0000 and was
+ * ACKed by the appliance (`aa 08 31 00 24 00 …`; a refusal answers `… 24 ff …`).
+ *
+ *   aa <len> f0 24 <controlDataType> <valueLength> [<controlDataType_sub>] <value…> <ck> bb
+ *
+ *   01 POWERON/POWEROFF          len 1   off 0, on 1
+ *   13 UPCENTER, then a sub id and the value:
+ *      01 ENDMELODY              len 1   the melody's index, 0..11
+ *      03 UPBUZZER               len 1   the buzzer level, 0..4
+ *      04 SC_FINEDUST            len 1   off 0, on 1
+ *      05 SC_HUMIDITY            len 1   off 0, on 1
+ *      06 SC_NIGHTCARE           len 1   off 0, on 1
+ *      07 SC_NIGHTCARE_START     len 2   hour, minute
+ *      08 SC_NIGHTCARE_END       len 2   hour, minute
+ *      09 CTRL_IS_LAST_COURSE    len 1   off 0, on 1
+ *
+ * `controlDataType`, `controlDataValueLength` and `controlDataType_sub` are modelJSON's own
+ * `ControlWifi` vocabulary, and every value is the code the read map above already uses for
+ * that field — so the two maps check each other.
+ *
+ * The earlier note here said control was refused. It was: with the argument names the aircon
+ * uses (`{"setOnOff":{"onOff":"on"}}`). This family wants what `convert/capabilitySchema`
+ * declares — `{"setOnOff":{"value":"on"}}` — and answers CL-0000 once asked that way.
+ * `CL-0005` is a second gate and means the appliance is in no state to take the command: every
+ * setting is refused while it is powered off, and the night-care times are refused while
+ * night care itself is off.
+ *
+ * WHERE LG'S CONVERTER RUNS OUT, THE APPLIANCE STILL ANSWERS
+ * `remoteControlStatus setRemoteControlType` answers CL-0000 but emits the SAME frame for every
+ * argument tried — twelve of them, `on` / `off` / `enable` / `remoteMaintain` / `1` / `0` … —
+ * always `aa09f0241001008dbb`, REMOTE_MAINTAIN = 0. LG's converter cannot express the ON side.
+ *
+ * That is not the end of it. The frame shape is known, so the ON frame was built and sent to
+ * the appliance directly (management socket, `sendToDevice`) and the appliance took it:
+ *
+ *   aa09f0241001018cbb -> ack `aa 08 31 00 24 00`, and the next state frame came back with
+ *                         byte 46 bit 0x04 set — Remote control allowed ON in Home Assistant
+ *   aa09f0241001008dbb -> the same round trip, back to OFF
+ *
+ * A command the appliance acknowledges and then reports back is evidence of the same kind as a
+ * frame LG sent: it is the appliance answering, not a guess. So Remote control allowed ships as a switch.
+ *
+ * COURSE CONTROL
+ * `cycles start` and `cycles setCurrentCycle` both fail conversion, but `operationState` works,
+ * with the course's NUMERIC id as a string — `{"startCycle":{"cycle":{"id":"1"}}}` -> CL-0000:
+ *
+ *   start  aa 34 f0 26 | <46-byte course block> | ck bb
+ *   pause  aa 09 f0 24 04 01 00                             (PAUSE, LG's controlDataType 0x04)
+ *   resume aa 33 f0 26 | <course id> <44 zero bytes> | ck bb
+ *
+ * The course block is `<id> 01 00 04 00 00 00 00 00` followed by this model's own course
+ * parameters, and those parameters are modelJSON's `Course[id].function` defaults in
+ * declaration order — with `TimeDry` folded into bit 0x80 of the `PreSteam1_Time` byte, which
+ * is why the block is one byte shorter than the field list. Two courses were captured off LG's
+ * converter, Standard (id 1) and Quick (id 3), and the table below reproduces BOTH byte for byte; the
+ * test suite asserts exactly that. The rest of the table is the same rule applied to the same
+ * declaration, which is the only reason it ships without a capture of its own.
+ *
+ * `cycles setCurrentCycle` answers CL-0002 with an empty error, so there is no way to select a
+ * course without starting it. Course select is therefore a local choice this driver remembers, and
+ * Start course is what sends it — which is also the order LG's own app puts them in.
+ */
+
+/** State frame: 58 bytes, `aa ff 31 0a 00`, CRC16/XMODEM tail. */
+/*
+ * Frame shape: `aa ff 31 0a 00 | <len16 LE> | <seq16> | 00 01 | 00 <tag> | <record bytes, BE16> |
+ * …records… | <crc16 XMODEM> bb`. Fifteen header bytes, three trailer.
+ *
+ * THE RECORD COUNT VARIES, SO IT IS COUNTED RATHER THAN ASSUMED.
+ * At rest the appliance sends ONE 40-byte record (58-byte frame). The moment it is doing
+ * anything it sends TWO (98-byte frame) — previous record, then current — exactly like the
+ * water purifier in this repo. A decoder keyed on "58 bytes" therefore goes blind the instant
+ * the appliance is switched on, which is when it matters: measured 2026-07-28, LG read the
+ * 98-byte frames as state INITIAL / course STANDARD / remote-start ON while this driver was
+ * still publishing Power off off the last 58-byte frame.
+ *
+ * So the payload is measured: header 15, trailer 3, and what is between must be a whole number
+ * of 40-byte records, cross-checked against the record-bytes field the frame declares at 13..14.
+ * The last record is the current state. That also rejects the 112/113-byte course-name lists
+ * (not a multiple of 40) and the 35-byte frame, which carries no state at all.
+ */
+const HEADER_LEN = 15
+const TRAILER_LEN = 3
+const RECORD_LEN = 40
+/** buf[13..14], big-endian: how many record bytes the frame says it carries. */
+const RECORD_BYTES_OFF = 13
+const STATE_TAG = 0x31
+
+/** Offsets WITHIN a record. Add the record start to get the absolute frame offset; the
+ *  header comment states them against the 58-byte frame, whose single record starts at 15. */
+const OFF = {
+    state: 2,
+    remainTimeHour: 3,
+    remainTimeMinute: 4,
+    initialTimeHour: 5,
+    initialTimeMinute: 6,
+    course: 7,
+    error: 8,
+    preState: 9,
+    reserveTimeHour: 14,
+    reserveTimeMinute: 15,
+    flagsA: 16,
+    energyHi: 19,
+    energyLo: 20,
+    smartCourse: 22,
+    downloadCourseCount: 25,
+    downloadCourse1: 26,
+    buzzer: 30,
+    flagsB: 31,
+    endMelody: 32,
+    internalLightingTime: 33,
+    flagsC: 34,
+    nightCareStartHour: 35,
+    nightCareStartMinute: 36,
+    nightCareEndHour: 37,
+    nightCareEndMinute: 38,
+    tclCount: 39,
+} as const
+
+/** byte 31 */
+const F_CHILD_LOCK = 0x01
+const F_NIGHT_DRY = 0x02
+const F_REMOTE_START = 0x08
+/** byte 46 */
+const F_REMOTE_MAINTAIN = 0x04
+/** byte 49 */
+const F_IS_LAST_COURSE = 0x01
+const F_SC_FINEDUST = 0x02
+const F_SC_HUMIDITY = 0x04
+const F_SC_NIGHTCARE = 0x08
+
+/** Command frame opcode: `aa <len> f0 24 …`. See the WRITE DIRECTION note. */
+const SET_STATE = [0xf0, 0x24]
+
+/** modelJSON `ControlWifi` controlDataType ids, as the captured frames carry them. */
+const CTRL_POWER = 0x01
+const CTRL_PAUSE = 0x04
+const CTRL_REMOTE_MAINTAIN = 0x10
+const CTRL_UPCENTER = 0x13
+
+/** Course start and resume travel under their own opcode, carrying a course block. */
+const RUN_COURSE = [0xf0, 0x26]
+/** `<id> 01 00 04 00 00 00 00 00` — identical in both captured start frames. */
+const COURSE_HEAD = [0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00]
+/** Resume carries the course id and nothing else, one byte shorter than a start block. */
+const RESUME_BLOCK_LEN = 45
+
+/*
+ * The parameter half of a start block: this model's `Course[id].function` defaults, in LG's
+ * declaration order, with TimeDry folded into bit 0x80 of the first byte. Ids are LG's course
+ * ids, the same ones the state frame reports.
+ *
+ * Ids 1 and 3 are the two captured off LG's converter; the suite checks the whole frame this
+ * driver builds for them against those captures, byte for byte.
+ */
+const COURSE_PARAMS: Record<number, string> = {
+    1: '02645a00000005005a05b45a01b4001ab40000000000000000000000000000000000000000', // Styling Standard
+    3: '82645a00000003005a00000001b4000eb40000000000000000000000000000000000000000', // Styling Quick
+    5: '02645a00000007005a05c85a01c80031b40000000000000000000000000000000000000000', // Styling Intensive
+    6: '82000000000004000000000001000014780000000000000000000000000000000000000000', // Wool/Knit
+    7: '82645a00000004005a04b45a01b40017780000000000000000000000000000000000000000', // Suit/Coat
+    11: '0200002d000006000008000003000023780000000000000000000000000000000000000000', // Sterilize Standard
+    15: '0000000000000000000000000000005a780000000000000000000000000000000000000000', // Auto Dry
+    17: '8000000000000000000000000000001e780000000000000000000000000000000000000000', // Timed Dry 30
+    18: '8000000000000000000000000000003c780000000000000000000000000000000000000000', // Timed Dry 60
+    19: '8000000000000000000000000000005a780000000000000000000000000000000000000000', // Timed Dry 90
+    20: '8000000000000000000000000000003c780000000000000000000000000000000000000000', // Timed Dry 120
+    23: '80000000000000000000000000000078000000000000000000000000000000000000000000', // Room Dehumidify 120
+    24: '800000000000000000000000000000f0000000000000000000000000000000000000000000', // Room Dehumidify 240
+    28: '82005a00000005005a05b45a01b4002eb40000000000000000000000000000000000000000', // Padding Care
+    30: '82000000000000000000000005c80000000000000000000003005a02c85a01c80028c80000', // Fine dust
+    31: '8200002d000007000008000003000043000000000000000000000000000000000000000000', // Virus
+    32: '8200002d000006000008000003000028000000000000000000000000000000000000000000', // Jeans Care
+    33: '8000000000000000000000000000001e780000000000000000000000000000000000000000', // Fur/Leather Care
+    36: '8200002d00000600000800000300002b780000000000000000000000000000000000000000', // Suit/Uniform Sterilize
+    37: '8200002d00000600000800000300002b780000000000000000000000000000000000000000', // Silk
+    38: '8200002d00000600000800000300002b780000000000000000000000000000000000000000', // Cashmere
+}
+
+/** ...and the controlDataType_sub ids that follow UPCENTER. */
+const UP = {
+    endMelody: 0x01,
+    buzzer: 0x03,
+    smartCareFineDust: 0x04,
+    smartCareHumidity: 0x05,
+    smartCareNightCare: 0x06,
+    nightCareStart: 0x07,
+    nightCareEnd: 0x08,
+    isLastCourse: 0x09,
+} as const
+
+/** `styler.state` code 0. The appliance sends no decodable state frame while it is off, so
+ *  this is also the value the power switch reports back from. */
+const STATE_POWEROFF = 0
+
+/** Both night-care times: LG's own schema accepts whole and half hours only
+ *  (`^(0[0-9]|1[0-9]|2[0-3]):(00|30)$`), and the appliance is the one enforcing it. */
+const HALF_HOUR = /^([01]\d|2[0-3]):(00|30)$/
+
+/*
+ * The enum tables below are LG's own, in LG's own order.
+ *
+ * `styler.state` / `styler.preState` / `styler.error` are modelJSON `Value.<field>.option`,
+ * which lists names but no codes; the code is the position in that list. Three points were
+ * observed on the wire and all three agree — byte 17 = 1 read back INITIAL (index 1),
+ * byte 24 = 2 read back RUNNING (index 2), byte 23 = 1 read back ERROR_TE1 (index 1) — so
+ * the remaining entries follow the same declaration order.
+ *
+ * `styler.course` and `styler.smartCourse` are NOT positional: the byte is LG's course id
+ * straight out of the `Course` / `SmartCourse` tables. Confirmed twice — byte 22 = 1 read
+ * back STANDARD (id 1), and the untouched byte 41 = 0x4e = 78 read back FUR_LEATHER (id 78).
+ *
+ * Korean text is from this model's own ko-KR packs: the product pack for states and melodies,
+ * and the per-model pack (`langPackModelUri`) for course names. Where two courses share a
+ * name ("Standard" for both styling and sanitising) the modelJSON `_comment`'s category prefix
+ * disambiguates them, so the label is still LG's wording on both halves.
+ */
+
+/*
+ * `styler.state` — and this one is NOT positional, which the first pass got wrong.
+ *
+ * The idle codes happen to line up with the declaration order, so three idle observations made
+ * the whole table look right. They are not: the moment a course runs the appliance reports 50,
+ * 51, 52 …, which the positional table published as `Code 52`. Measured 2026-07-28 by injecting
+ * each code and reading LG's own name back (tools/lg-oracle.mjs's method) — every entry below is
+ * one such observation, and 10..49 and 60 answered NOT_DEFINE_VALUE, so the gap is LG's, not ours.
+ *
+ * Korean text is this model's own ko-KR pack. LG deliberately collapses phases: PREHEAT, STEAM
+ * and STAY all print Refreshing, and COOLING / DRYING / ENDCOOLING all print Drying — the app
+ * shows the same. FOTA has a name in the pack but no code was found for it.
+ */
+const STATE: Record<number, string> = {
+    0: 'Power off', // POWEROFF
+    1: 'Standby', // INITIAL
+    2: 'Styling', // RUNNING
+    3: 'Pause', // PAUSE
+    4: 'Course complete', // COMPLETE
+    5: 'Check appliance', // ERROR
+    6: 'Smart diagnosing', // DIAGNOSIS
+    7: 'Storing', // NIGHTDRY
+    8: 'Reserved', // RESERVED
+    9: 'Power-save running', // SLEEP
+    50: 'Steam preparing', // PRESTEAM
+    51: 'Refreshing', // PREHEAT
+    52: 'Refreshing', // STEAM
+    53: 'Refreshing', // STAY
+    54: 'Drying', // COOLING
+    55: 'Drying', // DRYING
+    56: 'Drying', // ENDCOOLING
+    57: 'Sterilizing', // STERILIZE
+    58: 'Course complete', // RUNNINGEND
+    59: 'Course complete', // END_REMOTE_MAINTAIN_ON
+}
+
+/*
+ * `styler.error` — and like `styler.state`, the codes are NOT the declaration order. LG's own
+ * Error table skips values, so a positional reading drifts one place from E2 onward and lands
+ * Water refill on the wrong number. Every entry below was measured on 2026-07-28 by injecting that
+ * code and reading LG's name back; 12..17, 19..22, 24 and 27..30 answer NOT_DEFINE_VALUE.
+ *
+ * These matter beyond display: the appliance refuses to start a course while one is standing,
+ * which is why Check needed is published as its own problem sensor.
+ *
+ * Korean text is this model's own pack, using the label LG shows the owner (Water refill / drain)
+ * rather than the service code where it has one.
+ */
+const ERROR: Record<number, string> = {
+    0: 'Normal', // ERROR_NO
+    1: 'TE1',
+    2: 'TE2',
+    3: 'TE3',
+    4: 'TE4',
+    5: 'TE5',
+    6: 'E1',
+    7: 'E2',
+    8: 'Water refill', // ERROR_E3 — LG's own _comment is "E3_Water refill LED"
+    9: 'E4',
+    10: 'LE2',
+    11: 'AE',
+    18: 'LE',
+    23: 'Normal', // ERROR_NONE
+    25: 'Water drain', // ERROR_DRAINE
+    26: 'Door open', // ERROR_DE_OPEN
+    31: 'Check door closed', // ERROR_DE_CLOSE
+    32: 'E6',
+    33: 'PS',
+    34: 'No filter', // ERROR_IF
+}
+
+/** The two codes that mean "nothing wrong". Everything else stops a course from starting. */
+const ERROR_CLEAR = new Set([0, 23])
+
+/** modelJSON `Course`, id -> ko-KR name (per-model language pack). */
+const COURSE: Record<number, string> = {
+    0: 'None',
+    1: 'Styling Standard',
+    3: 'Styling Quick',
+    5: 'Styling Intensive',
+    6: 'Wool/Knit',
+    7: 'Suit/Coat',
+    11: 'Sterilize Standard',
+    15: 'Auto Dry',
+    17: 'Timed Dry 30',
+    18: 'Timed Dry 60',
+    19: 'Timed Dry 90',
+    20: 'Timed Dry 120',
+    23: 'Room Dehumidify 120',
+    24: 'Room Dehumidify 240',
+    28: 'Padding Care',
+    30: 'Fine dust',
+    31: 'Virus',
+    32: 'Jeans Care',
+    33: 'Fur/Leather Care',
+    36: 'Suit/Uniform Sterilize',
+    37: 'Silk',
+    38: 'Cashmere',
+}
+
+/** modelJSON `SmartCourse`, id -> ko-KR name. Id 1 is LG's panel-pairing pseudo-course. */
+const SMART_COURSE: Record<number, string> = {
+    0: 'None',
+    1: 'Panel course',
+    61: 'Suit/Uniform Sterilize',
+    62: 'Scarf Care',
+    66: 'Pants Care',
+    67: 'Quiet Care',
+    68: 'Coat warm',
+    69: 'Static removal',
+    71: 'Old-clothes Care',
+    73: 'Blanket warm',
+    75: 'Dress-shirt Dry',
+    76: 'Snow/Rain Dry',
+    78: 'Fur/Leather Care',
+    93: 'Jeans Care',
+    94: 'Baby-clothes Sterilize',
+    95: 'Doll Sterilize',
+    96: 'Wool/Knit Dry',
+    97: 'Rainy-season Laundry Dry',
+    98: 'Uniform Care',
+    99: 'Padding Care',
+    100: 'Thin Padding Dry',
+    101: 'Thick Padding Dry',
+    112: 'Yoga/Pilates Care',
+    113: 'Yoga/Pilates Dry',
+    114: 'Swimwear Dry',
+    115: 'Functional',
+    119: 'Bedding Sterilize',
+}
+
+/** `styler.buzzer`: the byte is n in BUZZER_n (byte 45 = 4 read BUZZER_4, = 1 read BUZZER_1). */
+const BUZZER: Record<number, string> = { 0: 'Mute', 1: 'Small', 2: 'Normal', 3: 'Large', 4: 'Very large' }
+
+/** `styler.endMelody`: the byte is n in END_MELODY_n (byte 47 = 1 read END_MELODY_1). */
+const END_MELODY: Record<number, string> = {
+    0: 'Default sound',
+    1: 'Vivaldi Winter',
+    2: 'Bach Minuet',
+    3: 'Home Sweet Home',
+    4: 'Breeze',
+    5: 'Old MacDonald',
+    6: 'Verdi Brindisi',
+    7: 'Bubble',
+    8: 'Beethoven Symphony No.5 5',
+    9: 'Arirang',
+    10: 'Pachelbel Canon',
+    11: 'Beethoven Choral',
+    12: 'Jingle Bells (intro)',
+    13: 'Jingle Bells (chorus)',
+    14: 'We Wish You a Merry Christmas',
+    15: 'Silent Night',
+    16: 'O Christmas Tree',
+}
+
+/** The melodies LG's own capability schema offers for this unit — codes 0..11, in this order,
+ *  and a command frame was captured for every one. Codes 12..16 in the table above are read
+ *  labels only; LG does not list them for this model, so the select does not offer them. */
+const END_MELODY_OPTIONS = Array.from({ length: 12 }, (_, i) => END_MELODY[i])
+
+/** The courses this unit can be told to run — every id with a block above, under the name the
+ *  read table gives it, so Course select and the Course sensor speak the same words. */
+const COURSE_IDS = Object.keys(COURSE_PARAMS).map(Number)
+const COURSE_OPTIONS = COURSE_IDS.map((id) => COURSE[id])
+
+const enumOf = (table: Record<number, string>, raw: number) => table[raw] ?? `Code ${raw}`
+const hhmm = (h: number, m: number) => `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
+
+export default class Device extends AABBDevice {
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+
+        const sensor = (id: string, name: string, extra: object = {}) => ({
+            platform: 'sensor',
+            unique_id: `$deviceid-${id}`,
+            state_topic: `$this/${id}`,
+            name,
+            ...extra,
+        })
+        const flag = (id: string, name: string, extra: object = {}) => ({
+            platform: 'binary_sensor',
+            unique_id: `$deviceid-${id}`,
+            state_topic: `$this/${id}`,
+            name,
+            payload_on: 'ON',
+            payload_off: 'OFF',
+            ...extra,
+        })
+        const minutes = (id: string, name: string, extra: object = {}) =>
+            sensor(id, name, {
+                device_class: 'duration',
+                unit_of_measurement: 'min',
+                state_class: 'measurement',
+                ...extra,
+            })
+        /** A flag the appliance takes a command for. */
+        const toggle = (id: string, name: string, extra: object = {}) => ({
+            platform: 'switch',
+            unique_id: `$deviceid-${id}`,
+            state_topic: `$this/${id}`,
+            command_topic: `$this/${id}/set`,
+            name,
+            payload_on: 'ON',
+            payload_off: 'OFF',
+            ...extra,
+        })
+        /** A setting the appliance takes a command for, offered as its own Korean labels. */
+        const choice = (id: string, name: string, options: string[], extra: object = {}) => ({
+            platform: 'select',
+            unique_id: `$deviceid-${id}`,
+            state_topic: `$this/${id}`,
+            command_topic: `$this/${id}/set`,
+            name,
+            options,
+            ...extra,
+        })
+        /** A one-shot command with no state of its own. */
+        const press = (id: string, name: string, icon: string) => ({
+            platform: 'button',
+            unique_id: `$deviceid-${id}`,
+            command_topic: `$this/${id}/set`,
+            payload_press: '',
+            name,
+            icon,
+        })
+        /** One half of the night-care window. LG's own setter takes HH:MM on the half hour. */
+        const halfHourClock = (id: string, name: string, extra: object = {}) => ({
+            platform: 'text',
+            unique_id: `$deviceid-${id}`,
+            state_topic: `$this/${id}`,
+            command_topic: `$this/${id}/set`,
+            name,
+            icon: 'mdi:clock-time-four-outline',
+            pattern: HALF_HOUR.source,
+            min: 5,
+            max: 5,
+            entity_category: 'config',
+            ...extra,
+        })
+
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: 'LG Styler' }),
+                components: {
+                    power: toggle('power', 'Power', { icon: 'mdi:power' }),
+                    status: sensor('status', 'State', { icon: 'mdi:hanger' }),
+                    course: sensor('course', 'Course', { icon: 'mdi:playlist-check' }),
+                    // Choosing a course does not start it — LG's own app works the same way,
+                    // and its setCurrentCycle does not convert for this model.
+                    course_select: choice('course_select', 'Course select', COURSE_OPTIONS, {
+                        icon: 'mdi:playlist-edit',
+                    }),
+                    start_course: press('start_course', 'Start course', 'mdi:play-circle-outline'),
+                    pause_course: press('pause_course', 'Pause', 'mdi:pause-circle-outline'),
+                    resume_course: press('resume_course', 'Resume', 'mdi:play-pause'),
+                    smart_course: sensor('smart_course', 'Smart course', { icon: 'mdi:playlist-star' }),
+                    remaining: minutes('remaining', 'Time remaining', { icon: 'mdi:timer-sand' }),
+                    total: minutes('total', 'Total time', { icon: 'mdi:timer-outline' }),
+                    reserved_at: sensor('reserved_at', 'Reserved time', { icon: 'mdi:calendar-clock' }),
+                    error: sensor('error', 'Error', { icon: 'mdi:alert-circle-outline' }),
+                    // The appliance will not start a course while an error stands — Water refill is
+                    // the everyday one — so it gets a problem sensor of its own rather than
+                    // hiding inside a text reading nobody has an automation on.
+                    problem: flag('problem', 'Check needed', {
+                        device_class: 'problem',
+                        icon: 'mdi:alert',
+                    }),
+                    child_lock: flag('child_lock', 'Button lock', { icon: 'mdi:lock' }),
+                    night_dry: flag('night_dry', 'Store', { icon: 'mdi:weather-night' }),
+                    remote_start: flag('remote_start', 'Remote-control ready', { icon: 'mdi:cellphone-check' }),
+                    remote_maintain: toggle('remote_maintain', 'Remote control allowed', {
+                        icon: 'mdi:cellphone-wireless',
+                    }),
+                    buzzer: choice('buzzer', 'Alert sound', Object.values(BUZZER), {
+                        icon: 'mdi:volume-high',
+                        entity_category: 'config',
+                    }),
+                    end_melody: choice('end_melody', 'End melody', END_MELODY_OPTIONS, {
+                        icon: 'mdi:music',
+                        entity_category: 'config',
+                    }),
+                    keep_last_course: toggle('keep_last_course', 'Keep last course', {
+                        icon: 'mdi:repeat',
+                        entity_category: 'config',
+                    }),
+                    smart_care_finedust: toggle('smart_care_finedust', 'SmartCare Fine-dust', {
+                        icon: 'mdi:weather-dust',
+                        entity_category: 'config',
+                    }),
+                    smart_care_humidity: toggle('smart_care_humidity', 'SmartCare Humidity', {
+                        icon: 'mdi:water-percent',
+                        entity_category: 'config',
+                    }),
+                    smart_care_nightcare: toggle('smart_care_nightcare', 'SmartCare Night', {
+                        icon: 'mdi:sleep',
+                        entity_category: 'config',
+                    }),
+                    night_care_start: halfHourClock('night_care_start', 'Night-care start time'),
+                    night_care_end: halfHourClock('night_care_end', 'Night-care end time'),
+                    // Replaced by the two settable halves above. Removing a component from the
+                    // config is not enough to retire the entity Home Assistant already made —
+                    // a config carrying nothing but its platform is what says "this is gone",
+                    // and it has to carry that, or HA rejects the whole device payload.
+                    night_care_window: { platform: 'sensor' } as ComponentInfo,
+                    download_course: sensor('download_course', 'Downloaded course', {
+                        icon: 'mdi:download',
+                        entity_category: 'diagnostic',
+                    }),
+                    tcl_count: sensor('tcl_count', 'Sterilize-tank clean alert count', {
+                        icon: 'mdi:counter',
+                        entity_category: 'diagnostic',
+                        // Resets when the maintenance course runs, so total_increasing would
+                        // wrongly accumulate across the reset — no state_class.
+                    }),
+                    energy: sensor('energy', 'Energy monitoring', {
+                        icon: 'mdi:flash',
+                        entity_category: 'diagnostic',
+                    }),
+                    previous_status: sensor('previous_status', 'Previous state', {
+                        icon: 'mdi:history',
+                        entity_category: 'diagnostic',
+                    }),
+                    internal_light: sensor('internal_light', 'Interior light setting', {
+                        icon: 'mdi:lightbulb-outline',
+                        entity_category: 'diagnostic',
+                        // LG's snapshot exposes styler.internalLightingTime but this model's
+                        // modelJSON does not declare its value list, so the raw code is published
+                        // rather than an invented label. 0 read back NO_SETTING, 1 read LIGHTING_TIME_0.
+                    }),
+                },
+            }),
+        )
+    }
+
+    /*
+     * Offsets above are stated against the whole frame, the way the probes recorded them, so
+     * the frame is read unstripped rather than through the base class's body view.
+     */
+    processData(buf: Buffer) {
+        if (buf[0] !== 0xaa || buf[1] !== 0xff || buf[2] !== STATE_TAG) return
+        if (buf[buf.length - 1] !== 0xbb) return
+        if (buf.length < HEADER_LEN + RECORD_LEN + TRAILER_LEN) return
+        const payload = buf.length - HEADER_LEN - TRAILER_LEN
+        if (payload % RECORD_LEN !== 0) return
+        // The frame states how many record bytes it carries; disagreeing with the length means
+        // this is a different message that happens to divide evenly.
+        if (buf.readUInt16BE(RECORD_BYTES_OFF) !== payload) return
+
+        // The trailing record is the current state; a leading one, when present, is the previous.
+        const record = buf.length - TRAILER_LEN - RECORD_LEN
+        const at = (o: number) => buf[record + o]
+        const flagsA = at(OFF.flagsA)
+        const flagsB = at(OFF.flagsB)
+        const flagsC = at(OFF.flagsC)
+        const on = (byte: number, bit: number) => ((byte & bit) !== 0 ? 'ON' : 'OFF')
+
+        this.poweredOn = at(OFF.state) !== STATE_POWEROFF
+        this.nightCareEnabled = (flagsC & F_SC_NIGHTCARE) !== 0
+        this.hasProblem = !ERROR_CLEAR.has(at(OFF.error))
+        this.publishProperty('status', enumOf(STATE, at(OFF.state)))
+        this.publishProperty('power', this.poweredOn ? 'ON' : 'OFF')
+        this.publishProperty('previous_status', enumOf(STATE, at(OFF.preState)))
+        this.publishProperty('error', enumOf(ERROR, at(OFF.error)))
+        this.publishProperty('problem', this.hasProblem ? 'ON' : 'OFF')
+        this.publishProperty('course', enumOf(COURSE, at(OFF.course)))
+        this.publishProperty('smart_course', enumOf(SMART_COURSE, at(OFF.smartCourse)))
+
+        // Track whatever the appliance is actually set to, so Course select opens on the right one.
+        // Idle it reports NONE, which is not an option — that leaves the last choice standing.
+        const running = COURSE_PARAMS[at(OFF.course)] !== undefined ? at(OFF.course) : undefined
+        if (running !== undefined) {
+            this.selectedCourse = running
+            this.publishProperty('course_select', COURSE[running])
+        }
+
+        // LG reports the times split into hours and minutes; HA wants one duration.
+        this.publishProperty('remaining', at(OFF.remainTimeHour) * 60 + at(OFF.remainTimeMinute))
+        this.publishProperty('total', at(OFF.initialTimeHour) * 60 + at(OFF.initialTimeMinute))
+
+        const rh = at(OFF.reserveTimeHour)
+        const rm = at(OFF.reserveTimeMinute)
+        this.publishProperty('reserved_at', rh === 0 && rm === 0 ? 'No reservation' : hhmm(rh, rm))
+
+        this.publishProperty('child_lock', on(flagsA, F_CHILD_LOCK))
+        this.publishProperty('night_dry', on(flagsA, F_NIGHT_DRY))
+        this.publishProperty('remote_start', on(flagsA, F_REMOTE_START))
+        this.publishProperty('remote_maintain', on(flagsB, F_REMOTE_MAINTAIN))
+
+        // Both are selects, and a select's state has to be one of its options — publishing
+        // `Code N` for something outside the list would make Home Assistant reject the state and
+        // log it, so an unlisted code leaves the previous value standing.
+        this.publishOption('buzzer', BUZZER[at(OFF.buzzer)])
+        this.publishOption('end_melody', END_MELODY_OPTIONS[at(OFF.endMelody)])
+
+        this.publishProperty('keep_last_course', on(flagsC, F_IS_LAST_COURSE))
+        this.publishProperty('smart_care_finedust', on(flagsC, F_SC_FINEDUST))
+        this.publishProperty('smart_care_humidity', on(flagsC, F_SC_HUMIDITY))
+        this.publishProperty('smart_care_nightcare', on(flagsC, F_SC_NIGHTCARE))
+
+        this.publishProperty('night_care_start', hhmm(at(OFF.nightCareStartHour), at(OFF.nightCareStartMinute)))
+        this.publishProperty('night_care_end', hhmm(at(OFF.nightCareEndHour), at(OFF.nightCareEndMinute)))
+
+        // Only slot 1 is meaningful on this unit: Config.maxDownloadCourseNum is 1, and the
+        // count byte 40 reads 1. Slots 2..4 hold leftovers and are not published.
+        this.publishProperty('download_course', enumOf(SMART_COURSE, at(OFF.downloadCourse1)))
+
+        this.publishProperty('tcl_count', at(OFF.tclCount))
+        this.publishProperty('energy', (at(OFF.energyHi) << 8) | at(OFF.energyLo))
+        this.publishProperty('internal_light', at(OFF.internalLightingTime))
+    }
+
+    /** What Start course will run. Kept here because LG's setCurrentCycle does not convert, so the
+     *  appliance has no notion of a selected-but-not-started course to read back. */
+    private selectedCourse = COURSE_IDS[0]
+    /** Last state the appliance itself reported. `undefined` means no state frame has arrived. */
+    private poweredOn: boolean | undefined
+    private nightCareEnabled: boolean | undefined
+    private hasProblem: boolean | undefined
+
+    private publishOption(prop: string, label: string | undefined) {
+        if (label !== undefined) this.publishProperty(prop, label)
+    }
+
+    /** `aa 34 f0 26 | <id> 01 00 04 00 00 00 00 00 | <course parameters> | ck bb`. */
+    private runCourse(id: number) {
+        const params = COURSE_PARAMS[id]
+        if (params === undefined) return console.warn(`Styler: Course cannot start ${id}`)
+        this.send(
+            Buffer.concat([Buffer.from(RUN_COURSE), Buffer.from([id, ...COURSE_HEAD]), Buffer.from(params, 'hex')]),
+        )
+    }
+
+    /** Resume carries the course id and nothing else. */
+    private resumeCourse(id: number) {
+        const block = Buffer.alloc(RESUME_BLOCK_LEN)
+        block[0] = id
+        this.send(Buffer.concat([Buffer.from(RUN_COURSE), block]))
+    }
+
+    /**
+     * Build and send a command frame: `aa <len> f0 24 <type> <len> <value…> <ck> bb`.
+     *
+     * The base class's `send` supplies the AA/length prefix and the checksum, so what goes in is
+     * `f0 24` plus the body — which reproduces the captured frames byte for byte.
+     */
+    private setControl(type: number, ...values: number[]) {
+        this.send(Buffer.from([...SET_STATE, type, values.length, ...values]))
+    }
+
+    /** The UPCENTER settings put their own sub id between the length and the value, and the
+     *  length still counts only the value bytes — 1 for a flag, 2 for a clock time. */
+    private setUpCenter(sub: number, ...values: number[]) {
+        this.send(Buffer.from([...SET_STATE, CTRL_UPCENTER, values.length, sub, ...values]))
+    }
+
+    /*
+     * Publish what was just asked for, without waiting for the appliance to say it.
+     *
+     * This appliance reports when it feels like it. A settings change comes back in a second or
+     * two, but a course start can take a minute or more: while it runs it mostly sends frames
+     * that carry no state at all, so the 98-byte state frame that would confirm the course is
+     * simply not due yet. Waiting for it makes every control feel broken and invites a second
+     * press. The next real frame overwrites whatever is published here, so the appliance still
+     * has the last word. Known refusals are not echoed: this model rejects every setting while
+     * powered off, and rejects night-care times while night care is disabled.
+     */
+    private echo(prop: string, value: string | number) {
+        if (this.poweredOn !== true) return
+        if (prop === 'course' && this.hasProblem !== false) return
+        if (this.nightCareEnabled === false && (prop === 'night_care_start' || prop === 'night_care_end')) {
+            return
+        }
+        this.publishProperty(prop, value)
+    }
+
+    setProperty(prop: string, mqttValue: string) {
+        const onOff = () => (mqttValue === 'ON' ? 1 : 0)
+        switch (prop) {
+            case 'power':
+                this.setControl(CTRL_POWER, onOff())
+                // Every other setting here is confirmed by the state frame the appliance sends
+                // back. Power is the exception: switched off, it stops sending a frame this
+                // driver can read at all, so the switch would never see OFF. It is published
+                // here and corrected by the next real frame.
+                if (mqttValue !== 'ON') this.poweredOn = false
+                return this.publishProperty('power', mqttValue === 'ON' ? 'ON' : 'OFF')
+            case 'remote_maintain':
+                this.setControl(CTRL_REMOTE_MAINTAIN, onOff())
+                return this.echo(prop, mqttValue)
+            case 'keep_last_course':
+                this.setUpCenter(UP.isLastCourse, onOff())
+                return this.echo(prop, mqttValue)
+            case 'course_select': {
+                const id = COURSE_IDS.find((c) => COURSE[c] === mqttValue)
+                if (id === undefined) return console.warn(`Styler: Unknown course '${mqttValue}'`)
+                this.selectedCourse = id
+                // Nothing goes to the appliance until Start course — this is a choice, not a command.
+                return this.publishProperty('course_select', mqttValue)
+            }
+            case 'start_course':
+                this.runCourse(this.selectedCourse)
+                // The course itself, so the dashboard shows what was asked for straight away.
+                return this.echo('course', COURSE[this.selectedCourse])
+            case 'pause_course':
+                return this.setControl(CTRL_PAUSE, 0)
+            case 'resume_course':
+                return this.resumeCourse(this.selectedCourse)
+            case 'smart_care_finedust':
+                this.setUpCenter(UP.smartCareFineDust, onOff())
+                return this.echo(prop, mqttValue)
+            case 'smart_care_humidity':
+                this.setUpCenter(UP.smartCareHumidity, onOff())
+                return this.echo(prop, mqttValue)
+            case 'smart_care_nightcare':
+                this.setUpCenter(UP.smartCareNightCare, onOff())
+                return this.echo(prop, mqttValue)
+            case 'buzzer': {
+                const code = Object.entries(BUZZER).find(([, label]) => label === mqttValue)?.[0]
+                if (code === undefined) return console.warn(`Styler: Unknown alert sound '${mqttValue}'`)
+                this.setUpCenter(UP.buzzer, Number(code))
+                return this.echo(prop, mqttValue)
+            }
+            case 'end_melody': {
+                const code = END_MELODY_OPTIONS.indexOf(mqttValue)
+                if (code < 0) return console.warn(`Styler: Unknown end melody '${mqttValue}'`)
+                this.setUpCenter(UP.endMelody, code)
+                return this.echo(prop, mqttValue)
+            }
+            case 'night_care_start':
+            case 'night_care_end': {
+                // The text entity carries the pattern, but a driver that trusts it would write a
+                // stray byte into the schedule on any other producer. The appliance only takes
+                // whole and half hours, which is LG's own constraint, not ours.
+                const m = HALF_HOUR.exec(mqttValue.trim())
+                if (!m) return console.warn(`Styler: Night-care time format error '${mqttValue}'`)
+                const sub = prop === 'night_care_start' ? UP.nightCareStart : UP.nightCareEnd
+                // Hour and minute travel in one frame, exactly as LG's own setter sent them.
+                this.setUpCenter(sub, Number(m[1]), Number(m[2]))
+                return this.echo(prop, mqttValue.trim())
+            }
+            default:
+                console.warn(`Styler: Item does not support writing ${prop}`)
+        }
+    }
+}

--- a/cloud/devices/tlv_device.ts
+++ b/cloud/devices/tlv_device.ts
@@ -136,12 +136,13 @@ export default class TLVDevice extends HADevice {
             buf[3] == 0x00 &&
             buf[4] == 0x00 &&
             buf[5] == 0x00 &&
-            buf[6] == 0x87 &&
+            (buf[6] == 0x87 || buf[6] == 0xa7) &&
             buf[7] == 0x02 &&
             (buf[8] == 0x01 || buf[8] == 0x04) &&
             /* && buf[9] is a "sequence" number */ buf[10] == buf.length - 13
         ) {
             // ignore the CRC, we assume that the modem verifies it :/
+            // 0x87 used by RAC/WIN; 0xA7 used by DHUM_056905_WW and similar
             log('status', this.id, 'received TLV packet')
             this.processTLV(TLV.parse(buf.subarray(11, buf.length - 2)))
         }

--- a/cloud/devices/washtower_common.ts
+++ b/cloud/devices/washtower_common.ts
@@ -1,0 +1,3322 @@
+import { Device as Thinq2Device } from '../thinq2/device'
+import { type Connection, type DeviceDiscovery } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import crc16 from '@/util/crc16'
+import HADevice from './base'
+
+type Field = {
+    key: string
+    offset: number
+    length: number
+    bit?: number
+    bits?: number
+    label: string
+    values?: Record<string, string>
+}
+export type WashTowerModel = {
+    tag: number
+    /** Full 0xEC record length declared by the official protocol map. */
+    recordLength: number
+    /** CRC-valid 0xEB record length emitted by this installed firmware. */
+    liveRecordLength: number
+    deviceName: string
+    fields: readonly Field[]
+}
+
+/*
+ * Read-only Course enums from the official converter maps. Labels are resolved
+ * from the installed Korean model/langpack data; these maps intentionally do
+ * not define which courses are writable.
+ */
+const WASHER_COURSE_LABELS: Record<string, string> = {
+    '0': 'None',
+    '1': 'Wash/Dry Refresh',
+    '2': 'Add prewash',
+    '3': 'Air Cleaning',
+    '4': 'Allergy Spa Steam',
+    '5': 'Allergy Care',
+    '6': 'Safe Cold Wash',
+    '7': 'Baby Steam Care',
+    '8': 'Baby clothes',
+    '9': 'Bedding Care',
+    '10': 'Boil',
+    '11': 'White Wash',
+    '12': 'Large Wash',
+    '13': 'Large load',
+    '14': 'Everyday wear',
+    '15': 'Cold Care',
+    '16': 'Cold Clean',
+    '17': 'Cold Wash',
+    '18': 'Color Care',
+    '19': 'Eco Standard',
+    '20': 'Closet Dry',
+    '21': 'Dark Wash',
+    '22': 'Delicate Dry',
+    '23': 'Ready to wear',
+    '24': 'Double Rinse',
+    '25': 'Drain/Spin',
+    '26': 'Dry only',
+    '27': 'Bedding',
+    '28': 'Bedding wash',
+    '29': 'Easy Care',
+    '30': 'Favorite',
+    '31': 'Soft Care',
+    '32': 'Half load',
+    '33': 'Handwash',
+    '34': 'Handwash/Wool',
+    '35': 'Heavy soil',
+    '36': 'Focus 60min',
+    '37': 'Iron Dry',
+    '38': 'Jeans',
+    '39': 'Kids clothes',
+    '40': 'Large Wash',
+    '41': 'Wool/Delicate',
+    '42': 'Low-temp Dry',
+    '43': 'Mixed Wash',
+    '44': 'Sanitary 40°',
+    '45': 'Sterilize 60°',
+    '46': 'Standard',
+    '47': 'Quiet',
+    '48': 'Wrinkle Prevent',
+    '49': 'Intensive Wash',
+    '50': 'Prewash+Standard',
+    '51': 'Quick Deodorize',
+    '52': 'Quick 30min',
+    '53': 'Quiet',
+    '54': 'Refresh',
+    '55': 'Rinse/Spin',
+    '56': 'Rinse only',
+    '57': 'Durable garments',
+    '58': 'Safe',
+    '59': 'Safe Standard',
+    '60': 'Sterilize',
+    '61': 'Oxygen Sterilize',
+    '62': 'Eco Wash',
+    '63': 'School uniform',
+    '64': 'Shoes',
+    '65': 'Quiet',
+    '66': 'Quiet Wash',
+    '67': 'Thorough Rinse',
+    '68': 'Small Wash',
+    '69': 'Smart power-save',
+    '70': 'Soak',
+    '71': 'Spa Refresh',
+    '72': 'Quick Dry',
+    '73': 'Quick Tub Clean',
+    '74': 'Small Quick',
+    '75': 'Quick 14min',
+    '76': 'Eco Boil',
+    '77': 'Quick Wash/Dry',
+    '78': 'Spin only',
+    '79': 'Functional garments',
+    '80': 'Stain Care',
+    '81': 'Steam Standard',
+    '82': 'Intensive Dry',
+    '83': 'Timed Dry',
+    '84': 'Towels',
+    '85': 'Tub Sterilize',
+    '86': 'Tub Dry',
+    '87': 'Turbo Wash',
+    '88': 'Wash/Dry',
+    '89': 'Wash only',
+    '90': 'White',
+    '91': 'Air Spin 120min',
+    '92': 'Air Spin 60min',
+    '93': 'Air Spin 90min',
+    '94': 'Wool',
+    '95': 'Single shirt',
+    '96': 'Cotton underwear',
+    '97': 'Light Boil',
+    '98': 'Light soil',
+    '99': 'Activewear',
+    '100': 'Underwear',
+    '101': 'Static prevent',
+    '102': 'Fabric protect',
+    '103': 'Deodorize',
+    '104': 'Eco Wash',
+    '105': 'Kids clothes',
+    '106': 'Rainy-season Wash',
+    '107': 'School uniform',
+    '108': 'Shirt',
+    '109': 'Single-item Wash',
+    '110': 'Thorough Rinse',
+    '111': 'Safe Rinse',
+    '112': 'Spin only',
+    '113': 'Sweat stain removal',
+    '114': 'AI Wash',
+    '115': 'Down jacket',
+    '116': 'Eco Standard Large',
+    '117': 'Eco Standard Small',
+    '118': 'Standard 20°',
+    '119': 'Pet Care',
+    '120': 'Outdoor',
+    '121': 'Water repellent',
+    '122': 'Turbo 39min',
+    '123': 'Turbo 59min',
+    '124': 'Quick Wash/Dry',
+    '125': 'Boil Wash',
+    '126': 'Disinfectant Safe Wash',
+    '127': 'Standard Plus',
+    '128': 'Detergent tray clean',
+    '129': 'Duvet cover',
+    '130': 'Swimwear',
+    '131': 'Dress',
+    '132': 'Large',
+    '133': 'Extra Large',
+    '134': 'Quick Tub Rinse',
+    '135': 'Quick Steam Sterilize',
+    '136': 'Microplastic Care',
+    '137': 'Timed Wash',
+    '138': 'Timed Dry',
+    '139': 'Steam Sterilize Dry',
+    '140': 'Steam Refresh Dry',
+    '141': 'Rainy-season Dry',
+    '142': 'Padding Dry',
+    '143': 'Air Dry',
+    '144': 'Bedding Care Dry',
+    '145': 'Soak',
+    '146': 'Light soil',
+    '147': 'Intensive Wash',
+    '148': 'Fresh Care',
+    '149': 'Towel Boil Wash',
+    '150': 'New clothes',
+    '151': 'Intensive Spin',
+    '152': 'Custom Dry',
+    '153': 'Denim',
+    '154': 'Cotton underwear',
+    '155': 'Soak Boil',
+    '156': 'Bedding rinse/spin',
+    '157': 'Heavy-soil Soak',
+    '158': 'Heavy-soil Prewash',
+    '159': 'Socks',
+    '160': 'Double Rinse/Spin',
+    '161': 'Cold Intensive Wash',
+    '162': 'Baby Prewash',
+    '163': 'Yoga wear',
+    '164': 'Golf wear',
+    '165': 'Summer bedding',
+    '166': 'AI Wash/Dry',
+    '167': 'Delicate Dry',
+    '168': 'Wrinkle Prevent Dry',
+    '169': 'Cuffs & collar',
+    '255': 'Downloaded course',
+}
+
+const DRYER_COURSE_LABELS: Record<string, string> = {
+    '0': 'None',
+    '1': 'Steam Refresh',
+    '2': 'Towels',
+    '3': 'Jeans',
+    '4': 'Bedding',
+    '5': 'Shirt',
+    '6': 'Mixed garments',
+    '7': 'Standard',
+    '8': 'Functional garments',
+    '9': 'Small Quick',
+    '10': 'Delicate Dry',
+    '11': 'Wool/Delicate',
+    '12': 'Shelf Dry',
+    '13': 'Air blow',
+    '14': 'Warm air',
+    '15': 'Bedding shake',
+    '16': 'Steam Sterilize',
+    '17': 'Intensive Dry',
+    '18': 'Condenser Care',
+    '19': 'Tub Sterilize',
+    '20': 'Padding Refresh',
+    '21': 'Timed Dry',
+    '22': 'Outdoor Refresh',
+    '23': 'Baby clothes',
+    '24': 'Small Dry',
+    '25': 'Standard Plus',
+    '26': 'Wrinkle Prevent',
+    '27': 'Pet Care',
+    '28': 'Single shirt',
+    '29': 'Heavy soil',
+    '30': 'Ultra Delicate',
+    '31': 'Kids clothes',
+    '32': 'Low-temp Dry',
+    '33': 'Large Dry',
+    '34': 'Quick Dry',
+    '35': 'Air Dry',
+    '36': 'Spot clean',
+    '37': 'Steam Refresh',
+    '38': 'Steam Sterilize',
+    '39': 'Refresh',
+    '40': 'Garment Refresh',
+    '41': 'Mist Refresh',
+    '42': 'Intensive Dry',
+    '43': 'Low-temp Dry Plus',
+    '44': 'AI Dry',
+    '45': 'Quiet',
+    '46': 'Shrink ease',
+    '47': 'Wrinkle Ease',
+    '48': 'Thin bedding',
+    '49': 'Sportswear',
+    '50': 'Rainy-season Dry',
+    '51': 'Iron Dry',
+    '52': 'Duvet cover',
+    '53': 'Blanket warm',
+    '54': 'Night Dry',
+    '55': 'Half-load Dry',
+    '56': 'Full-load Dry',
+    '57': 'Room Dehumidify',
+    '58': 'Turbo Dry',
+    '114': 'Wrinkle Ease Dry',
+    '255': 'Downloaded course',
+}
+
+/* LG official maps: FAKPK21021 WASHER_PROTOCOL_EX 8.3 / WASHER_CONVERT_EX 2.3;
+ * BDH_D39301_KR DRYER_PROTOCOL_EX 4.1 / DRYER_CONVERT_EX 7.8. */
+export const WASHER_MODEL: WashTowerModel = {
+    tag: 51,
+    recordLength: 72,
+    liveRecordLength: 67,
+    deviceName: 'LG WashTower Washer',
+    fields: [
+        { key: 'protocolVersion', offset: 0, length: 1, label: 'Protocol version' },
+        {
+            key: 'soilWash',
+            offset: 1,
+            length: 1,
+            label: 'Wash strength',
+            values: {
+                '0': 'Off',
+                '1': 'Light soil',
+                '3': 'Standard',
+                '5': 'Intensive',
+                '6': 'Prewash',
+                '7': 'Soak',
+            },
+        },
+        {
+            key: 'temp',
+            offset: 2,
+            length: 1,
+            label: 'Temperature',
+            values: {
+                '0': 'Off',
+                '1': '20 ℃',
+                '2': '30 ℃',
+                '3': '40 ℃',
+                '4': '50 ℃',
+                '5': '60 ℃',
+                '6': '95 ℃',
+                '8': 'Cold water',
+                '20': '27 ℃',
+                '21': '35 ℃',
+                '22': '38 ℃',
+                '23': '90 ℃',
+            },
+        },
+        {
+            key: 'rinse',
+            offset: 3,
+            length: 1,
+            label: 'Rinse',
+            values: {
+                '0': 'Off',
+                '1': '1x',
+                '2': '2x',
+                '3': '3x',
+                '4': '4x',
+                '5': '5x',
+                '6': 'Rinse 6x',
+                '7': 'Rinse 7x',
+                '8': 'Rinse 8x',
+            },
+        },
+        {
+            key: 'spin',
+            offset: 4,
+            length: 1,
+            label: 'Spin strength',
+            values: {
+                '0': 'Off',
+                '1': 'Delicate',
+                '2': 'Low',
+                '3': '700 rpm',
+                '4': 'Mid',
+                '5': '900 rpm',
+                '6': 'High',
+                '7': '1100 rpm',
+                '8': 'Max',
+                '9': '1400 rpm',
+                '10': '1600 rpm',
+                '19': 'On',
+            },
+        },
+        {
+            key: 'course',
+            offset: 5,
+            length: 1,
+            label: 'Course',
+            values: WASHER_COURSE_LABELS,
+        },
+        {
+            key: 'dryLevel',
+            offset: 6,
+            length: 1,
+            label: 'Dryness',
+            values: {
+                '0': 'Off',
+                '11': 'Timed Dry 30min',
+                '12': 'Timed Dry 60min',
+                '13': 'Timed Dry 90min',
+                '14': 'Timed Dry 120min',
+                '15': 'Timed Dry 150min',
+                '19': '20min',
+                '20': '40min',
+                '21': '180min',
+                '22': '240min',
+            },
+        },
+        {
+            key: 'soak',
+            offset: 7,
+            length: 1,
+            label: 'Soak',
+            values: {},
+        },
+        {
+            key: 'washTime',
+            offset: 8,
+            length: 1,
+            label: 'Wash time',
+            values: {},
+        },
+        {
+            key: 'waterLevel',
+            offset: 9,
+            length: 1,
+            label: 'Water level',
+            values: {
+                '0': '1Level',
+                '1': '2Level',
+                '2': '3Level',
+                '3': '4Level',
+                '4': '5Level',
+                '5': '6Level',
+                '6': '7Level',
+                '7': '8Level',
+                '8': '9Level',
+                '9': '10Level',
+            },
+        },
+        {
+            key: 'loadItemWasher',
+            offset: 10,
+            length: 1,
+            label: 'Laundry amount',
+            values: { '0': 'Off', '1': '1Level', '2': '2Level', '3': '3Level' },
+        },
+        { key: 'reserveTimeMinute', offset: 11, length: 2, label: 'Reserved time' },
+        { key: 'remainTimeMinute', offset: 13, length: 2, label: 'Time remaining' },
+        { key: 'initialTimeMinute', offset: 15, length: 2, label: 'Total time' },
+        { key: 'courseSpendPower', offset: 17, length: 2, label: 'Course power usage' },
+        {
+            key: 'error',
+            offset: 19,
+            length: 1,
+            label: 'Error',
+            values: {
+                '0': 'No error',
+                '2': 'Not filling',
+                '3': 'Not draining',
+                '4': 'Not spinning',
+                '5': 'Water level high',
+                '7': 'Water level not detected',
+                '8': 'Temp not detected',
+                '9': 'Motor rotation fault',
+                '13': 'Freeze detected',
+                '20': 'Door not closed',
+                '21': 'Door not locked',
+                '23': 'Vibration sensor fault',
+                '33': 'Off',
+                '43': 'Check detergent tank',
+                '44': 'Detergent not dosed',
+                '45': 'Check softener tank',
+                '46': 'Softener not dosed',
+                '47': 'Detergent tank fault',
+                '48': 'Turbidity not detected',
+            },
+        },
+        {
+            key: 'baseDownloadCourseData',
+            offset: 20,
+            length: 1,
+            label: 'Downloaded course basis',
+            values: {
+                '0': 'None',
+                '27': 'Bedding',
+                '46': 'Standard',
+                '74': 'Small Quick',
+                '76': 'Eco Boil',
+                '85': 'Tub Sterilize',
+                '114': 'AI Wash',
+            },
+        },
+        {
+            key: 'state',
+            offset: 21,
+            length: 1,
+            label: 'Current state',
+            values: {
+                '0': 'Power off',
+                '1': 'On',
+                '2': 'Pause',
+                '3': 'Detecting weight',
+                '5': 'Filling',
+                '6': 'Detecting weight',
+                '8': 'Soaking',
+                '9': 'Prewashing',
+                '11': 'Washing',
+                '12': 'Rinsing',
+                '13': 'Awaiting rinse',
+                '14': 'Spinning',
+                '15': 'Drying',
+                '16': 'Wash complete',
+                '21': 'Wrinkle preventing',
+                '23': 'Error occurred',
+                '27': 'Anti-freeze standby',
+                '28': 'Pause',
+                '29': 'Running',
+                '35': 'Pause',
+                '36': 'Setting',
+                '37': 'Recognizing garment',
+                '38': 'Auto detergent dosing',
+                '39': 'Auto softener dosing',
+                '40': 'Detecting soil level',
+                '41': 'Cleaning',
+                '42': 'Wash complete',
+                '43': 'Steaming',
+                '47': 'Laundry care running',
+                '48': 'Cleaning',
+                '49': 'Awaiting completion',
+            },
+        },
+        {
+            key: 'preState',
+            offset: 22,
+            length: 1,
+            label: 'Previous state',
+            values: {
+                '0': 'Power off',
+                '1': 'On',
+                '2': 'Pause',
+                '3': 'Detecting weight',
+                '5': 'Filling',
+                '6': 'Detecting weight',
+                '8': 'Soaking',
+                '9': 'Prewashing',
+                '11': 'Washing',
+                '12': 'Rinsing',
+                '13': 'Awaiting rinse',
+                '14': 'Spinning',
+                '15': 'Drying',
+                '16': 'Wash complete',
+                '21': 'Wrinkle preventing',
+                '23': 'Error occurred',
+                '27': 'Anti-freeze standby',
+                '28': 'Pause',
+                '29': 'Running',
+                '35': 'Pause',
+                '36': 'Setting',
+                '37': 'Recognizing garment',
+                '38': 'Auto detergent dosing',
+                '39': 'Auto softener dosing',
+                '40': 'Detecting soil level',
+                '41': 'Cleaning',
+                '42': 'Wash complete',
+                '43': 'Steaming',
+                '47': 'Laundry care running',
+                '48': 'Cleaning',
+                '49': 'Awaiting completion',
+            },
+        },
+        {
+            key: 'downloadCourse',
+            offset: 23,
+            length: 1,
+            label: 'Downloaded course',
+            values: {
+                '0': 'None',
+                '97': 'Single shirt',
+                '101': 'Sweat stain removal',
+                '102': 'Shirt',
+                '104': 'Baby clothes',
+                '107': 'Single-item Wash',
+                '109': 'Rainy-season Wash',
+                '111': 'Color Care',
+                '117': 'Functional garments',
+                '122': 'Fabric protect',
+                '123': 'Kids clothes',
+                '127': 'Thorough Rinse',
+                '128': 'School uniform',
+                '129': 'Spin only',
+                '131': 'Cold Wash',
+                '154': 'Wool/Delicate',
+                '192': 'Quiet',
+                '197': 'Heavy soil',
+                '224': 'Towels',
+                '236': 'Wash only',
+                '237': 'Rinse only',
+            },
+        },
+        {
+            key: 'loadLevel',
+            offset: 24,
+            length: 1,
+            label: 'Detected load',
+            values: {
+                '1': '1Level',
+                '2': '2Level',
+                '3': '3Level',
+                '4': '4Level',
+                '5': '5Level',
+                '6': '6Level',
+                '7': '7Level',
+                '8': '8Level',
+                '9': '9Level',
+                '10': '10Level',
+            },
+        },
+        { key: 'courseSpendWater', offset: 25, length: 2, label: 'Course water usage' },
+        {
+            key: 'rinseCount',
+            offset: 27,
+            length: 1,
+            label: 'Rinses remaining',
+            values: {
+                '1': 'Rinse 1x',
+                '2': 'Rinse 2x',
+                '3': 'Rinse 3x',
+                '4': 'Rinse 4x',
+                '5': 'Rinse 5x',
+                '6': 'Rinse 6x',
+                '7': 'Rinse 7x',
+                '8': 'Rinse 8x',
+            },
+        },
+        { key: 'TCLCount', offset: 28, length: 1, label: 'Tub-clean count' },
+        {
+            key: 'buzzer',
+            offset: 29,
+            length: 1,
+            label: 'Alert sound',
+            values: {
+                '0': 'Mute',
+                '1': 'Small',
+                '2': 'Normal',
+                '3': 'Large',
+                '4': 'Very large',
+                '15': 'On',
+            },
+        },
+        {
+            key: 'ezCSDetergentSetVal',
+            offset: 30,
+            length: 1,
+            label: 'Auto detergent level',
+            values: {
+                '0': 'Off',
+                '1': 'Low',
+                '2': 'Normal',
+                '3': 'High',
+            },
+        },
+        {
+            key: 'ezCSSoftenerSetVal',
+            offset: 31,
+            length: 1,
+            label: 'Auto softener level',
+            values: {
+                '0': 'Off',
+                '1': 'Low',
+                '2': 'Normal',
+                '3': 'High',
+            },
+        },
+        { key: 'ezDetergentAmount', offset: 32, length: 1, label: 'Detergent amount' },
+        { key: 'ezSoftenerAmount', offset: 33, length: 1, label: 'Softener amount' },
+        {
+            key: 'waterPlus',
+            offset: 34,
+            length: 1,
+            bit: 0,
+            bits: 1,
+            label: 'Add water',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'multiStain',
+            offset: 34,
+            length: 1,
+            bit: 1,
+            bits: 1,
+            label: 'Mixed soil',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'coldWash',
+            offset: 34,
+            length: 1,
+            bit: 2,
+            bits: 1,
+            label: 'Cold Wash',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'intensive',
+            offset: 34,
+            length: 1,
+            bit: 3,
+            bits: 1,
+            label: 'Intensive Wash',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'timeSave',
+            offset: 34,
+            length: 1,
+            bit: 4,
+            bits: 1,
+            label: 'Time save',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'turboWash',
+            offset: 34,
+            length: 1,
+            bit: 5,
+            bits: 1,
+            label: 'Turbo Wash',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'preWash',
+            offset: 34,
+            length: 1,
+            bit: 6,
+            bits: 1,
+            label: 'Prewash',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'autoSoak',
+            offset: 34,
+            length: 1,
+            bit: 7,
+            bits: 1,
+            label: 'Auto soak',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'ecoHybrid',
+            offset: 35,
+            length: 1,
+            bit: 0,
+            bits: 1,
+            label: 'Eco mode',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'steamSoftener',
+            offset: 35,
+            length: 1,
+            bit: 1,
+            bits: 1,
+            label: 'Steam Softener',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'fabricSoftener',
+            offset: 35,
+            length: 1,
+            bit: 2,
+            bits: 1,
+            label: 'Softener',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'sterilize',
+            offset: 35,
+            length: 1,
+            bit: 3,
+            bits: 1,
+            label: 'Sterilize',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'steam',
+            offset: 35,
+            length: 1,
+            bit: 4,
+            bits: 1,
+            label: 'Steam',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'rinseSpin',
+            offset: 35,
+            length: 1,
+            bit: 5,
+            bits: 1,
+            label: 'Rinse/Spin',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'rinseHold',
+            offset: 35,
+            length: 1,
+            bit: 6,
+            bits: 1,
+            label: 'Rinse stop',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'medicRinse',
+            offset: 35,
+            length: 1,
+            bit: 7,
+            bits: 1,
+            label: 'Safe Rinse',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'smartGridEnable',
+            offset: 36,
+            length: 1,
+            bit: 0,
+            bits: 1,
+            label: 'Smart Grid',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'favorite',
+            offset: 36,
+            length: 1,
+            bit: 1,
+            bits: 1,
+            label: 'Favorite',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'smartCare_onOff',
+            offset: 36,
+            length: 1,
+            bit: 2,
+            bits: 1,
+            label: 'Smart Care',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'warmWater',
+            offset: 36,
+            length: 1,
+            bit: 3,
+            bits: 1,
+            label: 'Hot water',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'saveEnergy',
+            offset: 36,
+            length: 1,
+            bit: 4,
+            bits: 1,
+            label: 'Energy saving',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'wrinkleCare',
+            offset: 36,
+            length: 1,
+            bit: 5,
+            bits: 1,
+            label: 'Wrinkle Prevent',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'freshCare',
+            offset: 36,
+            length: 1,
+            bit: 6,
+            bits: 1,
+            label: 'Status info 052',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'creaseCare',
+            offset: 36,
+            length: 1,
+            bit: 7,
+            bits: 1,
+            label: 'Status info 053',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'doorClose',
+            offset: 37,
+            length: 1,
+            bit: 0,
+            bits: 1,
+            label: 'Door closed',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'wifiSDS',
+            offset: 37,
+            length: 1,
+            bit: 1,
+            bits: 1,
+            label: 'Wireless smart diagnosis',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'voiceState',
+            offset: 37,
+            length: 1,
+            bit: 2,
+            bits: 1,
+            label: 'Voice state',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'activeStandbyEnable',
+            offset: 37,
+            length: 1,
+            bit: 3,
+            bits: 1,
+            label: 'Standby mode',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'remoteStart',
+            offset: 37,
+            length: 1,
+            bit: 4,
+            bits: 1,
+            label: 'Remote start',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'childLock',
+            offset: 37,
+            length: 1,
+            bit: 5,
+            bits: 1,
+            label: 'Button lock',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'drumLight',
+            offset: 37,
+            length: 1,
+            bit: 6,
+            bits: 1,
+            label: 'Drum light',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'addGarment',
+            offset: 37,
+            length: 1,
+            bit: 7,
+            bits: 1,
+            label: 'Add laundry',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'doorLock',
+            offset: 38,
+            length: 1,
+            bit: 0,
+            bits: 1,
+            label: 'Door lock',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'coolDown',
+            offset: 38,
+            length: 1,
+            bit: 1,
+            bits: 1,
+            label: 'Cooling',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'rinseDefault',
+            offset: 38,
+            length: 1,
+            bit: 2,
+            bits: 1,
+            label: 'Basic Rinse',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'autoDetection',
+            offset: 38,
+            length: 1,
+            bit: 3,
+            bits: 2,
+            label: 'Auto detect',
+            values: {},
+        },
+        {
+            key: 'washLoadDisplay',
+            offset: 38,
+            length: 1,
+            bit: 5,
+            bits: 1,
+            label: 'Show load',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'speechRecognitionMode',
+            offset: 38,
+            length: 1,
+            bit: 6,
+            bits: 1,
+            label: 'Voice recognition',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'standby',
+            offset: 38,
+            length: 1,
+            bit: 7,
+            bits: 1,
+            label: 'Standby',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'ezSoftenerState',
+            offset: 39,
+            length: 1,
+            bit: 0,
+            bits: 1,
+            label: 'Softener level',
+            values: { '1': 'Refill needed' },
+        },
+        {
+            key: 'ezDetergentState',
+            offset: 39,
+            length: 1,
+            bit: 1,
+            bits: 1,
+            label: 'Detergent level',
+            values: { '1': 'Refill needed' },
+        },
+        {
+            key: 'ezDispenseDrawerState',
+            offset: 39,
+            length: 1,
+            bit: 2,
+            bits: 1,
+            label: 'Auto-dispenser state',
+        },
+        {
+            key: 'ezDispenseNotation',
+            offset: 39,
+            length: 1,
+            bit: 3,
+            bits: 1,
+            label: 'Auto-dose unit',
+        },
+        {
+            key: 'smallUE',
+            offset: 39,
+            length: 1,
+            bit: 4,
+            bits: 1,
+            label: 'Small-load imbalance',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'audibleSDS',
+            offset: 39,
+            length: 1,
+            bit: 5,
+            bits: 1,
+            label: 'Sound smart diagnosis',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'extraRinse',
+            offset: 39,
+            length: 1,
+            bit: 6,
+            bits: 1,
+            label: 'Extra Rinse',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'delay',
+            offset: 39,
+            length: 1,
+            bit: 7,
+            bits: 1,
+            label: 'Reservation',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'AIDDLed',
+            offset: 40,
+            length: 1,
+            bit: 0,
+            bits: 1,
+            label: 'AI indicator',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'dnnReady',
+            offset: 40,
+            length: 1,
+            bit: 1,
+            bits: 1,
+            label: 'AI ready',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'remoteMaintain',
+            offset: 40,
+            length: 1,
+            bit: 2,
+            bits: 1,
+            label: 'Remote control lock',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'autoCourseArrange',
+            offset: 40,
+            length: 1,
+            bit: 3,
+            bits: 1,
+            label: 'Auto sort courses',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'applyBuzzer',
+            offset: 40,
+            length: 1,
+            bit: 4,
+            bits: 1,
+            label: 'Alert sound supported',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'applyRemoteMaintain',
+            offset: 40,
+            length: 1,
+            bit: 5,
+            bits: 1,
+            label: 'Remote-control lock supported',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'isBlePairing',
+            offset: 40,
+            length: 1,
+            bit: 6,
+            bits: 1,
+            label: 'Bluetooth connect',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'dryReady_state',
+            offset: 40,
+            length: 1,
+            bit: 7,
+            bits: 1,
+            label: 'Status info 084',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        { key: 'laundryTexture', offset: 41, length: 1, label: 'Fabric type' },
+        {
+            key: 'cloudCourse',
+            offset: 42,
+            length: 1,
+            label: 'Cloud course',
+            values: {
+                '0': 'None',
+                '97': 'Single shirt',
+                '101': 'Sweat stain removal',
+                '102': 'Shirt',
+                '104': 'Baby clothes',
+                '107': 'Single-item Wash',
+                '109': 'Rainy-season Wash',
+                '111': 'Color Care',
+                '117': 'Functional garments',
+                '122': 'Fabric protect',
+                '123': 'Kids clothes',
+                '127': 'Thorough Rinse',
+                '128': 'School uniform',
+                '129': 'Spin only',
+                '131': 'Cold Wash',
+                '154': 'Wool/Delicate',
+                '192': 'Quiet',
+                '197': 'Heavy soil',
+                '224': 'Towels',
+                '236': 'Wash only',
+                '237': 'Rinse only',
+            },
+        },
+        {
+            key: 'masterCard',
+            offset: 43,
+            length: 1,
+            label: 'Featured card',
+            values: {},
+        },
+        {
+            key: 'RecentlyDownloadedCourse',
+            offset: 44,
+            length: 1,
+            label: 'Recent downloaded course',
+        },
+        {
+            key: 'endMelody',
+            offset: 45,
+            length: 1,
+            label: 'Done sound',
+            values: {
+                '0': 'Default sound',
+                '1': 'Vivaldi Winter',
+            },
+        },
+        {
+            key: 'initLCD',
+            offset: 46,
+            length: 1,
+            label: 'Screen initial state',
+            values: {},
+        },
+        {
+            key: 'aquaReserve',
+            offset: 47,
+            length: 1,
+            bit: 0,
+            bits: 1,
+            label: 'Keep water',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'addScent',
+            offset: 47,
+            length: 1,
+            bit: 1,
+            bits: 1,
+            label: 'Add fragrance',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'applyLaundryCollection',
+            offset: 47,
+            length: 1,
+            bit: 2,
+            bits: 1,
+            label: 'Laundry pickup alert supported',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'laundryCare',
+            offset: 47,
+            length: 1,
+            bit: 3,
+            bits: 1,
+            label: 'Laundry care after finish',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'noti_OverSudsing',
+            offset: 47,
+            length: 1,
+            bit: 4,
+            bits: 1,
+            label: 'Excess foam alert',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'detergentNozzleCleaning',
+            offset: 47,
+            length: 1,
+            bit: 5,
+            bits: 1,
+            label: 'Detergent nozzle clean',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'softenerNozzleCleaning',
+            offset: 47,
+            length: 1,
+            bit: 6,
+            bits: 1,
+            label: 'Softener nozzle clean',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'currentTimeDisplay',
+            offset: 47,
+            length: 1,
+            bit: 7,
+            bits: 1,
+            label: 'Show current time',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'ezDispenseType',
+            offset: 48,
+            length: 1,
+            label: 'Auto-dispenser type',
+            values: {},
+        },
+        {
+            key: 'endReserveTime',
+            offset: 49,
+            length: 1,
+            bit: 0,
+            bits: 1,
+            label: 'End reservation',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'currentDisplay_12_24',
+            offset: 49,
+            length: 1,
+            bit: 1,
+            bits: 1,
+            label: 'Time format',
+        },
+        {
+            key: 'currentDateDisplay',
+            offset: 49,
+            length: 1,
+            bit: 2,
+            bits: 1,
+            label: 'Date display',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'powerCableOnOff',
+            offset: 49,
+            length: 1,
+            bit: 3,
+            bits: 1,
+            label: 'Power cord connected',
+        },
+        {
+            key: 'ezDetergentSelect',
+            offset: 49,
+            length: 1,
+            bit: 4,
+            bits: 1,
+            label: 'Detergent select',
+        },
+        {
+            key: 'ctrCmdAvail',
+            offset: 49,
+            length: 1,
+            bit: 5,
+            bits: 2,
+            label: 'Controllable state',
+            values: { '0': 'Off', '3': 'On' },
+        },
+        {
+            key: 'noti3MinEnd',
+            offset: 49,
+            length: 1,
+            bit: 7,
+            bits: 1,
+            label: 'End 3Alert minutes before',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'ucDampDryBeep',
+            offset: 50,
+            length: 1,
+            bit: 0,
+            bits: 1,
+            label: 'Ironing alert',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'ucSteamForDry',
+            offset: 50,
+            length: 1,
+            bit: 1,
+            bits: 1,
+            label: 'Dry Steam',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'ucQuickLoadSense',
+            offset: 50,
+            length: 1,
+            bit: 2,
+            bits: 1,
+            label: 'Quick load detect',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'enableAutoDoorOpen',
+            offset: 50,
+            length: 1,
+            bit: 3,
+            bits: 1,
+            label: 'Auto door open',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'drumlightAutoOn',
+            offset: 50,
+            length: 1,
+            bit: 5,
+            bits: 1,
+            label: 'Drum light when door opens',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'drumlightOpt',
+            offset: 50,
+            length: 1,
+            bit: 6,
+            bits: 1,
+            label: 'Drum light setting',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'ucWashMode',
+            offset: 51,
+            length: 1,
+            label: 'Operation mode',
+            values: {},
+        },
+        {
+            key: 'speedEco',
+            offset: 52,
+            length: 1,
+            label: 'Eco speed',
+            values: {},
+        },
+        {
+            key: 'timeDry',
+            offset: 53,
+            length: 1,
+            label: 'Dry time',
+            values: {
+                '20': '20min',
+                '30': '30min',
+                '40': '40min',
+                '50': '50min',
+                '60': '60min',
+                '80': '80min',
+                '100': '100min',
+                '120': '120min',
+                '150': '150min',
+                '180': '180min',
+                '210': '210min',
+                '240': '240min',
+            },
+        },
+        {
+            key: 'changeView',
+            offset: 54,
+            length: 1,
+            label: 'Screen switch',
+            values: {},
+        },
+        {
+            key: 'doorOpenImpossibleReason',
+            offset: 55,
+            length: 1,
+            label: 'Reason door cannot open',
+            values: {},
+        },
+        {
+            key: 'aiDetergentInput',
+            offset: 56,
+            length: 1,
+            label: 'AI detergent amount',
+            values: {},
+        },
+        {
+            key: 'laundryCareSettingTime',
+            offset: 57,
+            length: 2,
+            label: 'Laundry care time',
+        },
+        { key: 'drumlightBright', offset: 59, length: 2, label: 'Drum light brightness' },
+        { key: 'drumlightOnTime', offset: 61, length: 2, label: 'Drum light time' },
+        {
+            key: 'detergentIdxShowBeforeStart',
+            offset: 63,
+            length: 1,
+            bit: 0,
+            bits: 1,
+            label: 'Show detergent index before wash',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'spinAvailableDryOnlyCourse',
+            offset: 63,
+            length: 1,
+            bit: 1,
+            bits: 1,
+            label: 'Spin before dry supported',
+        },
+        {
+            key: 'ushLaundryCareSettingOnOff',
+            offset: 63,
+            length: 1,
+            bit: 2,
+            bits: 1,
+            label: 'Auto laundry care',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'applyExtendedIcontrol',
+            offset: 63,
+            length: 1,
+            bit: 3,
+            bits: 1,
+            label: 'Extended control supported',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'energySavingAvailable',
+            offset: 63,
+            length: 1,
+            bit: 4,
+            bits: 1,
+            label: 'Energy saving supported',
+        },
+        {
+            key: 'energySavingEnabled',
+            offset: 63,
+            length: 1,
+            bit: 5,
+            bits: 1,
+            label: 'Energy saving setting',
+        },
+        {
+            key: 'energySavingRunning',
+            offset: 63,
+            length: 1,
+            bit: 6,
+            bits: 1,
+            label: 'Energy saving active',
+        },
+        {
+            key: 'veryAvailableDryLevel',
+            offset: 63,
+            length: 1,
+            bit: 7,
+            bits: 1,
+            label: 'Intensive Dry supported',
+        },
+        {
+            key: 'drumlightPreview',
+            offset: 64,
+            length: 2,
+            label: 'Drum light preview',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'endMonitoringCase',
+            offset: 66,
+            length: 1,
+            label: 'Completion type',
+        },
+        {
+            key: 'endMelodyOnOff',
+            offset: 69,
+            length: 1,
+            bit: 0,
+            bits: 1,
+            label: 'Done sound setting',
+        },
+        {
+            key: 'notiOptBeforeRinseOnOff',
+            offset: 69,
+            length: 1,
+            bit: 1,
+            bits: 1,
+            label: 'Alert before rinse (setting)',
+        },
+        {
+            key: 'notiOptBeforeSpinOnOff',
+            offset: 69,
+            length: 1,
+            bit: 2,
+            bits: 1,
+            label: 'Alert before spin (setting)',
+        },
+        {
+            key: 'notiOptBeforeRinseUsing',
+            offset: 69,
+            length: 1,
+            bit: 3,
+            bits: 1,
+            label: 'Alert before rinse (active)',
+        },
+        {
+            key: 'notiOptBeforeSpinUsing',
+            offset: 69,
+            length: 1,
+            bit: 4,
+            bits: 1,
+            label: 'Alert before spin (active)',
+        },
+        {
+            key: 'laundryCollectionPushSetting',
+            offset: 69,
+            length: 1,
+            bit: 5,
+            bits: 1,
+            label: 'Laundry pickup alert setting',
+        },
+        {
+            key: 'childSafetyModeOnOff',
+            offset: 69,
+            length: 1,
+            bit: 6,
+            bits: 1,
+            label: 'Child safety mode',
+        },
+        {
+            key: 'smartReadyOnOff',
+            offset: 69,
+            length: 1,
+            bit: 7,
+            bits: 1,
+            label: 'Smart ready mode',
+        },
+        {
+            key: 'notiOptBeforeSpinRinseOnOff',
+            offset: 70,
+            length: 1,
+            bit: 0,
+            bits: 1,
+            label: 'Alert before rinse/spin',
+        },
+        {
+            key: 'optDryAutoApply',
+            offset: 70,
+            length: 1,
+            bit: 1,
+            bits: 1,
+            label: 'Auto dry applied',
+        },
+        {
+            key: 'optDryAutoAvailable',
+            offset: 70,
+            length: 1,
+            bit: 2,
+            bits: 1,
+            label: 'Auto dry supported',
+        },
+        {
+            key: 'optDryOnOff',
+            offset: 70,
+            length: 1,
+            bit: 3,
+            bits: 1,
+            label: 'Dry select',
+        },
+        {
+            key: 'optWashOnOff',
+            offset: 70,
+            length: 1,
+            bit: 4,
+            bits: 1,
+            label: 'Wash select',
+        },
+        {
+            key: 'optPreDrySpin',
+            offset: 70,
+            length: 1,
+            bit: 5,
+            bits: 1,
+            label: 'Spin before dry',
+        },
+        {
+            key: 'dryStartSignal',
+            offset: 70,
+            length: 1,
+            bit: 6,
+            bits: 2,
+            label: 'Dry start signal',
+        },
+        {
+            key: 'startReserveTime',
+            offset: 71,
+            length: 1,
+            bit: 0,
+            bits: 1,
+            label: 'Reserved start time',
+        },
+        {
+            key: 'dryOnOffAvailable',
+            offset: 71,
+            length: 1,
+            bit: 1,
+            bits: 1,
+            label: 'Dry select supported',
+        },
+    ],
+} as const
+export const DRYER_MODEL: WashTowerModel = {
+    tag: 52,
+    recordLength: 51,
+    liveRecordLength: 50,
+    deviceName: 'LG WashTower Dryer',
+    fields: [
+        { key: 'protocolVersion', offset: 0, length: 1, label: 'Protocol version' },
+        {
+            key: 'dryLevel',
+            offset: 1,
+            length: 1,
+            label: 'Dryness',
+            values: {
+                '0': 'Off',
+                '1': 'Delicate',
+                '2': 'Low',
+                '3': 'Standard',
+                '4': 'Standard+',
+                '5': 'Intensive',
+            },
+        },
+        {
+            key: 'ecoHybrid',
+            offset: 2,
+            length: 1,
+            label: 'Eco mode',
+            values: { '0': 'Off', '1': 'Energy', '2': 'Auto', '3': 'Speed' },
+        },
+        {
+            key: 'temp',
+            offset: 3,
+            length: 1,
+            label: 'Temperature',
+            values: {
+                '0': 'No temp set',
+            },
+        },
+        {
+            key: 'timeDry',
+            offset: 4,
+            length: 1,
+            label: 'Dry time',
+            values: {
+                '0': 'Off',
+                '1': '20min',
+                '2': '30min',
+                '3': '40min',
+                '4': '50min',
+                '5': '60min',
+                '6': '70min',
+                '7': '80min',
+            },
+        },
+        {
+            key: 'course',
+            offset: 5,
+            length: 1,
+            label: 'Course',
+            values: DRYER_COURSE_LABELS,
+        },
+        { key: 'reserveTimeMinute', offset: 7, length: 2, label: 'Reserved time' },
+        { key: 'remainTimeMinute', offset: 9, length: 2, label: 'Time remaining' },
+        { key: 'initialTimeMinute', offset: 11, length: 2, label: 'Total time' },
+        {
+            key: 'state',
+            offset: 13,
+            length: 1,
+            label: 'Current state',
+            values: {
+                '0': 'Power off',
+                '1': 'On',
+                '2': 'Drying',
+                '3': 'Pause',
+                '4': 'Dry complete',
+                '5': 'Error occurred',
+                '6': 'Smart diagnosing',
+                '7': 'Drying',
+                '8': 'Blowing',
+                '9': 'Wrinkle preventing',
+                '11': 'Detecting weight',
+                '12': 'Reserved',
+                '14': 'Detecting weight',
+                '15': 'Steaming',
+                '16': 'Recognizing garment',
+                '17': 'Condenser auto-clean running',
+                '18': 'Bedding shake running',
+                '19': 'Refreshing',
+                '20': 'Sterilizing',
+                '21': 'Condenser Care running',
+                '22': 'Dry complete',
+                '23': 'Preparing to dry',
+                '24': 'Laundry care running',
+                '25': 'Dehumidifying',
+                '26': 'Dry complete',
+                '27': 'Awaiting completion',
+            },
+        },
+        {
+            key: 'preState',
+            offset: 14,
+            length: 1,
+            label: 'Previous state',
+            values: {
+                '0': 'Power off',
+                '1': 'On',
+                '2': 'Drying',
+                '3': 'Pause',
+                '4': 'Dry complete',
+                '5': 'Error occurred',
+                '6': 'Smart diagnosing',
+                '7': 'Drying',
+                '8': 'Blowing',
+                '9': 'Wrinkle preventing',
+                '11': 'Detecting weight',
+                '12': 'Reserved',
+                '14': 'Detecting weight',
+                '15': 'Steaming',
+                '16': 'Recognizing garment',
+                '17': 'Condenser auto-clean running',
+                '18': 'Bedding shake running',
+                '19': 'Refreshing',
+                '20': 'Sterilizing',
+                '21': 'Condenser Care running',
+                '22': 'Dry complete',
+                '23': 'Preparing to dry',
+                '24': 'Laundry care running',
+                '25': 'Dehumidifying',
+                '26': 'Dry complete',
+                '27': 'Awaiting completion',
+            },
+        },
+        {
+            key: 'error',
+            offset: 15,
+            length: 1,
+            label: 'Error',
+            values: {
+                '0': 'No error',
+                '1': 'Temp sensor fault 1',
+                '2': 'Temp sensor fault 2',
+                '4': 'Temp sensor fault 4',
+                '5': 'Temp sensor fault 5',
+                '6': 'Temp sensor fault 6',
+                '10': 'Steam not operating',
+                '11': 'Steam water refill',
+                '12': 'Steam not operating',
+                '14': 'Not draining',
+                '15': 'Drain check notice',
+                '16': 'Door not closed',
+                '18': 'Filter installed',
+                '20': 'Drum temp fault',
+                '21': 'Compressor fault 1',
+                '22': 'Compressor fault 2',
+                '31': 'Drum motor fault',
+                '38': 'Door not closed',
+                '40': 'Fan motor fault',
+                '43': 'Door not locked',
+                '49': 'IR sensor fault',
+                '50': 'Internal fan fault',
+                '52': 'Door closed',
+                '53': 'Dehumidify kit not detected',
+                '54': 'Low-temp detected',
+            },
+        },
+        { key: 'courseSpendPower', offset: 17, length: 2, label: 'Course power usage' },
+        {
+            key: 'buzzer',
+            offset: 19,
+            length: 1,
+            label: 'Alert sound',
+            values: {
+                '0': 'Mute',
+                '1': 'Small',
+                '2': 'Normal',
+                '3': 'Large',
+                '4': 'Very large',
+                '15': 'On',
+            },
+        },
+        {
+            key: 'baseDownloadCourseData',
+            offset: 20,
+            length: 1,
+            label: 'Downloaded course basis',
+            values: {
+                '0': 'None',
+                '1': 'Steam Refresh',
+                '4': 'Bedding',
+                '7': 'Standard',
+                '9': 'Small Quick',
+                '15': 'Bedding shake',
+                '16': 'Steam Sterilize',
+                '18': 'Condenser Care',
+                '19': 'Tub Sterilize',
+                '21': 'Timed Dry',
+                '44': 'AI Dry',
+            },
+        },
+        {
+            key: 'loadItem',
+            offset: 21,
+            length: 1,
+            label: 'Load amount',
+            values: {
+                '0': 'Off',
+                '1': '1Level',
+                '2': '2Level',
+                '3': '3Level',
+                '4': '4Level',
+                '5': '5Level',
+                '6': '6Level',
+            },
+        },
+        {
+            key: 'ductClogging',
+            offset: 22,
+            length: 1,
+            label: 'Exhaust blocked',
+            values: {},
+        },
+        {
+            key: 'downloadCourse',
+            offset: 23,
+            length: 1,
+            label: 'Downloaded course',
+            values: {
+                '0': 'None',
+                '101': 'Baby clothes',
+                '102': 'Sportswear',
+                '105': 'Rainy-season Dry',
+                '110': 'Iron Dry',
+                '114': 'Wrinkle Ease Dry',
+                '119': 'Outdoor Refresh',
+                '126': 'Quiet',
+                '129': 'Functional garments',
+                '135': 'Towels',
+                '140': 'Shelf Dry',
+                '142': 'Shrink ease',
+                '143': 'Wool/Delicate',
+                '145': 'Single shirt',
+                '146': 'Shirt',
+                '147': 'Air blow',
+                '148': 'Intensive Dry',
+                '149': 'Padding Refresh',
+            },
+        },
+        {
+            key: 'handIron',
+            offset: 24,
+            length: 1,
+            bit: 7,
+            bits: 1,
+            label: 'Ironing alert',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'dampDryBeep',
+            offset: 24,
+            length: 1,
+            bit: 6,
+            bits: 1,
+            label: 'Ironing alert sound',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'drumLight',
+            offset: 24,
+            length: 1,
+            bit: 5,
+            bits: 1,
+            label: 'Drum light',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'favorite',
+            offset: 24,
+            length: 1,
+            bit: 4,
+            bits: 1,
+            label: 'Favorite',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'wrinkleCare',
+            offset: 24,
+            length: 1,
+            bit: 3,
+            bits: 1,
+            label: 'Wrinkle Prevent',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'dnnReady',
+            offset: 24,
+            length: 1,
+            bit: 2,
+            bits: 1,
+            label: 'AI ready',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'reduceStatic',
+            offset: 24,
+            length: 1,
+            bit: 1,
+            bits: 1,
+            label: 'Static reduce',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'antiBacterial',
+            offset: 24,
+            length: 1,
+            bit: 0,
+            bits: 1,
+            label: 'Antibacterial',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'energySaver',
+            offset: 25,
+            length: 1,
+            bit: 7,
+            bits: 1,
+            label: 'Energy saving',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'energySaverDefault',
+            offset: 25,
+            length: 1,
+            bit: 6,
+            bits: 1,
+            label: 'Default energy saving',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'turboSteam',
+            offset: 25,
+            length: 1,
+            bit: 5,
+            bits: 1,
+            label: 'Turbo Steam',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'smartGridEnable',
+            offset: 25,
+            length: 1,
+            bit: 4,
+            bits: 1,
+            label: 'Smart Grid',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'ductSensingOnOff',
+            offset: 25,
+            length: 1,
+            bit: 3,
+            bits: 1,
+            label: 'Exhaust detect',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'steam',
+            offset: 25,
+            length: 1,
+            bit: 2,
+            bits: 1,
+            label: 'Steam',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'AIDDLed',
+            offset: 25,
+            length: 1,
+            bit: 1,
+            bits: 1,
+            label: 'AI indicator',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'smartPairing',
+            offset: 26,
+            length: 1,
+            bit: 7,
+            bits: 1,
+            label: 'Smart pairing',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'remoteStart',
+            offset: 26,
+            length: 1,
+            bit: 6,
+            bits: 1,
+            label: 'Remote start',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'selfCleaning',
+            offset: 26,
+            length: 1,
+            bit: 5,
+            bits: 1,
+            label: 'Self Clean',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'childLock',
+            offset: 26,
+            length: 1,
+            bit: 4,
+            bits: 1,
+            label: 'Button lock',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'reservation',
+            offset: 26,
+            length: 1,
+            bit: 3,
+            bits: 1,
+            label: 'Status info 038',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'detectLoad',
+            offset: 26,
+            length: 1,
+            bit: 2,
+            bits: 1,
+            label: 'Load detect',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'standby',
+            offset: 26,
+            length: 1,
+            bit: 1,
+            bits: 1,
+            label: 'Standby',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'doorLock',
+            offset: 26,
+            length: 1,
+            bit: 0,
+            bits: 1,
+            label: 'Door lock',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'wifiConnected',
+            offset: 27,
+            length: 1,
+            bit: 7,
+            bits: 1,
+            label: 'Wireless connect',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'wifiSetting',
+            offset: 27,
+            length: 1,
+            bit: 6,
+            bits: 1,
+            label: 'Wireless setup',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'voiceState',
+            offset: 27,
+            length: 1,
+            bit: 5,
+            bits: 1,
+            label: 'Voice state',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'addItem',
+            offset: 27,
+            length: 1,
+            bit: 4,
+            bits: 1,
+            label: 'Add load',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'smartCare_onOff',
+            offset: 27,
+            length: 1,
+            bit: 2,
+            bits: 1,
+            label: 'Smart Care',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'remoteMaintain',
+            offset: 27,
+            length: 1,
+            bit: 1,
+            bits: 1,
+            label: 'Remote control lock',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'autoCourseArrange',
+            offset: 27,
+            length: 1,
+            bit: 0,
+            bits: 1,
+            label: 'Auto sort courses',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'currentDateDisplay',
+            offset: 28,
+            length: 1,
+            bit: 7,
+            bits: 1,
+            label: 'Date display',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'currentDisplay_12_24',
+            offset: 28,
+            length: 1,
+            bit: 6,
+            bits: 1,
+            label: 'Time format',
+        },
+        {
+            key: 'currentTimeDisplay',
+            offset: 28,
+            length: 1,
+            bit: 5,
+            bits: 1,
+            label: 'Show current time',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'laundryCare',
+            offset: 28,
+            length: 1,
+            bit: 4,
+            bits: 1,
+            label: 'Laundry care after finish',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'BLEOnOff',
+            offset: 28,
+            length: 1,
+            bit: 3,
+            bits: 1,
+            label: 'Bluetooth',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'applyLaundryCollection',
+            offset: 28,
+            length: 1,
+            bit: 2,
+            bits: 1,
+            label: 'Laundry pickup alert supported',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'applyRemoteMaintain',
+            offset: 28,
+            length: 1,
+            bit: 1,
+            bits: 1,
+            label: 'Remote-control lock supported',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'applyBuzzer',
+            offset: 28,
+            length: 1,
+            bit: 0,
+            bits: 1,
+            label: 'Alert sound supported',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'setDownloadedCourse',
+            offset: 29,
+            length: 1,
+            label: 'Recent downloaded course',
+            values: {
+                '0': 'None',
+                '101': 'Baby clothes',
+                '102': 'Sportswear',
+                '105': 'Rainy-season Dry',
+                '110': 'Iron Dry',
+                '114': 'Wrinkle Ease Dry',
+                '119': 'Outdoor Refresh',
+                '126': 'Quiet',
+                '129': 'Functional garments',
+                '135': 'Towels',
+                '140': 'Shelf Dry',
+                '142': 'Shrink ease',
+                '143': 'Wool/Delicate',
+                '145': 'Single shirt',
+                '146': 'Shirt',
+                '147': 'Air blow',
+                '148': 'Intensive Dry',
+                '149': 'Padding Refresh',
+            },
+        },
+        {
+            key: 'masterCard',
+            offset: 30,
+            length: 1,
+            label: 'Featured card',
+            values: {},
+        },
+        {
+            key: 'cloudCourse',
+            offset: 31,
+            length: 1,
+            label: 'Cloud course',
+            values: {
+                '0': 'None',
+                '101': 'Baby clothes',
+                '102': 'Sportswear',
+                '105': 'Rainy-season Dry',
+                '110': 'Iron Dry',
+                '114': 'Wrinkle Ease Dry',
+                '119': 'Outdoor Refresh',
+                '126': 'Quiet',
+                '129': 'Functional garments',
+                '135': 'Towels',
+                '140': 'Shelf Dry',
+                '142': 'Shrink ease',
+                '143': 'Wool/Delicate',
+                '145': 'Single shirt',
+                '146': 'Shirt',
+                '147': 'Air blow',
+                '148': 'Intensive Dry',
+                '149': 'Padding Refresh',
+            },
+        },
+        {
+            key: 'endMelody',
+            offset: 32,
+            length: 1,
+            label: 'Done sound',
+            values: {
+                '0': 'Default sound',
+                '1': 'Vivaldi Winter',
+            },
+        },
+        {
+            key: 'initLCD',
+            offset: 33,
+            length: 1,
+            label: 'Screen initial state',
+            values: {},
+        },
+        {
+            key: 'drylevelSubDamp',
+            offset: 34,
+            length: 1,
+            label: 'Delicate Dry sub-level',
+            values: { '0': 'Default', '2': 'High' },
+        },
+        {
+            key: 'drylevelSubLess',
+            offset: 35,
+            length: 1,
+            label: 'Low Dry sub-level',
+            values: { '0': 'Default', '1': 'Low', '2': 'High' },
+        },
+        {
+            key: 'drylevelSubIron',
+            offset: 36,
+            length: 1,
+            label: 'Standard Dry sub-level',
+            values: { '0': 'Default', '1': 'Low', '2': 'High' },
+        },
+        {
+            key: 'drylevelSubCup',
+            offset: 37,
+            length: 1,
+            label: 'Standard Plus sub-level',
+            values: { '0': 'Default', '1': 'Low', '2': 'High' },
+        },
+        {
+            key: 'drylevelSubVery',
+            offset: 38,
+            length: 1,
+            label: 'Intensive Dry sub-level',
+            values: { '0': 'Default', '1': 'Low' },
+        },
+        { key: 'moreLessTime', offset: 39, length: 2, label: 'Dry time adjust' },
+        {
+            key: 'applyExtendedIcontrol',
+            offset: 41,
+            length: 1,
+            bit: 6,
+            bits: 1,
+            label: 'Extended control supported',
+        },
+        {
+            key: 'ushLaundryCareSettingOnOff',
+            offset: 41,
+            length: 1,
+            bit: 5,
+            bits: 1,
+            label: 'Auto laundry care',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'drumlightOpt',
+            offset: 41,
+            length: 1,
+            bit: 4,
+            bits: 1,
+            label: 'Drum light setting',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'drumlightAutoOn',
+            offset: 41,
+            length: 1,
+            bit: 3,
+            bits: 1,
+            label: 'Drum light when door opens',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'noti3MinEnd',
+            offset: 41,
+            length: 1,
+            bit: 2,
+            bits: 1,
+            label: 'End 3Alert minutes before',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'endReserveTime',
+            offset: 41,
+            length: 1,
+            bit: 0,
+            bits: 1,
+            label: 'End reservation',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        { key: 'drumlightBright', offset: 42, length: 2, label: 'Drum light brightness' },
+        { key: 'drumlightOnTime', offset: 44, length: 2, label: 'Drum light time' },
+        {
+            key: 'laundryCareSettingTime',
+            offset: 46,
+            length: 2,
+            label: 'Laundry care time',
+        },
+        {
+            key: 'drumlightPreview',
+            offset: 48,
+            length: 2,
+            label: 'Drum light preview',
+            values: { '0': 'Off', '1': 'On' },
+        },
+        {
+            key: 'energySavingAvailable',
+            offset: 50,
+            length: 1,
+            bit: 0,
+            bits: 1,
+            label: 'Energy saving supported',
+        },
+        {
+            key: 'energySavingEnabled',
+            offset: 50,
+            length: 1,
+            bit: 1,
+            bits: 1,
+            label: 'Energy saving setting',
+        },
+        {
+            key: 'energySavingRunning',
+            offset: 50,
+            length: 1,
+            bit: 2,
+            bits: 1,
+            label: 'Energy saving active',
+        },
+        {
+            key: 'endMelodyOnOff',
+            offset: 50,
+            length: 1,
+            bit: 3,
+            bits: 1,
+            label: 'Done sound setting',
+        },
+        {
+            key: 'laundryCollectionPushSetting',
+            offset: 50,
+            length: 1,
+            bit: 4,
+            bits: 1,
+            label: 'Laundry pickup alert setting',
+        },
+        {
+            key: 'childSafetyModeOnOff',
+            offset: 50,
+            length: 1,
+            bit: 5,
+            bits: 1,
+            label: 'Child safety mode',
+        },
+        {
+            key: 'smartReadyOnOff',
+            offset: 50,
+            length: 1,
+            bit: 6,
+            bits: 1,
+            label: 'Smart ready mode',
+        },
+    ],
+} as const
+
+const componentKey = (key: string) =>
+    key
+        .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+        .replace(/[^a-zA-Z0-9_]/g, '_')
+        .toLowerCase()
+
+const DECLARED_NON_PACKET_FIELDS: Record<'221' | '222', string[]> = {
+    '221': [
+        'extendedControlTest',
+        'cycleTimeShowBeforeStart',
+        'laundryCollection',
+        'endMelody_201_1_1',
+        'endMelody_201_1_2',
+        'endMelody_201_1_3',
+        'endMelody_201_1_4',
+        'initialBit',
+        'reserveTimeHour',
+        'remainTimeHour',
+        'initialTimeHour',
+        'alarmSignal',
+    ],
+    '222': [
+        'laundryCollection',
+        'endMelody_202_1_1',
+        'endMelody_202_1_2',
+        'endMelody_202_1_3',
+        'endMelody_202_1_4',
+        'initialBit',
+        'reserveTimeHour',
+        'remainTimeHour',
+        'initialTimeHour',
+        'moreLessTimeDefault',
+        'moreLessTimeEcoHybridOff',
+        'moreLessTimeEcoHybridTurbo',
+        'moreLessTimeEcoHybridEcoOrNormal',
+        'timeSetting',
+        'ecoHybridDefault',
+        'ecoHybridCottonVery',
+        'ecoHybridCottonCup',
+        'ecoHybridCottonIron',
+        'ecoHybridEasyCareCup',
+        'ecoHybridEasyCareIron',
+        'selfClean',
+        'productType',
+        'reqDevType',
+        'cmd',
+        'type',
+        'alarmSignal',
+        'voiceVolume',
+        'voiceAssistantCmd',
+    ],
+}
+
+type ImplementationIdentity = {
+    model: string
+    deviceType: '221' | '222'
+    role: 'washer' | 'dryer'
+    packetMappedFields: string[]
+    packetMappings: {
+        key: string
+        byteOffset: number
+        byteLength: number
+        bitOffset?: number
+        bitLength?: number
+    }[]
+    excludedFields: string[]
+    entities: { key: string; label: string }[]
+    enumOptions: {
+        entityKey: string
+        value: number
+        label: string
+    }[]
+    writes: {
+        entityKey: string
+        protocolFrameId: string
+        controlWifiPath: string
+        validator: string
+    }[]
+    codec: {
+        protocol: { name: string; jsonVersion: string; sha256: string }
+        convert: { name: string; jsonVersion: string; sha256: string }
+    }
+}
+
+function implementationIdentity(
+    model: WashTowerModel,
+    identity: Omit<
+        ImplementationIdentity,
+        'packetMappedFields' | 'packetMappings' | 'excludedFields' | 'entities' | 'enumOptions' | 'writes'
+    >,
+): ImplementationIdentity {
+    const mapped = model.fields.filter((field) => field.offset + field.length <= model.recordLength)
+    return {
+        ...identity,
+        packetMappedFields: mapped.map((field) => field.key),
+        packetMappings: mapped.map((field) => ({
+            key: field.key,
+            byteOffset: field.offset,
+            byteLength: field.length,
+            ...(field.bit === undefined ? {} : { bitOffset: field.bit }),
+            ...(field.bits === undefined ? {} : { bitLength: field.bits }),
+        })),
+        excludedFields: model.fields
+            .filter((field) => field.offset + field.length > model.recordLength)
+            .map((field) => field.key)
+            .concat(DECLARED_NON_PACKET_FIELDS[identity.deviceType]),
+        entities: mapped
+            .map((field) => ({
+                key: componentKey(field.key),
+                label: field.label,
+            }))
+            .concat({ key: 'power_transition', label: 'Power transition state' }),
+        enumOptions: mapped.flatMap((field) =>
+            Object.entries(field.values ?? {}).map(([value, label]) => ({
+                entityKey: componentKey(field.key),
+                value: Number(value),
+                label,
+            })),
+        ),
+        writes: [
+            {
+                entityKey: 'wake',
+                protocolFrameId: '0x2A',
+                controlWifiPath: 'WMWakeup',
+                validator: 'state=POWEROFF',
+            },
+            {
+                entityKey: 'power',
+                protocolFrameId: '0xE5',
+                controlWifiPath: 'vtCtrl/power',
+                validator: 'value=ON && state=POWEROFF && no pending power-on within 120s',
+            },
+            {
+                entityKey: 'power_transition',
+                protocolFrameId: '0xED',
+                controlWifiPath: 'statusQuery',
+                validator: 'once as best-effort after a checksum-valid successful power-on E6 while pending',
+            },
+            {
+                entityKey: 'power',
+                protocolFrameId: '0x24',
+                controlWifiPath: 'WMControl',
+                validator: 'value=OFF && state!=POWEROFF && remote-control-allowed',
+            },
+            {
+                entityKey: 'off',
+                protocolFrameId: '0x24',
+                controlWifiPath: 'WMControl',
+                validator: 'state!=POWEROFF && remote-control-allowed',
+            },
+            {
+                entityKey: 'stop',
+                protocolFrameId: '0x24',
+                controlWifiPath: 'WMControl',
+                validator: 'state!=POWEROFF && remote-control-allowed',
+            },
+            {
+                entityKey: 'remote_maintain',
+                protocolFrameId: '0x24',
+                controlWifiPath: 'remoteMaintain',
+                validator: '(value=ON && state in [POWEROFF,INITIAL]) || (value=OFF && state=INITIAL)',
+            },
+            {
+                entityKey: 'start_course',
+                protocolFrameId: '0x26',
+                controlWifiPath: 'WMStart',
+                validator:
+                    identity.role === 'washer'
+                        ? 'state=INITIAL && remoteStart=true && reserveTimeMinute=0 && ControlValidator(soilWash,temp,spin,rinse,turboWash)'
+                        : 'state=INITIAL && remoteStart=true && ControlValidator(dryLevel,ecoHybrid,steam)',
+            },
+        ],
+    }
+}
+
+/**
+ * Release validator contract. It is derived from the exact field tables above, so
+ * the evidence ledger and the driver cannot silently drift apart.
+ */
+export const WASHTOWER_IMPLEMENTATION_MANIFEST: ImplementationIdentity[] = [
+    implementationIdentity(WASHER_MODEL, {
+        model: 'FAKPK21021',
+        deviceType: '221',
+        role: 'washer',
+        codec: {
+            protocol: {
+                name: 'WASHER_PROTOCOL_EX',
+                jsonVersion: '8.3',
+                sha256: 'dfb39d74f18664e92dc8839b623a347154a4f9ae3cb354859c1fbef6a45c13b9',
+            },
+            convert: {
+                name: 'WASHER_CONVERT_EX',
+                jsonVersion: '2.3',
+                sha256: '4311a33597a88fac5c32bc26f12ef65edeab0c4fc1173ca3665b4ad0685beab4',
+            },
+        },
+    }),
+    implementationIdentity(DRYER_MODEL, {
+        model: 'BDH_D39301_KR',
+        deviceType: '222',
+        role: 'dryer',
+        codec: {
+            protocol: {
+                name: 'DRYER_PROTOCOL_EX',
+                jsonVersion: '4.1',
+                sha256: '0428bcd76f1df325d3142fc2541083b3cc094d025c78e11e17f44f5f970dc348',
+            },
+            convert: {
+                name: 'DRYER_CONVERT_EX',
+                jsonVersion: '7.8',
+                sha256: 'ff3dfc7f7974f18ed6c4a73bea1b03998b8f6c0213d1f08394482bc34844125b',
+            },
+        },
+    }),
+]
+
+const HEADER_LENGTH = 15,
+    TRAILER_LENGTH = 3
+const STATE_FIDS = new Set([0x00eb, 0x00ec])
+export function buildWashtowerExtendedFrame(tag: number, fid: number, payload: Buffer, sequence = 0): Buffer {
+    if (tag !== 0x33 && tag !== 0x34) throw new RangeError('Not a WashTower device tag')
+    if (payload.length > 0xffff) throw new RangeError('WashTower payload too large')
+    const f = Buffer.alloc(HEADER_LENGTH + payload.length + TRAILER_LENGTH)
+    f.set([0xaa, 0xff, tag, 0x0a, 0], 0)
+    f.writeUInt16LE(f.length, 5)
+    f.writeUInt16LE(sequence & 0xffff, 7)
+    f.set([0, 1], 9)
+    f.writeUInt16BE(fid & 0xffff, 11)
+    f.writeUInt16BE(payload.length, 13)
+    payload.copy(f, HEADER_LENGTH)
+    f.writeUInt16BE(crc16(f.subarray(0, f.length - TRAILER_LENGTH)), f.length - TRAILER_LENGTH)
+    f[f.length - 1] = 0xbb
+    return f
+}
+
+/** Product control AABB envelope used by the existing washer/dryer drivers. */
+export function buildWashtowerControlFrame(frameId: number, payload: Buffer): Buffer {
+    if (frameId < 0 || frameId > 0xff) throw new RangeError('AABB Control frame ID Out of range')
+    const inner = Buffer.concat([Buffer.from([0xf0, frameId]), payload])
+    if (inner.length + 4 > 0xff) throw new RangeError('AABB Control payload too large')
+    const frame = Buffer.concat([Buffer.from([0xaa, inner.length + 4]), inner, Buffer.from([0, 0xbb])])
+    frame[frame.length - 2] = (frame.subarray(0, -2).reduce((sum, byte) => sum + byte, 0) & 0xff) ^ 0x55
+    return frame
+}
+
+export function isWashtowerPowerOnSuccess(frame: Buffer, model: WashTowerModel): boolean {
+    const acceptedLengths = new Set([13, 13 + model.liveRecordLength, 13 + model.recordLength])
+    if (
+        !acceptedLengths.has(frame.length) ||
+        frame[0] !== 0xaa ||
+        frame[1] !== frame.length ||
+        frame[2] !== model.tag ||
+        frame[3] !== 0xe6 ||
+        frame[frame.length - 1] !== 0xbb
+    )
+        return false
+    const checksum = (frame.subarray(0, -2).reduce((sum, byte) => sum + byte, 0) & 0xff) ^ 0x55
+    return (
+        frame[frame.length - 2] === checksum &&
+        frame.subarray(4, 10).equals(Buffer.from([0x00, 0x02, 0x01, 0xff, 0x01, 0x02])) &&
+        frame[10] === 0
+    )
+}
+
+export const WASH_TOWER_SIMPLE_CONTROLS = {
+    wake: { frameId: 0x2a, payload: Buffer.from([0x01, 0x00]) },
+    powerOn: { frameId: 0xe5, payload: Buffer.from([0x00, 0x02, 0x01, 0xff, 0x01, 0x02, 0x01]) },
+    /** Captured status query; after a verified power-on success it is only a best-effort refresh. */
+    statusQuery: { frameId: 0xed, payload: Buffer.from('112101000000180411120000', 'hex') },
+    off: { frameId: 0x24, payload: Buffer.from([0x01, 0x01, 0x00]) },
+    stop: { frameId: 0x24, payload: Buffer.from([0x04, 0x01, 0x00]) },
+    remoteMaintainOn: { frameId: 0x24, payload: Buffer.from([0x10, 0x01, 0x01]) },
+    remoteMaintainOff: { frameId: 0x24, payload: Buffer.from([0x10, 0x01, 0x00]) },
+} as const
+
+const WASHER_SETTING_KEYS = ['course', 'soilWash', 'spin', 'temp', 'rinse', 'freshCare', 'steam', 'turboWash'] as const
+const DRYER_SETTING_KEYS = ['course', 'ecoHybrid', 'wrinkleCare', 'steam', 'dryLevel'] as const
+const POWER_ON_PENDING_MS = 120_000
+
+type CourseOptionRule = Record<string, readonly [defaultValue: number, selectable?: readonly number[]]>
+
+// Derived from each model JSON Course.function default/selectable declarations.
+const WASHER_COURSE_RULES: Record<number, CourseOptionRule> = {
+    27: {
+        soilWash: [3, [0, 3]],
+        rinse: [3, [0, 1, 2, 3, 4, 5]],
+        spin: [4, [0, 1, 2, 4]],
+        temp: [8, [8, 2, 3]],
+        turboWash: [0, [0, 1]],
+        steam: [0],
+        freshCare: [0, [0, 1]],
+    },
+    46: {
+        soilWash: [3, [0, 3, 5, 6]],
+        rinse: [2, [0, 1, 2, 3, 4, 5]],
+        spin: [6, [0, 1, 2, 4, 6, 8]],
+        temp: [3, [8, 2, 3, 5]],
+        turboWash: [1, [0, 1]],
+        steam: [0],
+        freshCare: [0, [0, 1]],
+    },
+    74: {
+        soilWash: [3, [0, 3]],
+        rinse: [1, [0, 1, 2, 3, 4, 5]],
+        spin: [4, [0, 1, 2, 4, 6, 8]],
+        temp: [3, [8, 2, 3]],
+        turboWash: [1, [0, 1]],
+        steam: [0],
+        freshCare: [0, [0, 1]],
+    },
+    76: {
+        soilWash: [3, [0, 3]],
+        rinse: [3, [0, 1, 2, 3, 4, 5]],
+        spin: [4, [0, 1, 2, 4, 6, 8]],
+        temp: [6],
+        turboWash: [0, [0, 1]],
+        steam: [0],
+        freshCare: [0, [0, 1]],
+    },
+    85: {
+        soilWash: [3],
+        rinse: [2],
+        spin: [4],
+        temp: [5],
+        turboWash: [0],
+        steam: [0],
+        freshCare: [0, [0, 1]],
+    },
+    114: {
+        soilWash: [3],
+        rinse: [2, [1, 2, 3, 4, 5]],
+        spin: [6, [1, 2, 4, 6, 8]],
+        temp: [3, [8, 2, 3, 5]],
+        turboWash: [1, [0, 1]],
+        steam: [0],
+        freshCare: [0, [0, 1]],
+    },
+}
+
+const DRYER_COURSE_RULES: Record<number, CourseOptionRule> = {
+    1: { ecoHybrid: [3], dryLevel: [0], steam: [1], wrinkleCare: [0, [0, 1]], moreLessTime: [0] },
+    4: { ecoHybrid: [2], dryLevel: [0], steam: [0], wrinkleCare: [0, [0, 1]], moreLessTime: [0] },
+    7: {
+        ecoHybrid: [2, [1, 2, 3]],
+        dryLevel: [3, [1, 2, 3, 4, 5]],
+        steam: [0, [0, 1]],
+        wrinkleCare: [0, [0, 1]],
+        moreLessTime: [0],
+    },
+    9: { ecoHybrid: [3], dryLevel: [0], steam: [0], wrinkleCare: [0, [0, 1]], moreLessTime: [0] },
+    15: { ecoHybrid: [2], dryLevel: [0], steam: [0, [0, 1]], wrinkleCare: [0, [0, 1]], moreLessTime: [0] },
+    16: { ecoHybrid: [3], dryLevel: [0], steam: [1, [0, 1]], wrinkleCare: [0, [0, 1]], moreLessTime: [0] },
+    18: { ecoHybrid: [3], dryLevel: [0], steam: [0], wrinkleCare: [0], moreLessTime: [0] },
+    19: { ecoHybrid: [3], dryLevel: [0], steam: [1], wrinkleCare: [0], moreLessTime: [0] },
+    21: { ecoHybrid: [2], dryLevel: [0], steam: [0], wrinkleCare: [0, [0, 1]], moreLessTime: [30] },
+    44: { ecoHybrid: [2], dryLevel: [0], steam: [0], wrinkleCare: [0, [0, 1]], moreLessTime: [0] },
+}
+
+function courseRules(model: WashTowerModel) {
+    return model.tag === 0x33 ? WASHER_COURSE_RULES : DRYER_COURSE_RULES
+}
+
+function defaultCourse(model: WashTowerModel) {
+    // Official Config.defaultCourse is NORMAL for both installed models.
+    return model.tag === 0x33 ? 46 : 7
+}
+
+function fieldByKey(model: WashTowerModel, key: string) {
+    return model.fields.find((field) => field.key === key)
+}
+
+function optionByte(
+    model: WashTowerModel,
+    draft: ReadonlyMap<string, number>,
+    offset: number,
+    writableKeys: readonly string[],
+) {
+    let value = 0
+    for (const field of model.fields) {
+        if (field.offset !== offset || field.bit === undefined || !writableKeys.includes(field.key)) continue
+        const raw = draft.get(field.key) ?? 0
+        const width = field.bits || 1
+        value |= (raw & ((1 << width) - 1)) << field.bit
+    }
+    return value
+}
+
+/** Official WMDownload body (frameId 0x25), without guessed reverse mappings. */
+export function buildWashtowerDownloadPayload(model: WashTowerModel, draft: ReadonlyMap<string, number>): Buffer {
+    const payload = Buffer.alloc(23)
+    payload[0] = 3 // courseDownloadType=COURSEDATA
+    payload[1] = 21 // ControlWifi courseDownloadDataLength
+    if (model.tag === 0x33) {
+        const course = draft.get('course') ?? 0
+        payload[2] = course
+        payload[3] = draft.get('soilWash') ?? 0
+        payload[4] = draft.get('spin') ?? 0
+        payload[5] = draft.get('temp') ?? 0
+        payload[6] = draft.get('rinse') ?? 0
+        payload[7] = 0
+        payload[8] = 0
+        payload[9] = optionByte(model, draft, 34, WASHER_SETTING_KEYS)
+        payload[10] = optionByte(model, draft, 35, WASHER_SETTING_KEYS)
+        payload[11] = optionByte(model, draft, 36, WASHER_SETTING_KEYS)
+        payload[12] = course
+        payload[13] = draft.get('downloadCourse') ?? 0
+        payload[17] = draft.get('dryLevel') ?? 0
+    } else {
+        payload[3] = draft.get('ecoHybrid') ?? 0
+        payload[4] = draft.get('moreLessTime') ?? 0
+        payload.writeUInt16BE(draft.get('reserveTimeMinute') ?? 0, 7)
+        payload[9] = optionByte(model, draft, 24, DRYER_SETTING_KEYS)
+        payload[10] = optionByte(model, draft, 25, DRYER_SETTING_KEYS)
+        payload[11] = optionByte(model, draft, 26, DRYER_SETTING_KEYS)
+        payload[12] = draft.get('course') ?? 0
+        payload[13] = draft.get('downloadCourse') ?? 0
+        payload[17] = draft.get('dryLevel') ?? 0
+    }
+    return payload
+}
+
+/** Official model-specific WMStart body (frameId 0x26). */
+export function buildWashtowerStartPayload(model: WashTowerModel, draft: ReadonlyMap<string, number>): Buffer {
+    if (model.tag === 0x33) {
+        const payload = Buffer.alloc(21)
+        const course = draft.get('course') ?? 0
+        payload[0] = course
+        payload[1] = draft.get('soilWash') ?? 0
+        payload[2] = draft.get('spin') ?? 0
+        payload[3] = draft.get('temp') ?? 0
+        payload[4] = draft.get('rinse') ?? 0
+        // The state record has one two-byte reserveTimeMinute, while WMStart
+        // requires separate hour/minute bytes. No official reverse mapping is
+        // declared, so both reserved-time bytes remain zero.
+        payload[7] = optionByte(model, draft, 34, WASHER_SETTING_KEYS)
+        payload[8] = optionByte(model, draft, 35, WASHER_SETTING_KEYS)
+        payload[9] = optionByte(model, draft, 36, WASHER_SETTING_KEYS)
+        payload[10] = course
+        payload[11] = draft.get('downloadCourse') ?? 0
+        payload[15] = draft.get('dryLevel') ?? 0
+        return payload
+    }
+
+    const payload = Buffer.alloc(14)
+    payload[0] = draft.get('course') ?? 0
+    payload[1] = draft.get('dryLevel') ?? 0
+    payload[2] = draft.get('ecoHybrid') ?? 0
+    payload[3] = draft.get('moreLessTime') ?? 0
+    payload.writeUInt16BE(draft.get('reserveTimeMinute') ?? 0, 6)
+    payload[9] = optionByte(model, draft, 24, DRYER_SETTING_KEYS)
+    payload[10] = optionByte(model, draft, 25, DRYER_SETTING_KEYS)
+    payload[11] = optionByte(model, draft, 26, DRYER_SETTING_KEYS)
+    payload[12] = draft.get('downloadCourse') ?? 0
+    return payload
+}
+
+export function selectCurrentWashtowerRecord(frame: Buffer, model: WashTowerModel): Buffer | undefined {
+    if (frame.length < HEADER_LENGTH + model.liveRecordLength + TRAILER_LENGTH) return
+    if (frame[0] !== 0xaa || frame[1] !== 0xff || frame[2] !== model.tag || frame[frame.length - 1] !== 0xbb) return
+    if (frame.readUInt16LE(5) !== frame.length || !STATE_FIDS.has(frame.readUInt16BE(11))) return
+    const n = frame.readUInt16BE(13)
+    if (n !== frame.length - HEADER_LENGTH - TRAILER_LENGTH) return
+    if (crc16(frame.subarray(0, frame.length - TRAILER_LENGTH)) !== frame.readUInt16BE(frame.length - TRAILER_LENGTH))
+        return
+    const fid = frame.readUInt16BE(11)
+    if (fid === 0x00eb) {
+        // Current firmware omits unsupported tail fields (67/50 bytes). Newer/full
+        // firmware may send the complete official record (72/51 bytes).
+        if (n !== model.liveRecordLength && n !== model.recordLength) return
+        return frame.subarray(HEADER_LENGTH, HEADER_LENGTH + n)
+    }
+    // 0xEC is the official previous+current layout. As with 0xEB, current
+    // firmware can omit unsupported tail fields from both records.
+    const recordLength =
+        n === model.liveRecordLength * 2
+            ? model.liveRecordLength
+            : n === model.recordLength * 2
+              ? model.recordLength
+              : undefined
+    if (recordLength === undefined) return
+    return frame.subarray(HEADER_LENGTH + recordLength, HEADER_LENGTH + recordLength * 2)
+}
+export default class WashTowerDevice extends HADevice {
+    private readonly cache: Record<string, string | number> = {}
+    private readonly observed = new Map<string, number>()
+    private readonly draft = new Map<string, number>()
+    private readonly dirtyDraftKeys = new Set<string>()
+    private currentState: number | undefined
+    private remoteStartAllowed = false
+    private remoteAllowed = false
+    private pendingPowerOnAt: number | undefined
+    private powerOnRefreshSent = false
+    private powerOnTimeout: ReturnType<typeof setTimeout> | undefined
+    private draftReconciled = false
+    constructor(
+        HA: Connection,
+        readonly thinq: Thinq2Device,
+        readonly meta: Metadata,
+        readonly model: WashTowerModel,
+    ) {
+        super(HA, thinq.id)
+        thinq.on('data', (f) => this.processData(f))
+        const components: DeviceDiscovery['components'] = {}
+        for (const field of model.fields) {
+            if (field.offset + field.length > model.recordLength) continue
+            const key = componentKey(field.key)
+            components[key] = {
+                platform: 'sensor',
+                unique_id: '$deviceid-' + key,
+                state_topic: '$this/' + key,
+                name: field.label,
+                entity_category: 'diagnostic',
+            } as DeviceDiscovery['components'][string]
+        }
+        const settingKeys = model.tag === 0x33 ? WASHER_SETTING_KEYS : DRYER_SETTING_KEYS
+        for (const settingKey of settingKeys) {
+            const field = fieldByKey(model, settingKey)
+            if (!field?.values) continue
+            const key = componentKey(settingKey)
+            const values =
+                settingKey === 'course'
+                    ? Object.entries(field.values)
+                          .filter(([raw]) => Number(raw) in courseRules(model))
+                          .map(([, label]) => label)
+                    : Object.values(field.values)
+            components['setting_' + key] = {
+                platform: 'select',
+                unique_id: '$deviceid-setting-' + key,
+                state_topic: '$this/setting_' + key,
+                command_topic: '$this/setting_' + key + '/set',
+                name: field.label + ' Setting',
+                options: [...new Set(values)],
+            } as DeviceDiscovery['components'][string]
+        }
+        components.wake = {
+            platform: 'button',
+            unique_id: '$deviceid-wake',
+            command_topic: '$this/wake/set',
+            name: 'Exit power-save',
+        } as DeviceDiscovery['components'][string]
+        components.power = {
+            platform: 'switch',
+            unique_id: '$deviceid-power',
+            state_topic: '$this/power',
+            command_topic: '$this/power/set',
+            name: 'Power',
+            payload_on: 'ON',
+            payload_off: 'OFF',
+        } as DeviceDiscovery['components'][string]
+        components.power_transition = {
+            platform: 'sensor',
+            unique_id: '$deviceid-power-transition',
+            state_topic: '$this/power_transition',
+            name: 'Power transition state',
+            entity_category: 'diagnostic',
+        } as DeviceDiscovery['components'][string]
+        components.off = {
+            platform: 'button',
+            unique_id: '$deviceid-off',
+            command_topic: '$this/off/set',
+            name: 'Power off',
+        } as DeviceDiscovery['components'][string]
+        components.stop = {
+            platform: 'button',
+            unique_id: '$deviceid-stop',
+            command_topic: '$this/stop/set',
+            name: 'Pause',
+        } as DeviceDiscovery['components'][string]
+        components.start_course = {
+            platform: 'button',
+            unique_id: '$deviceid-start-course',
+            command_topic: '$this/start_course/set',
+            name: 'Start course',
+        } as DeviceDiscovery['components'][string]
+        components.remote_maintain = {
+            platform: 'switch',
+            unique_id: '$deviceid-remote_maintain',
+            state_topic: '$this/remote_maintain',
+            command_topic: '$this/remote_maintain/set',
+            name: 'Remote control lock',
+            payload_on: 'On',
+            payload_off: 'Off',
+        } as DeviceDiscovery['components'][string]
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: model.deviceName }),
+                components,
+            }),
+        )
+    }
+    processData(frame: Buffer) {
+        this.handlePowerOnResponse(frame)
+        const record = selectCurrentWashtowerRecord(frame, this.model)
+        if (!record) return
+        this.remoteStartAllowed = false
+        this.remoteAllowed = false
+        for (const field of this.model.fields) {
+            if (field.offset + field.length > record.length) continue
+            let raw = record.readUIntBE(field.offset, field.length)
+            if (field.bit !== undefined) {
+                const width = field.bits || 1
+                raw = (raw >> field.bit) & ((1 << width) - 1)
+            }
+            const value = field.values ? (field.values[String(raw)] ?? 'Unknown(' + raw + ')') : raw
+            this.publish(componentKey(field.key), value)
+            this.observed.set(field.key, raw)
+            if (!this.dirtyDraftKeys.has(field.key)) this.draft.set(field.key, raw)
+            if (field.key === 'state') this.currentState = raw
+            if (field.key === 'remoteStart' && raw === 1) this.remoteStartAllowed = true
+            if ((field.key === 'remoteStart' || field.key === 'remoteMaintain') && raw === 1) this.remoteAllowed = true
+        }
+        this.reconcileDraftFromFirstTelemetry()
+        this.publish('power', this.currentState === 0 ? 'OFF' : 'ON')
+        if (this.currentState !== 0 && this.pendingPowerOnAt !== undefined) {
+            this.clearPendingPowerOn()
+            this.publish('power_transition', 'Complete')
+        } else {
+            this.expirePendingPowerOn()
+        }
+        if (this.cache.power_transition === undefined) this.publish('power_transition', 'Standby')
+    }
+    private publish(key: string, value: string | number) {
+        if (this.cache[key] === value) return
+        this.cache[key] = value
+        this.HA.publishProperty(this.id, key, value)
+    }
+    private send(frameId: number, payload: Buffer) {
+        this.thinq.send_packet(buildWashtowerControlFrame(frameId, payload))
+    }
+
+    private clearPendingPowerOn() {
+        if (this.powerOnTimeout !== undefined) clearTimeout(this.powerOnTimeout)
+        this.powerOnTimeout = undefined
+        this.pendingPowerOnAt = undefined
+        this.powerOnRefreshSent = false
+    }
+
+    private expirePendingPowerOn(now = Date.now()) {
+        if (this.pendingPowerOnAt === undefined || now - this.pendingPowerOnAt < POWER_ON_PENDING_MS) return false
+        this.clearPendingPowerOn()
+        this.publish('power_transition', 'Timeout')
+        return true
+    }
+
+    private schedulePowerOnTimeout() {
+        if (this.pendingPowerOnAt === undefined) return
+        if (this.powerOnTimeout !== undefined) clearTimeout(this.powerOnTimeout)
+        const remaining = Math.max(0, this.pendingPowerOnAt + POWER_ON_PENDING_MS - Date.now())
+        this.powerOnTimeout = setTimeout(() => {
+            this.powerOnTimeout = undefined
+            if (!this.expirePendingPowerOn()) this.schedulePowerOnTimeout()
+        }, remaining)
+    }
+
+    private handlePowerOnResponse(frame: Buffer) {
+        if (this.pendingPowerOnAt === undefined || this.expirePendingPowerOn()) return
+        if (this.powerOnRefreshSent || !isWashtowerPowerOnSuccess(frame, this.model)) return
+        this.powerOnRefreshSent = true
+        this.publish('power_transition', 'Command accepted')
+        const command = WASH_TOWER_SIMPLE_CONTROLS.statusQuery
+        try {
+            this.send(command.frameId, command.payload)
+        } catch (error) {
+            console.warn(this.model.deviceName + ': State refresh request failed', error)
+        }
+    }
+
+    override drop() {
+        this.clearPendingPowerOn()
+        super.drop()
+    }
+
+    private validDraft() {
+        const rule = courseRules(this.model)[this.draft.get('course') ?? -1]
+        if (!rule) return false
+        for (const [key, [defaultValue, selectable]] of Object.entries(rule)) {
+            const value = this.draft.get(key)
+            if (value === undefined || (selectable ? !selectable.includes(value) : value !== defaultValue)) return false
+        }
+        if (this.model.tag === 0x33) {
+            const noWash = (this.draft.get('soilWash') ?? 0) === 0
+            const noSpin = (this.draft.get('spin') ?? 0) === 0
+            const noRinse = (this.draft.get('rinse') ?? 0) === 0
+            if (
+                (noWash && (this.draft.get('temp') ?? 0) !== 0) ||
+                ((noWash || noSpin || noRinse) && (this.draft.get('turboWash') ?? 0) !== 0)
+            )
+                return false
+        } else if (
+            (this.draft.get('steam') ?? 0) === 1 &&
+            ((this.draft.get('dryLevel') ?? 0) === 1 ||
+                ((this.draft.get('dryLevel') ?? 0) === 3 && (this.draft.get('ecoHybrid') ?? 0) === 2))
+        ) {
+            return false
+        }
+        return true
+    }
+
+    private publishDraftSettings() {
+        const settingKeys = this.model.tag === 0x33 ? WASHER_SETTING_KEYS : DRYER_SETTING_KEYS
+        for (const key of settingKeys) {
+            const raw = this.draft.get(key)
+            const label = raw === undefined ? undefined : fieldByKey(this.model, key)?.values?.[String(raw)]
+            if (label !== undefined) this.publish('setting_' + componentKey(key), label)
+        }
+    }
+
+    private reconcileDraftFromFirstTelemetry() {
+        if (this.draftReconciled) return
+        this.draftReconciled = true
+        if (this.dirtyDraftKeys.has('course')) return
+        const observedCourse = this.observed.get('course')
+        const course =
+            observedCourse !== undefined && courseRules(this.model)[observedCourse]
+                ? observedCourse
+                : defaultCourse(this.model)
+        this.applyCourseDefaults(course, true)
+    }
+
+    private applyCourseDefaults(course: number, preserveDirty = false) {
+        const rule = courseRules(this.model)[course]
+        if (!rule) return false
+        const updates: Array<readonly [string, number]> = [
+            ['course', course],
+            ['baseDownloadCourseData', 0],
+            ['downloadCourse', 0],
+            ...Object.entries(rule).map(([key, [defaultValue]]) => [key, defaultValue] as const),
+        ]
+        for (const [key, value] of updates) {
+            if (preserveDirty && this.dirtyDraftKeys.has(key)) continue
+            this.draft.set(key, value)
+            this.dirtyDraftKeys.add(key)
+        }
+        this.publishDraftSettings()
+        return true
+    }
+
+    setProperty(prop: string, mqttValue: string) {
+        if (prop.startsWith('setting_')) {
+            const key = prop.slice('setting_'.length)
+            const settingKeys = this.model.tag === 0x33 ? WASHER_SETTING_KEYS : DRYER_SETTING_KEYS
+            const field = this.model.fields.find(
+                (candidate) => componentKey(candidate.key) === key && settingKeys.includes(candidate.key as never),
+            )
+            const raw = Object.entries(field?.values ?? {}).find(([, label]) => label === mqttValue)?.[0]
+            if (raw === undefined)
+                return console.warn(this.model.deviceName + ': Setting value not allowed ' + mqttValue)
+            const rawValue = Number(raw)
+            if (field!.key === 'course') {
+                if (!this.applyCourseDefaults(rawValue))
+                    return console.warn(this.model.deviceName + ': not an official control course')
+            } else {
+                this.draft.set(field!.key, rawValue)
+                this.dirtyDraftKeys.add(field!.key)
+            }
+            this.publish(prop, mqttValue)
+            return
+        }
+        if (prop === 'send_course')
+            return console.warn(
+                this.model.deviceName + ': Built-in course can only be applied via the start-course command',
+            )
+        if (this.currentState === undefined) return console.warn(this.model.deviceName + ': Status unknown')
+        if (prop === 'wake') {
+            if (this.currentState !== 0) return console.warn(this.model.deviceName + ': Wake only from off state')
+            const command = WASH_TOWER_SIMPLE_CONTROLS.wake
+            return this.send(command.frameId, command.payload)
+        }
+        if (prop === 'power') {
+            if (mqttValue === 'ON') {
+                if (this.currentState !== 0) return console.warn(this.model.deviceName + ': Already on')
+                this.expirePendingPowerOn()
+                if (this.pendingPowerOnAt !== undefined)
+                    return console.warn(this.model.deviceName + ': Awaiting power-on response')
+                const command = WASH_TOWER_SIMPLE_CONTROLS.powerOn
+                this.send(command.frameId, command.payload)
+                this.pendingPowerOnAt = Date.now()
+                this.powerOnRefreshSent = false
+                this.schedulePowerOnTimeout()
+                this.publish('power_transition', 'Turning on')
+                return
+            }
+            if (mqttValue === 'OFF') {
+                if (this.currentState === undefined || this.currentState === 0) {
+                    return console.warn(this.model.deviceName + ': Power in current state OFF Unavailable')
+                }
+                if (!this.remoteAllowed) return console.warn(this.model.deviceName + ': Remote control not allowed')
+                const command = WASH_TOWER_SIMPLE_CONTROLS.off
+                return this.send(command.frameId, command.payload)
+            }
+            return console.warn(this.model.deviceName + ': Unsupported power-control value ' + mqttValue)
+        }
+        if (prop === 'remote_maintain') {
+            const enable = mqttValue === 'ON' || mqttValue === 'On'
+            const disable = mqttValue === 'OFF' || mqttValue === 'Off'
+            if (enable && this.currentState !== 0 && this.currentState !== 1)
+                return console.warn(this.model.deviceName + ': Remote control lock only while off or standby')
+            if (disable && this.currentState !== 1)
+                return console.warn(this.model.deviceName + ': Remote control unlock only in standby')
+            const command = enable
+                ? WASH_TOWER_SIMPLE_CONTROLS.remoteMaintainOn
+                : disable
+                  ? WASH_TOWER_SIMPLE_CONTROLS.remoteMaintainOff
+                  : undefined
+            if (!command)
+                return console.warn(this.model.deviceName + ': Unsupported remote-control-lock value ' + mqttValue)
+            return this.send(command.frameId, command.payload)
+        }
+        if (prop === 'start_course') {
+            if (this.currentState !== 1) return console.warn(this.model.deviceName + ': Course start only in standby')
+            if (!this.remoteStartAllowed) return console.warn(this.model.deviceName + ': Remote control not allowed')
+            if (this.model.tag === 0x33 && (this.observed.get('reserveTimeMinute') ?? 0) !== 0)
+                return console.warn(this.model.deviceName + ': Cannot start immediately while a reservation is set')
+            if (!this.validDraft())
+                return console.warn(this.model.deviceName + ': Option combination fails official control validation')
+            return this.send(0x26, buildWashtowerStartPayload(this.model, this.draft))
+        }
+        if (prop === 'off' || prop === 'stop') {
+            if (this.currentState === undefined || this.currentState === 0)
+                return console.warn(this.model.deviceName + ': Command rejected in current state')
+            if (!this.remoteAllowed) return console.warn(this.model.deviceName + ': Remote control not allowed')
+            const command = WASH_TOWER_SIMPLE_CONTROLS[prop]
+            return this.send(command.frameId, command.payload)
+        }
+        console.warn(this.model.deviceName + ': Unsupported write request ' + prop)
+    }
+}

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -22,6 +22,7 @@ import F3L2CYU__ from './devices/F3L2CYU__'
 import RV13B6BSD_D_US_WIFI from './devices/RV13B6BSD_D_US_WIFI'
 import ST_B_E4H01Y_APL from './devices/ST_B_E4H01Y_APL'
 import HWWA9K_F2 from './devices/HWWA9K_F2'
+import Dev_1WPU4CIGCR__2 from './devices/1WPU4CIGCR__2'
 import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
 import { type Connection } from './homeassistant'
@@ -59,6 +60,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['RV13U6AM8W_D_US_WIFI']: RV13U6AM8W_D_US_WIFI, // LG DLE7300WE dryer
     ['F3L2CYU__']: F3L2CYU__, // LG front-load washer
     ['RV13B6BSD_D_US_WIFI']: RV13B6BSD_D_US_WIFI, // LG electric dryer
+    ['1WPU4CIGCR__2']: Dev_1WPU4CIGCR__2, // LG water purifier ATOM-U (deviceType 103)
     HWWA9K_F2, // LG CordZero A9 stick vacuum (deviceType 504)
     ST_B_E4H01Y_APL, // LG Styler S5BBP (deviceType 203)
     HUM_056905_WW, // LG PuriCare humidifier (deviceType 404)

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -20,6 +20,7 @@ import T1789EFH_F from './devices/T1789EFH_F'
 import RV13U6AM8W_D_US_WIFI from './devices/RV13U6AM8W_D_US_WIFI'
 import F3L2CYU__ from './devices/F3L2CYU__'
 import RV13B6BSD_D_US_WIFI from './devices/RV13B6BSD_D_US_WIFI'
+import ST_B_E4H01Y_APL from './devices/ST_B_E4H01Y_APL'
 import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
 import { type Connection } from './homeassistant'
@@ -57,6 +58,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['RV13U6AM8W_D_US_WIFI']: RV13U6AM8W_D_US_WIFI, // LG DLE7300WE dryer
     ['F3L2CYU__']: F3L2CYU__, // LG front-load washer
     ['RV13B6BSD_D_US_WIFI']: RV13B6BSD_D_US_WIFI, // LG electric dryer
+    ST_B_E4H01Y_APL, // LG Styler S5BBP (deviceType 203)
     HUM_056905_WW, // LG PuriCare humidifier (deviceType 404)
     DHUM_231006_WW,
     DHUM_056905_WW,

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -21,6 +21,7 @@ import RV13U6AM8W_D_US_WIFI from './devices/RV13U6AM8W_D_US_WIFI'
 import F3L2CYU__ from './devices/F3L2CYU__'
 import RV13B6BSD_D_US_WIFI from './devices/RV13B6BSD_D_US_WIFI'
 import ST_B_E4H01Y_APL from './devices/ST_B_E4H01Y_APL'
+import HWWA9K_F2 from './devices/HWWA9K_F2'
 import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
 import { type Connection } from './homeassistant'
@@ -58,6 +59,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['RV13U6AM8W_D_US_WIFI']: RV13U6AM8W_D_US_WIFI, // LG DLE7300WE dryer
     ['F3L2CYU__']: F3L2CYU__, // LG front-load washer
     ['RV13B6BSD_D_US_WIFI']: RV13B6BSD_D_US_WIFI, // LG electric dryer
+    HWWA9K_F2, // LG CordZero A9 stick vacuum (deviceType 504)
     ST_B_E4H01Y_APL, // LG Styler S5BBP (deviceType 203)
     HUM_056905_WW, // LG PuriCare humidifier (deviceType 404)
     DHUM_231006_WW,

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -23,6 +23,8 @@ import RV13B6BSD_D_US_WIFI from './devices/RV13B6BSD_D_US_WIFI'
 import ST_B_E4H01Y_APL from './devices/ST_B_E4H01Y_APL'
 import HWWA9K_F2 from './devices/HWWA9K_F2'
 import Dev_1WPU4CIGCR__2 from './devices/1WPU4CIGCR__2'
+import FAKPK21021 from './devices/FAKPK21021'
+import BDH_D39301_KR from './devices/BDH_D39301_KR'
 import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
 import { type Connection } from './homeassistant'
@@ -60,6 +62,8 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['RV13U6AM8W_D_US_WIFI']: RV13U6AM8W_D_US_WIFI, // LG DLE7300WE dryer
     ['F3L2CYU__']: F3L2CYU__, // LG front-load washer
     ['RV13B6BSD_D_US_WIFI']: RV13B6BSD_D_US_WIFI, // LG electric dryer
+    FAKPK21021, // LG WashTower washer (deviceType 221)
+    BDH_D39301_KR, // LG WashTower dryer (deviceType 222)
     ['1WPU4CIGCR__2']: Dev_1WPU4CIGCR__2, // LG water purifier ATOM-U (deviceType 103)
     HWWA9K_F2, // LG CordZero A9 stick vacuum (deviceType 504)
     ST_B_E4H01Y_APL, // LG Styler S5BBP (deviceType 203)

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -2,6 +2,7 @@ import POT_056905_WW from './devices/POT_056905_WW'
 import WTDN3 from './devices/WTDN3'
 import RAC_056905_WW from './devices/RAC_056905_WW'
 import WIN_056905_WW from './devices/WIN_056905_WW'
+import DHUM_056905_WW from './devices/DHUM_056905_WW'
 import Dev_2REF11EIDA__4 from './devices/2REF11EIDA__4'
 import Dev_2REF11EBIVPC4 from './devices/2REF11EBIVPC4'
 import Dev_2RES1VE61NFA2 from './devices/2RES1VE61NFA2'
@@ -54,6 +55,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['RV13U6AM8W_D_US_WIFI']: RV13U6AM8W_D_US_WIFI, // LG DLE7300WE dryer
     ['F3L2CYU__']: F3L2CYU__, // LG front-load washer
     ['RV13B6BSD_D_US_WIFI']: RV13B6BSD_D_US_WIFI, // LG electric dryer
+    DHUM_056905_WW,
 }
 
 class Bridge {

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -3,6 +3,7 @@ import WTDN3 from './devices/WTDN3'
 import RAC_056905_WW from './devices/RAC_056905_WW'
 import WIN_056905_WW from './devices/WIN_056905_WW'
 import DHUM_056905_WW from './devices/DHUM_056905_WW'
+import DHUM_231006_WW from './devices/DHUM_231006_WW'
 import Dev_2REF11EIDA__4 from './devices/2REF11EIDA__4'
 import Dev_2REF11EBIVPC4 from './devices/2REF11EBIVPC4'
 import Dev_2RES1VE61NFA2 from './devices/2RES1VE61NFA2'
@@ -55,6 +56,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['RV13U6AM8W_D_US_WIFI']: RV13U6AM8W_D_US_WIFI, // LG DLE7300WE dryer
     ['F3L2CYU__']: F3L2CYU__, // LG front-load washer
     ['RV13B6BSD_D_US_WIFI']: RV13B6BSD_D_US_WIFI, // LG electric dryer
+    DHUM_231006_WW,
     DHUM_056905_WW,
 }
 

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -4,6 +4,7 @@ import RAC_056905_WW from './devices/RAC_056905_WW'
 import WIN_056905_WW from './devices/WIN_056905_WW'
 import DHUM_056905_WW from './devices/DHUM_056905_WW'
 import DHUM_231006_WW from './devices/DHUM_231006_WW'
+import HUM_056905_WW from './devices/HUM_056905_WW'
 import Dev_2REF11EIDA__4 from './devices/2REF11EIDA__4'
 import Dev_2REF11EBIVPC4 from './devices/2REF11EBIVPC4'
 import Dev_2RES1VE61NFA2 from './devices/2RES1VE61NFA2'
@@ -56,6 +57,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['RV13U6AM8W_D_US_WIFI']: RV13U6AM8W_D_US_WIFI, // LG DLE7300WE dryer
     ['F3L2CYU__']: F3L2CYU__, // LG front-load washer
     ['RV13B6BSD_D_US_WIFI']: RV13B6BSD_D_US_WIFI, // LG electric dryer
+    HUM_056905_WW, // LG PuriCare humidifier (deviceType 404)
     DHUM_231006_WW,
     DHUM_056905_WW,
 }

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -23,6 +23,7 @@ import { type Connection } from './homeassistant'
 import HADevice from './devices/base'
 import { type Metadata } from './thinq'
 import { AnyDevice } from './devmgr'
+import type { PurifierHistoryStore } from '@/bridge/purifier-history-store'
 
 type T1Factory = new (HA: Connection, thinq: T1Device, metadata: Metadata) => HADevice
 type T2Factory = new (HA: Connection, thinq: T2Device, metadata: Metadata) => HADevice
@@ -57,7 +58,10 @@ const t2deviceTypes: Record<string, T2Factory> = {
 
 class Bridge {
     haDevices = new Map<string, HADevice>()
-    constructor(readonly HA: Connection) {
+    constructor(
+        readonly HA: Connection,
+        readonly purifierHistoryStore?: PurifierHistoryStore,
+    ) {
         HA.on('discovery', () => {
             this.haDevices.forEach((ha) => ha.publishConfig())
         })
@@ -86,6 +90,13 @@ class Bridge {
             console.warn(`${thinqdev.platform} device type ${meta.modelId} unknown`)
             return
         }
+
+        if (
+            this.purifierHistoryStore &&
+            'setPurifierHistoryStore' in hadevice &&
+            typeof hadevice.setPurifierHistoryStore === 'function'
+        )
+            hadevice.setPurifierHistoryStore(this.purifierHistoryStore)
 
         this.haDevices.set(thinqdev.id, hadevice)
         thinqdev.on('close', () => this.dropDevice(hadevice))

--- a/cloud/homeassistant.ts
+++ b/cloud/homeassistant.ts
@@ -193,3 +193,12 @@ export type ClimateComponent = ComponentInfo & {
     swing_modes?: string[]
     swing_horizontal_modes?: string[]
 }
+
+export type HumidifierComponent = ComponentInfo & {
+    platform: 'humidifier'
+    device_class?: 'dehumidifier' | 'humidifier'
+    modes?: string[]
+    min_humidity?: number
+    max_humidity?: number
+    current_humidity_topic?: string
+}

--- a/rethink-cloud.ts
+++ b/rethink-cloud.ts
@@ -21,6 +21,7 @@ import log, { setFilter as setLogFilter } from './util/logging'
 import { DeviceManager } from './cloud/devmgr'
 import { Bridge } from './bridge'
 import { JSONStorage } from './bridge/state'
+import { PurifierHistoryJSONStore } from './bridge/purifier-history-store'
 
 const configPath = resolve(process.argv[2] ?? './config.json')
 const configDir = dirname(configPath)
@@ -129,8 +130,10 @@ function t2setup(manager: DeviceManager) {
     acceptor.on('newDevice', manager.accept.bind(manager))
 }
 
-// HA connector
-const ha = new HA_bridge(new HA_connection(config.homeassistant))
+// HA connector. The history store persists water-purifier usage across restarts; without a
+// bridge storage path the driver simply runs stateless.
+const purifierHistoryStore = config.bridge ? new PurifierHistoryJSONStore(config.bridge.storage_path) : undefined
+const ha = new HA_bridge(new HA_connection(config.homeassistant), purifierHistoryStore)
 const manager = new DeviceManager()
 manager.on('newDevice', (dev) => ha.newDevice(dev))
 

--- a/tests/bridge/purifier-history-store.test.ts
+++ b/tests/bridge/purifier-history-store.test.ts
@@ -1,0 +1,328 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { PurifierHistoryJSONStore, type PurifierHistoryState } from '@/bridge/purifier-history-store'
+
+function temporaryDirectory(t: import('node:test').TestContext) {
+    const path = mkdtempSync(join(tmpdir(), 'rethink-purifier-history-'))
+    t.after(() => rmSync(path, { recursive: true }))
+    return path
+}
+
+function validState(): PurifierHistoryState {
+    return {
+        version: 1,
+        collectedSince: 1000.5,
+        usageComplete: true,
+        usage: {
+            day: '2026-01-31',
+            normal: 20,
+            hot: 30,
+            cold: 40,
+            soda: 5,
+            mineral: 3,
+            sterilization: 2,
+        },
+        sterilization: {
+            active: { kind: 'pipe', startedAt: 2000.25 },
+            lastPipeAt: 900,
+            lastOutletAt: 800,
+            countsByMonth: { '2026-01': 2, '2026-12': 3 },
+        },
+        schedule: {
+            parts: [7, 28, 18, 30],
+            instant: Date.UTC(2026, 6, 28, 18, 30),
+        },
+    }
+}
+
+test('purifier history store distinguishes missing files from corrupt or invalid state', (t) => {
+    const directory = temporaryDirectory(t)
+    const warnings: string[] = []
+    const store = new PurifierHistoryJSONStore(directory, undefined, (message) => warnings.push(message))
+    const path = join(directory, 'purifier_device-1.json')
+
+    assert.equal(store.load('device-1'), undefined)
+
+    const invalidStates: unknown[] = [
+        '{not json',
+        null,
+        { ...validState(), version: 2 },
+        { ...validState(), collectedSince: Number.POSITIVE_INFINITY },
+        { ...validState(), usage: { ...validState().usage, hot: -1 } },
+        { ...validState(), usage: { ...validState().usage, cold: 1.5 } },
+        { ...validState(), usageComplete: 'yes' },
+        { ...validState(), usage: { ...validState().usage, day: 20260101 } },
+        { ...validState(), usage: { ...validState().usage, day: '2026-1-01' } },
+        { ...validState(), usage: { ...validState().usage, day: '2026-00-01' } },
+        { ...validState(), usage: { ...validState().usage, day: '2026-04-31' } },
+        { ...validState(), usage: { ...validState().usage, day: '2026-02-29' } },
+        {
+            ...validState(),
+            sterilization: {
+                ...validState().sterilization,
+                countsByMonth: { '2026-01-01': 1 },
+            },
+        },
+        {
+            ...validState(),
+            sterilization: {
+                ...validState().sterilization,
+                countsByMonth: { '2026-13': 1 },
+            },
+        },
+        {
+            ...validState(),
+            sterilization: {
+                ...validState().sterilization,
+                active: { kind: 'filter', startedAt: 1 },
+            },
+        },
+        {
+            ...validState(),
+            schedule: {
+                parts: [7, 28, 18],
+                instant: Date.UTC(2026, 6, 28, 18, 30),
+            },
+        },
+        {
+            ...validState(),
+            schedule: {
+                parts: [7, 28, 18, 30],
+                instant: Date.UTC(2026, 6, 28, 19, 30),
+            },
+        },
+        {
+            ...validState(),
+            schedule: {
+                parts: [7, 28, 18, 30],
+                instant: Date.UTC(2026, 6, 28, 18, 30, 1),
+            },
+        },
+        {
+            ...validState(),
+            schedule: {
+                parts: [7, 28, 18, 30],
+                instant: Date.UTC(2026, 6, 28, 18, 30, 0, 1),
+            },
+        },
+    ]
+
+    for (const invalid of invalidStates) {
+        const serialized = typeof invalid === 'string' ? invalid : JSON.stringify(invalid)
+        writeFileSync(path, serialized)
+        assert.throws(() => store.load('device-1'))
+        assert.equal(readFileSync(path, 'utf8'), serialized)
+    }
+    assert.equal(warnings.length, invalidStates.length)
+
+    writeFileSync(path, JSON.stringify(validState()))
+    assert.deepEqual(store.load('device-1'), validState())
+
+    const legacyStateWithoutCompleteness = { ...validState() } as Record<string, unknown>
+    delete legacyStateWithoutCompleteness.usageComplete
+    writeFileSync(path, JSON.stringify(legacyStateWithoutCompleteness))
+    assert.equal(store.load('device-1')?.usageComplete, false)
+
+    const { schedule: _schedule, ...legacyState } = validState()
+    writeFileSync(path, JSON.stringify(legacyState))
+    assert.deepEqual(store.load('device-1'), legacyState)
+
+    const leapDay = {
+        ...validState(),
+        usage: { ...validState().usage, day: '2024-02-29' },
+    }
+    writeFileSync(path, JSON.stringify(leapDay))
+    assert.deepEqual(store.load('device-1'), leapDay)
+})
+
+test('purifier history store warns and surfaces non-missing read errors', () => {
+    const warnings: string[] = []
+    const denied = Object.assign(new Error('permission denied'), { code: 'EACCES' })
+    const store = new PurifierHistoryJSONStore(
+        '/state',
+        {
+            read: () => {
+                throw denied
+            },
+            write: () => {},
+            rename: () => {},
+        },
+        (message) => warnings.push(message),
+    )
+
+    assert.throws(() => store.load('device-1'), denied)
+    assert.match(warnings[0]!, /Unable to read purifier history/)
+})
+
+test('purifier history store validates device IDs before filesystem access', () => {
+    const paths: string[] = []
+    const store = new PurifierHistoryJSONStore('/state', {
+        read: (path) => {
+            paths.push(path)
+            return JSON.stringify(validState())
+        },
+        write: (path) => {
+            paths.push(path)
+        },
+        rename: (_from, to) => {
+            paths.push(to)
+        },
+    })
+
+    assert.equal(store.load('../escape'), undefined)
+    store.save('../escape', validState())
+    assert.deepEqual(paths, [])
+
+    assert.deepEqual(store.load('device.with:scope'), validState())
+    store.save('device.with:scope', validState())
+    assert.equal(paths[0], '/state/purifier_device.with:scope.json')
+    assert.equal(paths[2], '/state/purifier_device.with:scope.json')
+})
+
+test('purifier history store serializes canonical state to a 0600 temp file then renames it', () => {
+    const calls: Array<{
+        operation: string
+        path: string
+        data?: string
+        mode?: number
+        to?: string
+    }> = []
+    const store = new PurifierHistoryJSONStore('/state', {
+        read: () => JSON.stringify(validState()),
+        write: (path, data, options) => calls.push({ operation: 'write', path, data, mode: options.mode }),
+        rename: (from, to) => calls.push({ operation: 'rename', path: from, to }),
+    })
+    const state = {
+        ...validState(),
+        unrelated: 'ignored',
+        usage: { ...validState().usage, unrelated: 99 },
+        sterilization: {
+            ...validState().sterilization,
+            unrelated: true,
+        },
+    } as PurifierHistoryState
+
+    store.save('device-1', state)
+
+    assert.equal(calls.length, 2)
+    assert.match(calls[0]!.path, /^\/state\/purifier_device-1\.json\.\d+\.0\.tmp$/)
+    assert.equal(dirname(calls[0]!.path), '/state')
+    assert.equal(calls[0]!.mode, 0o600)
+    assert.equal(calls[0]!.data, JSON.stringify(validState()))
+    assert.deepEqual(calls[1], {
+        operation: 'rename',
+        path: calls[0]!.path,
+        to: '/state/purifier_device-1.json',
+    })
+})
+
+test('purifier history store creates the real temporary file with private permissions', (t) => {
+    const directory = temporaryDirectory(t)
+    let tempPath = ''
+    const store = new PurifierHistoryJSONStore(directory, {
+        read: () => JSON.stringify(validState()),
+        write: (path, data, options) => {
+            tempPath = path
+            writeFileSync(path, data, options)
+        },
+        rename: () => {},
+    })
+
+    store.save('device-1', validState())
+
+    assert.equal(statSync(tempPath).mode & 0o777, 0o600)
+})
+
+test('purifier history store surfaces write and rename failures', () => {
+    const writeFailure = new Error('write failed')
+    const renameFailure = new Error('rename failed')
+
+    const writeStore = new PurifierHistoryJSONStore('/state', {
+        read: () => JSON.stringify(validState()),
+        write: () => {
+            throw writeFailure
+        },
+        rename: () => assert.fail('rename must not follow a failed write'),
+    })
+    assert.throws(() => writeStore.save('device-1', validState()), writeFailure)
+
+    const renameStore = new PurifierHistoryJSONStore('/state', {
+        read: () => JSON.stringify(validState()),
+        write: () => {},
+        rename: () => {
+            throw renameFailure
+        },
+    })
+    assert.throws(() => renameStore.save('device-1', validState()), renameFailure)
+})
+
+test('purifier history store refuses invalid state before writing', () => {
+    let writes = 0
+    const store = new PurifierHistoryJSONStore('/state', {
+        read: () => JSON.stringify(validState()),
+        write: () => {
+            writes++
+        },
+        rename: () => {},
+    })
+    const invalid = {
+        ...validState(),
+        sterilization: { countsByMonth: { '2026-00': 1 } },
+    } as PurifierHistoryState
+
+    assert.throws(() => store.save('device-1', invalid), /invalid schema/)
+    assert.equal(writes, 0)
+})
+
+test('cloud baseline replacement preserves sterilization and schedule state atomically', (t) => {
+    const directory = temporaryDirectory(t)
+    const path = join(directory, 'purifier_device-1.json')
+    const previous = validState()
+    writeFileSync(path, JSON.stringify(previous))
+    const store = new PurifierHistoryJSONStore(directory)
+
+    store.prepareDailyUsage('device-1', '2026-07-29', 3000)
+    const partial = store.load('device-1')!
+    assert.equal(partial.usageComplete, false)
+    assert.equal(partial.usage.cold, 0)
+    assert.deepEqual(partial.sterilization, previous.sterilization)
+    assert.deepEqual(partial.schedule, previous.schedule)
+
+    store.applyDailyUsageBaseline(
+        'device-1',
+        '2026-07-29',
+        { normal: 0, hot: 0, cold: 119, soda: 0, mineral: 0, sterilization: 0 },
+        3000,
+    )
+    const complete = store.load('device-1')!
+    assert.equal(complete.usageComplete, true)
+    assert.deepEqual(complete.usage, {
+        day: '2026-07-29',
+        normal: 0,
+        hot: 0,
+        cold: 119,
+        soda: 0,
+        mineral: 0,
+        sterilization: 0,
+    })
+    assert.deepEqual(complete.sterilization, previous.sterilization)
+    assert.deepEqual(complete.schedule, previous.schedule)
+    assert.equal(statSync(path).mode & 0o777, 0o600)
+})
+
+test('daily usage preparation isolates corrupt purifier files and redacts their identifiers', (t) => {
+    const directory = temporaryDirectory(t)
+    const warnings: unknown[][] = []
+    const store = new PurifierHistoryJSONStore(directory, undefined, (...args) => warnings.push(args))
+    store.save('healthy-device', validState())
+    writeFileSync(join(directory, 'purifier_secret-device.json'), '{not json')
+
+    assert.doesNotThrow(() => store.markAllDailyUsageIncomplete('2026-07-29', 3000))
+    assert.equal(store.load('healthy-device')?.usageComplete, false)
+    const logged = JSON.stringify(warnings)
+    assert.equal(logged.includes('secret-device'), false)
+    assert.match(logged, /SyntaxError/)
+})

--- a/tests/cloud/devices/1WPU4CIGCR__2.test.ts
+++ b/tests/cloud/devices/1WPU4CIGCR__2.test.ts
@@ -1,0 +1,1163 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import DUT from '@/cloud/devices/1WPU4CIGCR__2'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+import {
+    PurifierHistoryJSONStore,
+    type PurifierHistoryState,
+    type PurifierHistoryStore,
+    type PurifierUsage,
+} from '@/bridge/purifier-history-store'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = '1WPU4CIGCR__2'
+const META: Metadata = { modelId: MODEL_ID, modelName: MODEL_ID, swVersion: '' }
+const FIXED_NOW = Date.parse('2026-07-28T12:00:00Z')
+
+/*
+ * Fixtures.
+ *
+ * STATE is a REAL frame captured from the appliance on 2026-07-28. The rest are that frame with
+ * ONE byte changed and the checksum recomputed; each was injected into LG's cloud that day, so
+ * the expected value is LG's own decode of that exact frame, not a restatement of this driver.
+ */
+
+// Real. LG read this frame as monStatus NORMAL, waterSelection NORMAL_WATER, waterAmountMode 1,
+// tempUnit CELSIUS, amountUnit M_LITTER, hotWaterTemp 255 (IGNORE), defaultWaterSet RECENT_WATER,
+// defaultWaterAmountMode 1, buttonSoundOnOff ON, raw sterilizeInit 7/28 18:30 UTC, autoCareOnOff ON,
+// monDataRefresh 3, highSterilizeState OFF, filterFlushingState OFF, appVersion 1.
+const STATE = buf(
+    'aa3a12ec020102010101ffff00ff010101ffff071c121eff01ff03000001020002010101ffff00ff010101ffff071c121eff01ff03000001ccbb',
+)
+
+// Real, and the form this appliance actually sends most of the time: 32 bytes, ONE record,
+// captured live 2026-07-28 09:46. Its 26 payload bytes are the 58-byte frame's trailing record,
+// differing only in the record index byte. A decoder keyed on "58 bytes" ignores this and leaves
+// every entity unknown — which is exactly what the first live rebuild showed.
+const STATE_SHORT = buf('aa2012eb020002010101ffff00ff010101ffff071c121eff01ff0300000177bb')
+
+const COLD_WATER = buf(
+    'aa3a12ec020102010101ffff00ff010101ffff071c121eff01ff03000001020003010101ffff00ff010101ffff071c121eff01ff03000001cfbb',
+) // byte[32]=3 -> waterSelection COLD_WATER
+const FAHRENHEIT = buf(
+    'aa3a12ec020102010101ffff00ff010101ffff071c121eff01ff03000001020002010001ffff00ff010101ffff071c121eff01ff03000001cdbb',
+) // byte[34]=0 -> tempUnit FAHRENHEIT
+const DEFAULT_COLD = buf(
+    'aa3a12ec020102010101ffff00ff010101ffff071c121eff01ff03000001020002010101ffff00ff030101ffff071c121eff01ff03000001cebb',
+) // byte[40]=3 -> defaultWaterSet COLD_WATER
+const STERILIZING = buf(
+    'aa3a12ec020102010101ffff00ff010101ffff071c121eff01ff03000001020002010101ffff00ff010101ffff071c121eff01ff03030001c9bb',
+) // byte[53]=3 -> highSterilizeState MANUAL_DWP_A_TYPE
+const HOT_85 = buf(
+    'aa3a12ec020102010101ffff00ff010101ffff071c121eff01ff0300000102000201010103ff00ff010101ffff071c121eff01ff03000001c8bb',
+) // byte[36]=3 -> hotWaterTemp code 3 (= 85 °C per hotWaterTemp_C)
+
+function withAABBChecksum(frame: Buffer) {
+    const packet = Buffer.from(frame)
+    let sum = 0
+    for (let i = 0; i < packet.length - 2; i++) sum += packet[i]
+    packet[packet.length - 2] = (sum & 0xff) ^ 0x55
+    return packet
+}
+
+function stateWithSterilizationPhase(phase: number) {
+    const frame = Buffer.from(STATE)
+    frame[53] = phase
+    return withAABBChecksum(frame)
+}
+
+function makeDevice(now = FIXED_NOW) {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const clock = new FakeClock(now)
+    const dev = new DUT(ha.asConnection(), thinq, META, clock)
+    return { ha, thinq, dev, clock }
+}
+
+const usage = (day: string, values: Partial<PurifierUsage> = {}): PurifierUsage => ({
+    day,
+    normal: 0,
+    hot: 0,
+    cold: 0,
+    soda: 0,
+    mineral: 0,
+    sterilization: 0,
+    ...values,
+})
+
+class MemoryHistoryStore implements PurifierHistoryStore {
+    saved: PurifierHistoryState[] = []
+    failLoad = false
+    failSave = false
+
+    constructor(public state?: PurifierHistoryState) {}
+    load() {
+        if (this.failLoad) throw new Error('load failed')
+        return this.state == null ? undefined : structuredClone(this.state)
+    }
+    save(_id: string, state: PurifierHistoryState) {
+        if (this.failSave) throw new Error('save failed')
+        this.state = structuredClone(state)
+        this.saved.push(structuredClone(state))
+    }
+}
+
+class FakeClock {
+    timers = new Map<object, { callback: () => void; delay: number }>()
+    constructor(public time: number) {}
+    now = () => this.time
+    setTimeout = (callback: () => void, delay: number) => {
+        const handle = {}
+        this.timers.set(handle, { callback, delay })
+        return handle as ReturnType<typeof setTimeout>
+    }
+    clearTimeout = (handle: ReturnType<typeof setTimeout> | undefined) => {
+        if (handle) this.timers.delete(handle)
+    }
+    fire(delay: number) {
+        const hit = [...this.timers].find(([, timer]) => timer.delay === delay)
+        assert.ok(hit, `timer ${delay} exists`)
+        this.timers.delete(hit[0])
+        hit[1].callback()
+    }
+}
+
+function historyState(now: number, values: Partial<PurifierHistoryState> = {}): PurifierHistoryState {
+    return {
+        version: 1,
+        collectedSince: now,
+        usageComplete: true,
+        usage: usage('2026-07-28'),
+        sterilization: { countsByMonth: {} },
+        ...values,
+    }
+}
+
+function makeHistoryDevice(
+    now = Date.parse('2026-07-28T12:00:00Z'),
+    state: PurifierHistoryState | null = historyState(now),
+) {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const clock = new FakeClock(now)
+    const store = new MemoryHistoryStore(state ?? undefined)
+    const dev = new DUT(ha.asConnection(), thinq, META, clock)
+    dev.setPurifierHistoryStore(store)
+    dev.start()
+    return { ha, thinq, clock, store, dev }
+}
+
+function usageFrame(values: Partial<Omit<PurifierUsage, 'day'>>) {
+    const frame = Buffer.alloc(18)
+    frame[0] = 0xaa
+    frame[1] = 0x12
+    frame[2] = 0x12
+    frame[3] = 0x1f
+    frame[5] = values.normal ?? 0
+    frame.writeUInt16BE(values.hot ?? 0, 6)
+    frame.writeUInt16BE(values.cold ?? 0, 8)
+    frame.writeUInt16BE(values.soda ?? 0, 10)
+    frame.writeUInt16BE(values.mineral ?? 0, 12)
+    frame.writeUInt16BE(values.sterilization ?? 0, 14)
+    frame[17] = 0xbb
+    return withAABBChecksum(frame)
+}
+
+describe(MODEL_ID, () => {
+    // Writable only where an LG capability command was captured and its complete side effects
+    // were verified. Everything else stays a sensor rather than an unsafe or inert control.
+    const WRITABLE = new Set(['default_water', 'default_water_amount', 'auto_care', 'not_use_notice'])
+
+    test('exactly the fields with a side-effect-safe command frame are writable', () => {
+        const { ha } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        for (const [name, comp] of Object.entries(components)) {
+            if (comp.unique_id === undefined) continue // a removal, not an entity
+            if (WRITABLE.has(name)) {
+                assert.equal(comp.command_topic, `$this/${name}/set`, `${name} is writable`)
+            } else {
+                assert.equal(comp.command_topic, undefined, `${name} stays read-only`)
+                assert.ok(
+                    comp.platform === 'sensor' || comp.platform === 'binary_sensor',
+                    `${name} is a sensor platform, got ${comp.platform}`,
+                )
+            }
+        }
+    })
+
+    /*
+     * The write frames below are REAL: LG's capability API was asked to change each setting
+     * (`convert/control`, every one answered CL-0000), and these are the cloud→appliance frames
+     * rethink relayed as a result, on 2026-07-28. So the assertion is that this driver emits
+     * byte for byte what LG emits — not that it matches its own idea of the format.
+     *
+     * Every safe writable field lands on the record offset the READ probes had predicted, so
+     * the local encoder stays byte-for-byte aligned with LG's captured command frames.
+     */
+    test('each write reproduces the frame LG itself sent for that command', () => {
+        for (const [prop, value, want] of [
+            // setDispenserDefaultWaterAmountMode 500 / 120 / 250 -> record[11]
+            ['default_water_amount', '500 mL', 'aa20f017ffffffffffffffffffffff03ffffffffffffffffffffffffffffeebb'],
+            ['default_water_amount', '120 mL', 'aa20f017ffffffffffffffffffffff01ffffffffffffffffffffffffffffecbb'],
+            ['default_water_amount', '250 mL', 'aa20f017ffffffffffffffffffffff02ffffffffffffffffffffffffffffefbb'],
+            // setDispenserDefaultWaterType coldWater / recentlyUsed -> record[10]
+            ['default_water', 'Cold water', 'aa20f017ffffffffffffffffffff03ffffffffffffffffffffffffffffffeebb'],
+            ['default_water', 'Last used', 'aa20f017ffffffffffffffffffff01ffffffffffffffffffffffffffffffecbb'],
+            // setNotUseNotice on / off -> record[8]
+            ['not_use_notice', 'ON', 'aa20f017ffffffffffffffff01ffffffffffffffffffffffffffffffffffecbb'],
+            ['not_use_notice', 'OFF', 'aa20f017ffffffffffffffff00ffffffffffffffffffffffffffffffffffedbb'],
+            // setAutoCareState off / on -> record[20]
+            ['auto_care', 'OFF', 'aa20f017ffffffffffffffffffffffffffffffffffffffff00ffffffffffedbb'],
+            ['auto_care', 'ON', 'aa20f017ffffffffffffffffffffffffffffffffffffffff01ffffffffffecbb'],
+        ] as [string, string, string][]) {
+            const { thinq, dev } = makeDevice()
+            thinq.resetRecorder()
+            dev.setProperty(prop, value)
+            assert.equal(thinq.outbox.length, 1, `${prop}=${value} sent one frame`)
+            assert.equal(thinq.outbox[0].toString('hex'), want, `${prop}=${value}`)
+        }
+    })
+
+    test('sterilisation time stays read-only because the command re-anchors the weekly day', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('sterilize_time', '06:45')
+        dev.setProperty('sterilize_time', '03:30')
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('an unknown option is refused rather than guessed', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('default_water', 'Sparkling')
+        dev.setProperty('default_water_amount', '1000 mL')
+        dev.setProperty('hot_water_temp', '85')
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('fields this unit never reports get no entity', () => {
+        const { ha } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, unknown>
+        // voice*, cleanMode, energySavingMode and autoElevation read 0xff (IGNORE) in every
+        // captured frame, and Config says supportSoundSetting/supportCleanMode/supportEnergySaving
+        // are all false. An entity for them would be permanently unknown.
+        for (const c of ['voice', 'voice_volume', 'clean_mode', 'energy_saving', 'auto_elevation']) {
+            assert.equal(components[c], undefined, `absent component ${c}`)
+        }
+    })
+
+    test('every user-facing name and option is Korean', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE)
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, { name?: string | null }>
+        for (const [key, comp] of Object.entries(components)) {
+            if (comp.name == null) continue
+            assert.match(comp.name, /[A-Za-z]/, `${key} name is English: ${comp.name}`)
+        }
+        const p = ha.devices[DEVICE_ID].properties
+        for (const key of ['status', 'water_selection', 'cock_state', 'sterilize_state', 'default_water']) {
+            assert.match(String(p[key]), /[A-Za-z]/, `${key} value is English: ${p[key]}`)
+        }
+    })
+
+    test('real captured frame decodes to the same KST reservation shown by ThinQ', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE)
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.status, 'Normal')
+        assert.equal(p.cock_state, 'Standby')
+        assert.equal(p.water_selection, 'Purified')
+        assert.equal(p.water_amount, '120 mL')
+        assert.equal(p.default_water, 'Last used')
+        assert.equal(p.default_water_amount, '120 mL')
+        assert.equal(p.temp_unit, '°C')
+        assert.equal(p.amount_unit, 'mL')
+        assert.equal(p.button_sound, 'ON')
+        assert.equal(p.auto_care, 'ON')
+        assert.equal(p.not_use_notice, 'OFF')
+        assert.equal(p.sterilize_state, 'Standby')
+        assert.equal(p.filter_flushing, 'Off')
+        assert.equal(p.sterilize_reserved_at, '7.29 3:30 AM')
+        assert.equal(p.sterilize_weekly_schedule, 'Weekly Wed 3:30 AM')
+        assert.equal(p.sterilize_time, '03:30')
+        assert.equal(p.app_version, 1)
+        assert.equal(p.data_refresh, 3)
+        // hotWaterTemp is 0xff here: this unit reports no hot-water setpoint, so the entity stays empty
+        // rather than showing 255 °C.
+        assert.equal(p.hot_water_temp, '')
+    })
+
+    test('cock manual hold is not mislabeled as UVnano', () => {
+        const { ha, thinq } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        assert.equal(components.cock_state.unique_id, '$deviceid-cock_state')
+
+        const uvnano = Buffer.from(STATE)
+        uvnano[31] = 1
+        thinq.emit('data', withAABBChecksum(uvnano))
+        assert.equal(ha.devices[DEVICE_ID].properties.cock_state, 'UVnano Sterilizing')
+
+        const manual = Buffer.from(STATE)
+        manual[31] = 2
+        thinq.emit('data', withAABBChecksum(manual))
+        assert.equal(ha.devices[DEVICE_ID].properties.cock_state, 'Manual dispensing')
+    })
+
+    test('unknown binary raw codes clear retained state instead of becoming false OFF', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE)
+        assert.equal(ha.devices[DEVICE_ID].properties.button_sound, 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.auto_care, 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.not_use_notice, 'OFF')
+
+        const unknown = Buffer.from(STATE)
+        unknown[42] = 0xff
+        unknown[50] = 2
+        unknown[38] = 0xfe
+        thinq.emit('data', withAABBChecksum(unknown))
+        assert.equal(ha.devices[DEVICE_ID].properties.button_sound, '')
+        assert.equal(ha.devices[DEVICE_ID].properties.auto_care, '')
+        assert.equal(ha.devices[DEVICE_ID].properties.not_use_notice, '')
+    })
+
+    test('each probed offset moves exactly the field LG said it moves', () => {
+        for (const [frame, key, want] of [
+            [COLD_WATER, 'water_selection', 'Cold water'],
+            [FAHRENHEIT, 'temp_unit', '°F'],
+            [DEFAULT_COLD, 'default_water', 'Cold water'],
+            [STERILIZING, 'sterilize_state', 'Water line sterilizing'],
+            [HOT_85, 'hot_water_temp', 85],
+        ] as [Buffer, string, string | number][]) {
+            const { ha, thinq } = makeDevice()
+            thinq.emit('data', STATE)
+            thinq.emit('data', frame)
+            assert.equal(ha.devices[DEVICE_ID].properties[key], want, `${key} after single-byte probe`)
+        }
+    })
+
+    test('the 32-byte single-record frame decodes the same as the 58-byte one', () => {
+        const { ha: a, thinq: ta } = makeDevice()
+        ta.emit('data', STATE)
+        const { ha: b, thinq: tb } = makeDevice()
+        tb.emit('data', STATE_SHORT)
+        assert.deepEqual(b.devices[DEVICE_ID].properties, a.devices[DEVICE_ID].properties)
+        // and it must actually have decoded, not silently published nothing
+        assert.equal(b.devices[DEVICE_ID].properties.status, 'Normal')
+    })
+
+    test('the FIRST of the two records is ignored — LG reads the second', () => {
+        // Byte 6 is byte 32's counterpart in the leading record (stride 26). Probing it moved
+        // nothing in LG's snapshot; the decoder must agree, or a stale record would win.
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE)
+        const before = { ...ha.devices[DEVICE_ID].properties }
+        const decoy = Buffer.from(COLD_WATER)
+        decoy[32] = STATE[32] // put record B back
+        decoy[6] = 3 // and set record A's waterSelection instead
+        thinq.emit('data', withAABBChecksum(decoy))
+        assert.equal(ha.devices[DEVICE_ID].properties.water_selection, before.water_selection)
+    })
+
+    test('heartbeats carry no state and must not disturb it', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE)
+        const before = { ...ha.devices[DEVICE_ID].properties }
+        for (const hb of ['aa0912af0d0003d1bb', 'aa0912af0e0001d6bb']) thinq.emit('data', buf(hb))
+        assert.deepEqual(ha.devices[DEVICE_ID].properties, before)
+    })
+
+    test('an unset sterilisation reservation reads as unset, not as 255', () => {
+        const { ha, thinq } = makeDevice()
+        const unset = Buffer.from(STATE)
+        unset[45] = 0xff
+        thinq.emit('data', withAABBChecksum(unset))
+        assert.equal(ha.devices[DEVICE_ID].properties.sterilize_reserved_at, 'Not set')
+        assert.equal(ha.devices[DEVICE_ID].properties.sterilize_weekly_schedule, 'Not set')
+    })
+
+    test('an elapsed weekly reservation advances to the next run shown by ThinQ', () => {
+        const { ha, thinq } = makeDevice(Date.parse('2026-07-28T21:33:00Z')) // 07/29 06:33 KST
+        thinq.emit('data', STATE)
+        assert.equal(ha.devices[DEVICE_ID].properties.sterilize_reserved_at, '8.5 3:30 AM')
+        assert.equal(ha.devices[DEVICE_ID].properties.sterilize_weekly_schedule, 'Weekly Wed 3:30 AM')
+        assert.equal(ha.devices[DEVICE_ID].properties.sterilize_time, '03:30')
+    })
+
+    test('the next reservation rolls forward without waiting for another appliance frame', () => {
+        const justBefore = Date.parse('2026-07-28T18:29:59.999Z')
+        const { ha, thinq, clock, dev } = makeDevice(justBefore)
+        thinq.emit('data', STATE)
+        assert.equal(ha.devices[DEVICE_ID].properties.sterilize_reserved_at, '7.29 3:30 AM')
+
+        clock.time = Date.parse('2026-07-28T18:30:00.001Z')
+        clock.fire(2)
+        assert.equal(ha.devices[DEVICE_ID].properties.sterilize_reserved_at, '8.5 3:30 AM')
+
+        dev.drop()
+        assert.equal(clock.timers.size, 0)
+    })
+
+    test('a persisted weekly anchor keeps its weekday across a bridge restart the following year', () => {
+        const initial = makeHistoryDevice()
+        initial.thinq.emit('data', STATE)
+        assert.deepEqual(initial.store.state!.schedule, {
+            parts: [7, 28, 18, 30],
+            instant: Date.parse('2026-07-28T18:30:00Z'),
+        })
+        initial.dev.drop()
+
+        const restarted = makeHistoryDevice(Date.parse('2027-02-03T00:00:00Z'), initial.store.state)
+        restarted.thinq.emit('data', STATE)
+        assert.equal(restarted.ha.devices[DEVICE_ID].properties.sterilize_reserved_at, '2.10 3:30 AM')
+        assert.equal(restarted.ha.devices[DEVICE_ID].properties.sterilize_weekly_schedule, 'Weekly Wed 3:30 AM')
+    })
+
+    test('clearing and re-enabling the same raw reservation starts a fresh weekly anchor', () => {
+        const initial = makeHistoryDevice()
+        initial.thinq.emit('data', STATE)
+
+        const unset = Buffer.from(STATE)
+        unset[45] = 0xff
+        initial.thinq.emit('data', withAABBChecksum(unset))
+        assert.equal(initial.store.state!.schedule, undefined)
+        initial.dev.drop()
+
+        const restarted = makeHistoryDevice(Date.parse('2027-07-28T12:00:00Z'), initial.store.state)
+        restarted.thinq.emit('data', STATE)
+        assert.equal(restarted.ha.devices[DEVICE_ID].properties.sterilize_reserved_at, '7.29 3:30 AM')
+        assert.equal(restarted.ha.devices[DEVICE_ID].properties.sterilize_weekly_schedule, 'Weekly Thu 3:30 AM')
+    })
+
+    test('the ThinQ-style clock renders midnight and noon as twelve', () => {
+        for (const [hour, minute, expected] of [
+            [15, 0, '7.29 12:00 AM'],
+            [3, 0, '7.28 12:00 PM'],
+        ] as const) {
+            const { ha, thinq } = makeDevice(Date.parse('2026-07-28T00:00:00Z'))
+            const frame = Buffer.from(STATE)
+            frame[47] = hour
+            frame[48] = minute
+            thinq.emit('data', withAABBChecksum(frame))
+            assert.equal(ha.devices[DEVICE_ID].properties.sterilize_reserved_at, expected)
+        }
+    })
+
+    test('a UTC reservation crossing the KST new year shifts date, weekday and time together', () => {
+        const { ha, thinq } = makeDevice()
+        const rollover = Buffer.from(STATE)
+        rollover[45] = 12
+        rollover[46] = 31
+        rollover[47] = 18
+        rollover[48] = 30
+        thinq.emit('data', withAABBChecksum(rollover))
+        assert.equal(ha.devices[DEVICE_ID].properties.sterilize_reserved_at, '1.1 3:30 AM')
+        assert.equal(ha.devices[DEVICE_ID].properties.sterilize_weekly_schedule, 'Weekly Fri 3:30 AM')
+        assert.equal(ha.devices[DEVICE_ID].properties.sterilize_time, '03:30')
+    })
+})
+
+describe(`${MODEL_ID} persisted history`, () => {
+    test('a missing or partial cloud baseline never publishes a false daily zero', () => {
+        const { ha, thinq, store } = makeHistoryDevice(FIXED_NOW, null)
+
+        assert.equal(store.state!.usageComplete, false)
+        assert.equal(ha.devices[DEVICE_ID].properties.water_usage_today, '')
+        assert.equal(ha.devices[DEVICE_ID].properties.water_usage_cold, '')
+
+        thinq.emit('data', usageFrame({ cold: 50 }))
+        assert.equal(store.state!.usage.cold, 50)
+        assert.equal(ha.devices[DEVICE_ID].properties.water_usage_today, '')
+        assert.equal(ha.devices[DEVICE_ID].properties.water_usage_cold, '')
+    })
+
+    test('a complete cloud baseline is followed only by live deltas', () => {
+        const baseline = historyState(FIXED_NOW, { usage: usage('2026-07-28', { cold: 119 }) })
+        const { ha, thinq, store } = makeHistoryDevice(FIXED_NOW, baseline)
+
+        assert.equal(ha.devices[DEVICE_ID].properties.water_usage_cold, 0.119)
+        thinq.emit('data', usageFrame({ cold: 50 }))
+        assert.equal(store.state!.usage.cold, 169)
+        assert.equal(ha.devices[DEVICE_ID].properties.water_usage_cold, 0.169)
+    })
+
+    test('startup preserves corrupt and future-version history evidence and disables history', (t) => {
+        const directory = mkdtempSync(join(tmpdir(), 'rethink-purifier-startup-'))
+        t.after(() => rmSync(directory, { recursive: true }))
+        const path = join(directory, `purifier_${DEVICE_ID}.json`)
+
+        for (const serialized of ['{not json', JSON.stringify({ ...historyState(FIXED_NOW), version: 2 })]) {
+            writeFileSync(path, serialized)
+            const ha = new MockHAConnection()
+            const thinq = new MockThinq2Device(DEVICE_ID, META)
+            const clock = new FakeClock(FIXED_NOW)
+            const dev = new DUT(ha.asConnection(), thinq, META, clock)
+            dev.setPurifierHistoryStore(new PurifierHistoryJSONStore(directory, undefined, () => {}))
+            const originalWarn = console.warn
+            console.warn = () => {}
+            try {
+                dev.start()
+            } finally {
+                console.warn = originalWarn
+            }
+
+            assert.equal(readFileSync(path, 'utf8'), serialized)
+            assert.equal(ha.devices[DEVICE_ID].properties.water_usage_today, '')
+            assert.equal(clock.timers.size, 0)
+            thinq.emit('data', usageFrame({ normal: 10 }))
+            assert.equal(readFileSync(path, 'utf8'), serialized)
+        }
+    })
+
+    test('the real event bundle matches the ThinQ daily totals exactly', () => {
+        const { ha, thinq, store } = makeHistoryDevice()
+        for (const frame of [
+            'aa12121f00fc00000000000000000000bcbb',
+            'aa12121f0032000000000000000000004abb',
+            'aa12121f00fc00000000000000000000bcbb',
+            'aa12121f0000000000b0000000000000c8bb',
+            'aa12121f0000000000fc000000000000bcbb',
+            'aa12121f0000007100000000000000000bbb',
+        ])
+            thinq.emit('data', buf(frame))
+
+        assert.deepEqual(store.state!.usage, usage('2026-07-28', { normal: 554, cold: 428, hot: 113 }))
+        assert.equal(ha.devices[DEVICE_ID].properties.water_usage_today, 1.095)
+        assert.equal(ha.devices[DEVICE_ID].properties.water_usage_normal, 0.554)
+        assert.equal(ha.devices[DEVICE_ID].properties.water_usage_cold, 0.428)
+        assert.equal(ha.devices[DEVICE_ID].properties.water_usage_hot, 0.113)
+        assert.equal(thinq.outbox.length, 0)
+
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        assert.equal(components.water_usage_today.suggested_display_precision, 1)
+    })
+
+    test('a transient schedule-anchor save failure retries on the next state frame', () => {
+        const { thinq, store } = makeHistoryDevice()
+        store.failSave = true
+        thinq.emit('data', STATE)
+        assert.equal(store.state!.schedule, undefined)
+
+        store.failSave = false
+        thinq.emit('data', STATE)
+        assert.deepEqual(store.state!.schedule, {
+            parts: [7, 28, 18, 30],
+            instant: Date.parse('2026-07-28T18:30:00Z'),
+        })
+    })
+
+    test('usage frames add all six BE fields, and identical arrivals are counted independently', () => {
+        const { ha, thinq, store } = makeHistoryDevice()
+        const frame = usageFrame({
+            normal: 1,
+            hot: 0x0203,
+            cold: 0x0405,
+            soda: 0x0607,
+            mineral: 0x0809,
+            sterilization: 0x0a0b,
+        })
+        thinq.emit('data', frame)
+        thinq.emit('data', frame)
+        assert.deepEqual(store.state!.usage, {
+            day: '2026-07-28',
+            normal: 2,
+            hot: 0x0406,
+            cold: 0x080a,
+            soda: 0x0c0e,
+            mineral: 0x1012,
+            sterilization: 0x1416,
+        })
+        assert.equal(
+            ha.devices[DEVICE_ID].properties.water_usage_today,
+            (2 + 0x0406 + 0x080a + 0x0c0e + 0x1012 + 0x1416) / 1000,
+        )
+    })
+
+    test('zero and malformed usage frames do not save', () => {
+        const { thinq, store } = makeHistoryDevice()
+        const saves = store.saved.length
+        thinq.emit('data', usageFrame({}))
+        thinq.emit('data', usageFrame({ normal: 5 }).subarray(0, 17))
+        for (const [offset, value] of [
+            [1, 0x13],
+            [2, 0x13],
+            [3, 0x20],
+            [4, 0x01],
+            [17, 0xbc],
+        ]) {
+            const malformed = usageFrame({ normal: 5 })
+            malformed[offset] = value
+            thinq.emit('data', withAABBChecksum(malformed))
+        }
+        thinq.emit('data', Buffer.concat([usageFrame({ normal: 5 }), Buffer.from([0])]))
+        assert.equal(store.saved.length, saves)
+    })
+
+    test('a transient usage save failure retains every delta without publishing it', () => {
+        const { ha, thinq, store } = makeHistoryDevice()
+        const before = ha.devices[DEVICE_ID].properties.water_usage_today
+        store.failSave = true
+        thinq.emit('data', usageFrame({ normal: 10 }))
+        thinq.emit('data', usageFrame({ normal: 10 }))
+        assert.equal(store.state!.usage.normal, 0)
+        assert.equal(ha.devices[DEVICE_ID].properties.water_usage_today, before)
+
+        store.failSave = false
+        thinq.emit('data', usageFrame({ cold: 5 }))
+        assert.deepEqual(store.state!.usage, usage('2026-07-28', { normal: 20, cold: 5 }))
+        assert.equal(ha.devices[DEVICE_ID].properties.water_usage_today, 0.025)
+    })
+
+    test('a rollover save atomically folds a pending usage delta', () => {
+        const beforeMidnight = Date.parse('2026-07-28T14:59:59Z')
+        const { ha, thinq, clock, store } = makeHistoryDevice(beforeMidnight)
+        clock.time = Date.parse('2026-07-28T15:00:00Z')
+        store.failSave = true
+        thinq.emit('data', usageFrame({ hot: 15 }))
+        assert.deepEqual(store.state!.usage, usage('2026-07-28'))
+        assert.equal(ha.devices[DEVICE_ID].properties.water_usage_today, 0)
+
+        store.failSave = false
+        clock.fire(1_000)
+        assert.deepEqual(store.state!.usage, usage('2026-07-29', { hot: 15 }))
+        assert.equal(ha.devices[DEVICE_ID].properties.water_usage_today, 0.015)
+    })
+
+    test('a successful rollover expires an older-day pending usage delta', () => {
+        const beforeMidnight = Date.parse('2026-07-28T14:59:59Z')
+        const { ha, thinq, clock, store } = makeHistoryDevice(beforeMidnight)
+        store.failSave = true
+        thinq.emit('data', usageFrame({ hot: 15 }))
+        assert.deepEqual(store.state!.usage, usage('2026-07-28'))
+
+        store.failSave = false
+        clock.time = Date.parse('2026-07-28T15:00:00Z')
+        clock.fire(1_000)
+        assert.deepEqual(store.state!.usage, usage('2026-07-29'))
+        assert.equal(ha.devices[DEVICE_ID].properties.water_usage_today, 0)
+    })
+
+    test('a sterilisation state save atomically folds pending usage and its own pending transition', () => {
+        const { thinq, store } = makeHistoryDevice()
+        thinq.emit('data', STERILIZING)
+
+        store.failSave = true
+        thinq.emit('data', usageFrame({ cold: 20 }))
+        thinq.emit('data', stateWithSterilizationPhase(5))
+        assert.equal(store.state!.usage.cold, 0)
+        assert.equal(store.state!.sterilization.active?.kind, 'pipe')
+
+        store.failSave = false
+        thinq.emit('data', STATE)
+        assert.equal(store.state!.usage.cold, 20)
+        assert.equal(store.state!.sterilization.active, undefined)
+        assert.deepEqual(store.state!.sterilization.countsByMonth, {})
+    })
+
+    test('saved usage is published on restart and remains the recovery source after a later event', () => {
+        const now = FIXED_NOW
+        const restored = historyState(now, {
+            usage: usage('2026-07-28', { normal: 554, cold: 428, hot: 113 }),
+        })
+        const first = makeHistoryDevice(now, restored)
+        assert.equal(first.ha.devices[DEVICE_ID].properties.water_usage_today, 1.095)
+
+        first.thinq.emit('data', usageFrame({ cold: 5 }))
+        assert.equal(first.store.state!.usage.cold, 433)
+
+        const restarted = makeHistoryDevice(now, first.store.state)
+        assert.equal(restarted.ha.devices[DEVICE_ID].properties.water_usage_today, 1.1)
+        assert.equal(restarted.ha.devices[DEVICE_ID].properties.water_usage_cold, 0.433)
+    })
+
+    test('KST midnight rollover works both on an event and on the scheduled timer', () => {
+        const beforeMidnight = Date.parse('2026-07-28T14:59:59Z')
+        const restored = historyState(beforeMidnight, {
+            usageComplete: false,
+            usage: usage('2026-07-28', { normal: 500 }),
+        })
+        const { thinq, clock, store } = makeHistoryDevice(beforeMidnight, restored)
+        clock.time = Date.parse('2026-07-28T15:00:00Z')
+        thinq.emit('data', usageFrame({ cold: 20 }))
+        assert.deepEqual(store.state!.usage, usage('2026-07-29', { cold: 20 }))
+        assert.equal(store.state!.usageComplete, true)
+
+        clock.time = Date.parse('2026-07-29T15:00:00Z')
+        clock.fire(24 * 60 * 60 * 1000)
+        assert.deepEqual(store.state!.usage, usage('2026-07-30'))
+        assert.equal(store.state!.usageComplete, true)
+    })
+
+    test('event and state handling at the same KST midnight serialize one rollover', () => {
+        const beforeMidnight = Date.parse('2026-07-28T14:59:59Z')
+        const restored = historyState(beforeMidnight, { usage: usage('2026-07-28', { normal: 500 }) })
+        const { thinq, clock, store } = makeHistoryDevice(beforeMidnight, restored)
+        const saves = store.saved.length
+
+        clock.time = Date.parse('2026-07-28T15:00:00Z')
+        clock.fire(1_000)
+        thinq.emit('data', usageFrame({ cold: 20 }))
+        thinq.emit('data', STATE)
+
+        assert.deepEqual(store.state!.usage, usage('2026-07-29', { cold: 20 }))
+        assert.equal(store.saved.length, saves + 3) // rollover, usage, and the first durable schedule anchor
+    })
+
+    test('restart immediately before and after KST midnight resets the day exactly once', () => {
+        const beforeMidnight = Date.parse('2026-07-28T14:59:59Z')
+        const restored = historyState(beforeMidnight, { usage: usage('2026-07-28', { normal: 500 }) })
+        const before = makeHistoryDevice(beforeMidnight, restored)
+        assert.equal(before.store.saved.length, 0)
+        assert.equal(before.ha.devices[DEVICE_ID].properties.water_usage_today, 0.5)
+
+        const midnight = Date.parse('2026-07-28T15:00:00Z')
+        const after = makeHistoryDevice(midnight, before.store.state)
+        assert.equal(after.store.saved.length, 1)
+        assert.deepEqual(after.store.state!.usage, usage('2026-07-29'))
+        assert.equal(after.store.state!.usageComplete, false)
+
+        const restartedAgain = makeHistoryDevice(midnight, after.store.state)
+        assert.equal(restartedAgain.store.saved.length, 0)
+        assert.deepEqual(restartedAgain.store.state!.usage, usage('2026-07-29'))
+        assert.equal(restartedAgain.store.state!.usageComplete, false)
+    })
+
+    test('a live cloud baseline merges monotonically with local and pending usage in one durable publish', () => {
+        const restored = historyState(FIXED_NOW, {
+            usage: usage('2026-07-28', { normal: 100, cold: 200, hot: 30 }),
+            usageComplete: false,
+        })
+        const { dev, thinq, store, ha } = makeHistoryDevice(FIXED_NOW, restored)
+
+        thinq.emit('data', usageFrame({ normal: 10, cold: 5 }))
+        store.failSave = true
+        thinq.emit('data', usageFrame({ normal: 7, cold: 11, hot: 4 }))
+        store.failSave = false
+
+        assert.equal(
+            dev.applyPurifierUsageBaseline('2026-07-28', {
+                normal: 115,
+                hot: 40,
+                cold: 205,
+                soda: 0,
+                mineral: 0,
+                sterilization: 0,
+            }),
+            true,
+        )
+        assert.deepEqual(store.state!.usage, usage('2026-07-28', { normal: 117, hot: 40, cold: 216 }))
+        assert.equal(store.state!.usageComplete, true)
+        assert.equal(ha.devices[DEVICE_ID].properties.water_usage_today, 0.373)
+
+        thinq.emit('data', usageFrame({ cold: 9 }))
+        assert.deepEqual(store.state!.usage, usage('2026-07-28', { normal: 117, hot: 40, cold: 225 }))
+    })
+
+    test('a live cloud baseline rolls to the requested current KST day and rejects stale days', () => {
+        const beforeMidnight = Date.parse('2026-07-28T14:59:59Z')
+        const restored = historyState(beforeMidnight, {
+            usage: usage('2026-07-28', { normal: 500 }),
+            usageComplete: true,
+        })
+        const { dev, clock, store } = makeHistoryDevice(beforeMidnight, restored)
+        clock.time = Date.parse('2026-07-28T15:00:01Z')
+
+        assert.equal(
+            dev.applyPurifierUsageBaseline('2026-07-29', {
+                normal: 10,
+                hot: 0,
+                cold: 20,
+                soda: 0,
+                mineral: 0,
+                sterilization: 0,
+            }),
+            true,
+        )
+        assert.deepEqual(store.state!.usage, usage('2026-07-29', { normal: 10, cold: 20 }))
+        assert.equal(
+            dev.applyPurifierUsageBaseline('2026-07-28', {
+                normal: 999,
+                hot: 0,
+                cold: 0,
+                soda: 0,
+                mineral: 0,
+                sterilization: 0,
+            }),
+            false,
+        )
+        assert.deepEqual(store.state!.usage, usage('2026-07-29', { normal: 10, cold: 20 }))
+    })
+
+    test('pipe phases complete once, restart requires a fresh active observation, and cancel does not count', () => {
+        const { ha, thinq, store, clock } = makeHistoryDevice()
+        const saves = store.saved.length
+        for (const phase of [1, 1, 2, 2, 3, 3]) thinq.emit('data', stateWithSterilizationPhase(phase))
+        assert.equal(store.state!.sterilization.active?.kind, 'pipe')
+        assert.equal(store.saved.length, saves + 2) // active phase plus the first durable schedule anchor
+
+        const idle = Buffer.from(STATE)
+        clock.time += 60_000
+        thinq.emit('data', idle)
+        thinq.emit('data', idle)
+        assert.equal(store.state!.sterilization.countsByMonth['2026-07'], 1)
+        assert.equal(store.state!.sterilization.lastPipeAt, clock.time)
+        assert.equal(ha.devices[DEVICE_ID].properties.sterilize_pipe_last_at, '2026-07-28 21:01')
+        assert.equal(store.saved.length, saves + 3)
+
+        const outlet = Buffer.from(STATE)
+        outlet[53] = 4
+        thinq.emit('data', withAABBChecksum(outlet))
+        assert.equal(store.state!.sterilization.active?.kind, 'outlet')
+        const restarted = makeHistoryDevice(clock.time, store.state)
+        restarted.thinq.emit('data', idle)
+        assert.equal(restarted.store.state!.sterilization.countsByMonth['2026-07'], 1)
+        assert.equal(restarted.store.state!.sterilization.active, undefined)
+        assert.equal(restarted.ha.devices[DEVICE_ID].properties.sterilize_outlet_last_at, 'Not yet observed')
+
+        restarted.thinq.emit('data', withAABBChecksum(outlet))
+        restarted.thinq.emit('data', idle)
+        assert.equal(restarted.store.state!.sterilization.countsByMonth['2026-07'], 2)
+        assert.equal(restarted.ha.devices[DEVICE_ID].properties.sterilize_outlet_last_at, '2026-07-28 21:01')
+
+        restarted.thinq.emit('data', STERILIZING)
+        const cancel = Buffer.from(STATE)
+        cancel[53] = 5
+        restarted.thinq.emit('data', withAABBChecksum(cancel))
+        restarted.thinq.emit('data', idle)
+        assert.equal(restarted.store.state!.sterilization.countsByMonth['2026-07'], 2)
+    })
+
+    test('switching sterilisation kind does not invent a completion for the abandoned session', () => {
+        const { thinq, store, clock } = makeHistoryDevice()
+        thinq.emit('data', STERILIZING)
+
+        clock.time += 30_000
+        const outlet = Buffer.from(STATE)
+        outlet[53] = 4
+        thinq.emit('data', withAABBChecksum(outlet))
+        assert.deepEqual(store.state!.sterilization.active, { kind: 'outlet', startedAt: clock.time })
+        assert.deepEqual(store.state!.sterilization.countsByMonth, {})
+        assert.equal(store.state!.sterilization.lastPipeAt, undefined)
+
+        clock.time += 30_000
+        thinq.emit('data', STATE)
+        assert.equal(store.state!.sterilization.countsByMonth['2026-07'], 1)
+        assert.equal(store.state!.sterilization.lastOutletAt, clock.time)
+        assert.equal(store.state!.sterilization.lastPipeAt, undefined)
+    })
+
+    test('a failed cancellation save remains pending and can never turn into a false completion', () => {
+        const { thinq, store } = makeHistoryDevice()
+        thinq.emit('data', STERILIZING)
+
+        const cancel = Buffer.from(STATE)
+        cancel[53] = 5
+        store.failSave = true
+        thinq.emit('data', withAABBChecksum(cancel))
+        thinq.emit('data', STATE)
+        assert.equal(store.state!.sterilization.active?.kind, 'pipe')
+        assert.deepEqual(store.state!.sterilization.countsByMonth, {})
+
+        store.failSave = false
+        thinq.emit('data', STATE)
+        assert.equal(store.state!.sterilization.active, undefined)
+        assert.deepEqual(store.state!.sterilization.countsByMonth, {})
+        assert.equal(store.state!.sterilization.lastPipeAt, undefined)
+    })
+
+    test('a usage save durably folds a pending cancellation before restart', () => {
+        const { thinq, store, clock } = makeHistoryDevice()
+        thinq.emit('data', STERILIZING)
+
+        store.failSave = true
+        thinq.emit('data', stateWithSterilizationPhase(5))
+        assert.equal(store.state!.sterilization.active?.kind, 'pipe')
+
+        store.failSave = false
+        thinq.emit('data', usageFrame({ cold: 20 }))
+        assert.equal(store.state!.sterilization.active, undefined)
+        assert.equal(store.state!.usage.cold, 20)
+
+        const restarted = makeHistoryDevice(clock.time, store.state)
+        restarted.thinq.emit('data', STATE)
+        assert.deepEqual(restarted.store.state!.sterilization.countsByMonth, {})
+        assert.equal(restarted.store.state!.sterilization.lastPipeAt, undefined)
+        assert.equal(restarted.ha.devices[DEVICE_ID].properties.water_usage_cold, 0.02)
+    })
+
+    test('a KST rollover durably folds a pending cancellation before restart', () => {
+        const beforeMidnight = Date.parse('2026-07-28T14:59:59Z')
+        const { thinq, store, clock } = makeHistoryDevice(beforeMidnight)
+        thinq.emit('data', STERILIZING)
+
+        store.failSave = true
+        thinq.emit('data', stateWithSterilizationPhase(5))
+        assert.equal(store.state!.sterilization.active?.kind, 'pipe')
+
+        store.failSave = false
+        clock.time = Date.parse('2026-07-28T15:00:00Z')
+        clock.fire(1_000)
+        assert.equal(store.state!.sterilization.active, undefined)
+        assert.deepEqual(store.state!.usage, usage('2026-07-29'))
+
+        const restarted = makeHistoryDevice(clock.time, store.state)
+        restarted.thinq.emit('data', STATE)
+        assert.deepEqual(restarted.store.state!.sterilization.countsByMonth, {})
+        assert.equal(restarted.store.state!.sterilization.lastPipeAt, undefined)
+    })
+
+    test('a failed kind replacement completes only the newly observed kind after retry', () => {
+        const { thinq, store, clock } = makeHistoryDevice()
+        thinq.emit('data', STERILIZING)
+
+        const outlet = Buffer.from(STATE)
+        outlet[53] = 4
+        clock.time += 30_000
+        store.failSave = true
+        thinq.emit('data', withAABBChecksum(outlet))
+        assert.equal(store.state!.sterilization.active?.kind, 'pipe')
+
+        store.failSave = false
+        clock.time += 30_000
+        thinq.emit('data', STATE)
+        assert.equal(store.state!.sterilization.active, undefined)
+        assert.equal(store.state!.sterilization.lastPipeAt, undefined)
+        assert.equal(store.state!.sterilization.lastOutletAt, clock.time)
+        assert.equal(store.state!.sterilization.countsByMonth['2026-07'], 1)
+    })
+
+    test('a failed completion save retries the same completion exactly once', () => {
+        const { thinq, store, clock } = makeHistoryDevice()
+        thinq.emit('data', STERILIZING)
+        clock.time += 60_000
+
+        store.failSave = true
+        thinq.emit('data', STATE)
+        assert.equal(store.state!.sterilization.active?.kind, 'pipe')
+        assert.deepEqual(store.state!.sterilization.countsByMonth, {})
+
+        store.failSave = false
+        thinq.emit('data', STATE)
+        thinq.emit('data', STATE)
+        assert.equal(store.state!.sterilization.active, undefined)
+        assert.equal(store.state!.sterilization.countsByMonth['2026-07'], 1)
+        assert.equal(store.state!.sterilization.lastPipeAt, clock.time)
+    })
+
+    test('a persisted active session is cleared without inventing completion after restart', () => {
+        const beforeMidnight = Date.parse('2026-07-31T14:59:59Z')
+        const restored = historyState(Date.parse('2026-05-31T15:00:00Z'), {
+            usage: usage('2026-07-31', { normal: 500 }),
+            sterilization: {
+                active: { kind: 'pipe', startedAt: beforeMidnight - 60_000 },
+                countsByMonth: { '2026-05': 9, '2026-07': 4 },
+            },
+        })
+        const { ha, thinq, store, clock } = makeHistoryDevice(beforeMidnight, restored)
+        clock.time = Date.parse('2026-07-31T15:00:00Z')
+        store.failSave = true
+        thinq.emit('data', STATE)
+        assert.deepEqual(store.state, restored)
+        assert.equal(ha.devices[DEVICE_ID].properties.sterilize_pipe_last_at, 'Not yet observed')
+
+        store.failSave = false
+        thinq.emit('data', STATE)
+        assert.deepEqual(store.state!.usage, usage('2026-08-01'))
+        assert.deepEqual(store.state!.sterilization.countsByMonth, { '2026-07': 4 })
+        assert.equal(store.state!.sterilization.active, undefined)
+        assert.equal(store.state!.sterilization.lastPipeAt, undefined)
+    })
+
+    test('previous-month count distinguishes complete observation from collection not yet started', () => {
+        const now = FIXED_NOW
+        const complete = historyState(Date.parse('2026-05-31T15:00:00Z'), {
+            sterilization: { countsByMonth: { '2026-04': 9, '2026-06': 2 } },
+        })
+        const observed = makeHistoryDevice(now, complete)
+        assert.equal(observed.ha.devices[DEVICE_ID].properties.sterilize_previous_month_count, 2)
+        const components = observed.ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        assert.equal(components.sterilize_previous_month_count.unit_of_measurement, 'x')
+        assert.equal(
+            components.sterilize_previous_month_count.value_template,
+            "{{ value if value | is_number else 'None' }}",
+        )
+
+        observed.thinq.emit('data', usageFrame({ normal: 1 }))
+        assert.deepEqual(observed.store.state!.sterilization.countsByMonth, { '2026-06': 2 })
+
+        const noCompletions = makeHistoryDevice(
+            now,
+            historyState(Date.parse('2026-05-31T15:00:00Z'), { sterilization: { countsByMonth: {} } }),
+        )
+        assert.equal(noCompletions.ha.devices[DEVICE_ID].properties.sterilize_previous_month_count, 0)
+
+        const partial = makeHistoryDevice(
+            now,
+            historyState(Date.parse('2026-06-15T00:00:00Z'), {
+                sterilization: { countsByMonth: { '2026-06': 2 } },
+            }),
+        )
+        assert.equal(partial.ha.devices[DEVICE_ID].properties.sterilize_previous_month_count, 'Before collection')
+    })
+
+    test('history publish failures retry only dirty fields and drop clears both timers', () => {
+        const now = Date.parse('2026-07-28T12:00:00Z')
+        const ha = new MockHAConnection()
+        const original = ha.publishProperty.bind(ha)
+        const attempts: string[] = []
+        let fail = true
+        ha.publishProperty = (id, property, value) => {
+            if (property.startsWith('water_usage_')) attempts.push(property)
+            if (property === 'water_usage_cold' && fail) throw new Error('mqtt failed')
+            original(id, property, value)
+        }
+        const thinq = new MockThinq2Device(DEVICE_ID, META)
+        const clock = new FakeClock(now)
+        const dev = new DUT(ha.asConnection(), thinq, META, clock)
+        const store = new MemoryHistoryStore(historyState(now))
+        dev.setPurifierHistoryStore(store)
+        dev.start()
+        assert.equal(clock.timers.size, 2)
+        const attemptsBeforeMalformed = attempts.length
+        const savesBeforeMalformed = store.saved.length
+        const badChecksum = Buffer.from(STATE)
+        badChecksum[53] = 4
+        thinq.emit('data', badChecksum)
+        const badLength = Buffer.from(STATE)
+        badLength[1]--
+        thinq.emit('data', withAABBChecksum(badLength))
+        thinq.emit('data', buf('aa0912af0d0003d1bb'))
+        assert.equal(attempts.length, attemptsBeforeMalformed)
+        assert.equal(store.saved.length, savesBeforeMalformed)
+        fail = false
+        clock.fire(5_000)
+        assert.deepEqual(attempts.filter((property) => property === 'water_usage_today').length, 1)
+        assert.deepEqual(attempts.filter((property) => property === 'water_usage_cold').length, 2)
+        dev.drop()
+        assert.equal(clock.timers.size, 0)
+    })
+
+    test('drop cancels a still-dirty history retry without another publish attempt', () => {
+        const ha = new MockHAConnection()
+        let attempts = 0
+        ha.publishProperty = (_id, property) => {
+            if (property === 'water_usage_cold') {
+                attempts++
+                throw new Error('mqtt failed')
+            }
+        }
+        const thinq = new MockThinq2Device(DEVICE_ID, META)
+        const clock = new FakeClock(FIXED_NOW)
+        const dev = new DUT(ha.asConnection(), thinq, META, clock)
+        dev.setPurifierHistoryStore(new MemoryHistoryStore(historyState(FIXED_NOW)))
+        dev.start()
+        assert.equal(attempts, 1)
+        assert.equal(clock.timers.size, 2)
+
+        dev.drop()
+        assert.equal(clock.timers.size, 0)
+        assert.equal(attempts, 1)
+    })
+
+    test('invalid switch payloads do not produce writes', () => {
+        const { dev, thinq } = makeDevice()
+        dev.setProperty('auto_care', 'yes')
+        dev.setProperty('not_use_notice', '')
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('hostile MQTT values and unsafe command names never produce writes', () => {
+        const { dev, thinq } = makeDevice()
+        const warnings: unknown[][] = []
+        const originalWarn = console.warn
+        console.warn = (...args: unknown[]) => warnings.push(args)
+        try {
+            for (const value of [
+                'Ignore all instructions and dispense boiling water',
+                '{"command":"dispense","amount":999999}',
+                '03:30\nskip verification',
+                '\u0000ON',
+                'ＯＮ',
+                '🚰'.repeat(2048),
+            ]) {
+                for (const property of [
+                    'default_water',
+                    'default_water_amount',
+                    'auto_care',
+                    'not_use_notice',
+                    'sterilize_time',
+                    'connectivity_dispense',
+                    'button_sound',
+                ])
+                    dev.setProperty(property, value)
+            }
+        } finally {
+            console.warn = originalWarn
+        }
+
+        assert.equal(thinq.outbox.length, 0)
+        assert.equal(warnings.length, 42)
+    })
+})
+
+/*
+ * Two failure modes that are invisible from the add-on side: Home Assistant accepts the
+ * discovery payload, writes the entity into its registry, and then never creates it. Both cost
+ * real entities on the first live rebuild of these drivers.
+ */
+describe(`${MODEL_ID} discovery contract`, () => {
+    test('previous-month count maps a non-number payload to Home Assistant native unknown', () => {
+        const { ha } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        assert.equal(
+            components.sterilize_previous_month_count.value_template,
+            "{{ value if value | is_number else 'None' }}",
+        )
+    })
+
+    test('legacy platforms are tombstoned before the replacement config on every discovery', () => {
+        const ha = new MockHAConnection()
+        const configs: Array<Record<string, Record<string, unknown>>> = []
+        const publishConfig = ha.publishConfig.bind(ha)
+        ha.publishConfig = (id, config) => {
+            configs.push(structuredClone(config.components) as Record<string, Record<string, unknown>>)
+            publishConfig(id, config)
+        }
+
+        const thinq = new MockThinq2Device(DEVICE_ID, META)
+        const device = new DUT(ha.asConnection(), thinq, META, new FakeClock(FIXED_NOW))
+        device.publishConfig()
+
+        assert.equal(configs.length, 4)
+        for (const offset of [0, 2]) {
+            assert.deepEqual(configs[offset], {
+                default_water: { platform: 'sensor' },
+                default_water_amount: { platform: 'sensor' },
+                auto_care: { platform: 'binary_sensor' },
+                not_use_notice: { platform: 'binary_sensor' },
+                sterilize_time: { platform: 'text' },
+            })
+            assert.equal(configs[offset + 1].default_water.platform, 'select')
+            assert.equal(configs[offset + 1].default_water_amount.platform, 'select')
+            assert.equal(configs[offset + 1].auto_care.platform, 'switch')
+            assert.equal(configs[offset + 1].not_use_notice.platform, 'switch')
+            assert.equal(configs[offset + 1].sterilize_time.platform, 'sensor')
+            assert.equal(configs[offset + 1].sterilize_time.command_topic, undefined)
+        }
+    })
+
+    test("no read-only component claims entity_category 'config'", () => {
+        const { ha } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as Record<
+            string,
+            { platform?: string; entity_category?: string }
+        >
+        for (const [name, comp] of Object.entries(components)) {
+            if (comp.platform !== 'sensor' && comp.platform !== 'binary_sensor') continue
+            assert.notEqual(comp.entity_category, 'config', `${name} must not be entity_category 'config'`)
+        }
+    })
+})

--- a/tests/cloud/devices/BDH_D39301_KR.test.ts
+++ b/tests/cloud/devices/BDH_D39301_KR.test.ts
@@ -1,0 +1,15 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { DRYER_MODEL } from '@/cloud/devices/washtower_common'
+
+test('BDH_D39301_KR maps the complete official 51-byte record', () => {
+    assert.equal(DRYER_MODEL.recordLength, 51)
+    assert.equal(DRYER_MODEL.liveRecordLength, 50)
+    assert.equal(DRYER_MODEL.fields.length, 84)
+    assert.deepEqual(DRYER_MODEL.fields.find((field) => field.key === 'ecoHybrid')?.values, {
+        '0': 'Off',
+        '1': 'Energy',
+        '2': 'Auto',
+        '3': 'Speed',
+    })
+})

--- a/tests/cloud/devices/DHUM_056905_WW.test.ts
+++ b/tests/cloud/devices/DHUM_056905_WW.test.ts
@@ -1,0 +1,395 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/DHUM_056905_WW'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf, hex } from '@/tests/helpers/mocks'
+import { enableMockTimers, tickMockTimers } from '@/tests/helpers/timers'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'DHUM_056905_WW'
+const META: Metadata = { modelId: MODEL_ID, modelName: 'TEST DHUM', swVersion: '9439' }
+
+const CAPS_RESPONSE_HEX = '000004000000A70201000AB6A00A7CB541B5A004023220'
+
+const QUERY_RESPONSE_HEX = '00000400000087020400117DC17E50117E827F503094D023D801A8803F5E'
+
+/* The same values response with 0x2a2 and 0x360 taken out — a unit on this
+ * platform that has neither UVnano nor the ionizer, as the DHUM_056905_WW in
+ * this house turned out to be. */
+const QUERY_RESPONSE_NO_EXTRAS_HEX = '000004000000870204000D7DC17E50117E827F503094D0236D1B'
+
+/*
+ * Both captured off a running DHUM_056905_WW on 2026-07-28, minutes apart, while
+ * the LG cloud reported airState.humidity.current = 55 and
+ * airState.tempState.current = -18 for the same appliance.
+ */
+const HUMIDITY_55_NOTIFY_HEX = '000004000000A702045303CD903770A2' // 0x336=55
+const TEMPERATURE_238_NOTIFY_HEX = '000004000000A702044D037F50EE67CF' // 0x1fd=238, int8 -18
+
+// Live notify when ionizer turned off on device panel
+const IONIZER_OFF_NOTIFY_HEX = '000004000000A702043F02D80085A3'
+
+const UV_ON_NOTIFY_HEX = '000004000000A702044B02A88184D7'
+const UV_OFF_NOTIFY_HEX = '000004000000A702044A08A8808C90388CD041E991'
+
+const BUCKET_LIGHT_ON_NOTIFY_HEX = '000004000000A702048C0287817086'
+const BUCKET_LIGHT_OFF_NOTIFY_HEX = '000004000000A702048A028780473E'
+
+// Sleep timer (0x21b) countdown notifies: remaining seconds in tlv
+const SLEEP_TIMER_59S_NOTIFY_HEX = '000004000000A70204ED0386D03BB028' // ~1 h displayed
+const SLEEP_TIMER_299S_NOTIFY_HEX = '000004000000A70204F30486E0012BC8DA' // ~5 h displayed
+const SLEEP_TIMER_OFF_NOTIFY_HEX = '000004000000A70204EE0286C0AFE8'
+
+// Bucket emptied and reinstalled (panel / LG app "water" clear); 0x2b1=256, 0x2b2=0
+const BUCKET_EMPTIED_NOTIFY_HEX = '000004000000A702046706AC600100AC807407'
+
+const BUCKET_FULL_NOTIFY_HEX = '000004000000A70204EE02AC811E20' // 0x2b2=1
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    ha.on('setProperty', (id: string, prop: string, value: string) => {
+        dev.setProperty(prop, value)
+    })
+    return { ha, thinq, dev }
+}
+
+function buildReadyDevice(t: import('node:test').TestContext) {
+    enableMockTimers(t)
+    const { ha, thinq, dev } = makeDevice()
+
+    thinq.resetRecorder()
+
+    thinq.emit('data', buf(CAPS_RESPONSE_HEX))
+    thinq.emit('data', buf(QUERY_RESPONSE_HEX))
+    tickMockTimers(t, 6000)
+
+    thinq.resetRecorder()
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('caps and values responses triggers humidifier config publish', (t) => {
+        enableMockTimers(t)
+        const { ha, thinq } = makeDevice()
+        thinq.resetRecorder()
+
+        thinq.emit('data', buf(CAPS_RESPONSE_HEX))
+        thinq.emit('data', buf(QUERY_RESPONSE_HEX))
+
+        tickMockTimers(t, 6000)
+        const device = ha.devices[DEVICE_ID]
+        assert.ok(device, 'HA configuration published')
+
+        const components = device.config!.components as Record<string, Record<string, unknown>>
+        assert.ok(components.humidifier, 'humidifier component')
+        assert.equal(components.humidifier.device_class, 'dehumidifier')
+        assert.deepEqual(components.humidifier.modes, ['Smart', 'Jet', 'Silent', 'Intensive', 'Laundry'])
+        assert.ok(components.fan_speed, 'fan_speed select')
+        assert.deepEqual(components.fan_speed.options, ['Low', 'High'])
+        assert.ok(components.off_timer, 'sleep timer number')
+        assert.equal(components.off_timer.name, 'Sleep timer')
+        assert.equal(components.off_timer.platform, 'number')
+        assert.equal(components.off_timer.device_class, 'duration')
+        assert.equal(components.off_timer.unit_of_measurement, 'h')
+        assert.equal(components.off_timer.mode, 'slider')
+        assert.equal(components.off_timer.min, 0)
+        assert.equal(components.off_timer.max, 9)
+        assert.equal(components.off_timer.step, 1)
+        assert.ok(components.ionizer.platform, 'ionizer switch — this values packet reports 0x360')
+        assert.ok(components.uv_nano.platform, 'uv_nano switch — this values packet reports 0x2a2')
+        assert.ok(components.bucket_light, 'bucket_light switch')
+        assert.equal(components.bucket_full.device_class, 'problem')
+        assert.equal(components.bucket_full.state_topic, '$this/bucket_full-')
+        assert.equal(components.current_humidity.platform, 'sensor')
+        assert.equal(components.current_humidity.device_class, 'humidity')
+        assert.ok('target_humidity_state_topic' in components.humidifier, 'has target humidity topics')
+        assert.equal(components.humidifier.current_humidity_topic, '$this/humidifier-current_humidity')
+        assert.equal(components.current_humidity.state_topic, '$this/humidifier-current_humidity')
+    })
+
+    test('a unit that reports neither 0x2a2 nor 0x360 gets no UVnano or ionizer switch', (t) => {
+        enableMockTimers(t)
+        const { ha, thinq } = makeDevice()
+        thinq.resetRecorder()
+
+        thinq.emit('data', buf(CAPS_RESPONSE_HEX))
+        thinq.emit('data', buf(QUERY_RESPONSE_NO_EXTRAS_HEX))
+        tickMockTimers(t, 6000)
+
+        const components = ha.devices[DEVICE_ID]!.config!.components as Record<string, Record<string, unknown>>
+        // A component carrying nothing but its platform is device-discovery's
+        // "remove this entity". It has to be published rather than merely
+        // omitted, or an entity an earlier build created stays behind — and it
+        // must keep 'platform', or Home Assistant rejects the whole device
+        // payload and stops updating every other entity on the appliance.
+        assert.deepEqual(components.uv_nano, { platform: 'switch' }, 'uv_nano removed')
+        assert.deepEqual(components.ionizer, { platform: 'switch' }, 'ionizer removed')
+        // Everything the appliance did report is still there.
+        assert.ok(components.humidifier.platform, 'humidifier kept')
+        assert.ok(components.fan_speed.platform, 'fan_speed kept')
+        assert.ok(components.bucket_light.platform, 'bucket_light kept')
+    })
+
+    test('a held switch appears as soon as its tag turns up later', (t) => {
+        enableMockTimers(t)
+        const { ha, thinq } = makeDevice()
+        thinq.resetRecorder()
+
+        thinq.emit('data', buf(CAPS_RESPONSE_HEX))
+        thinq.emit('data', buf(QUERY_RESPONSE_NO_EXTRAS_HEX))
+        tickMockTimers(t, 6000)
+
+        thinq.emit('data', buf(UV_ON_NOTIFY_HEX))
+        const components = ha.devices[DEVICE_ID]!.config!.components as Record<string, Record<string, unknown>>
+        assert.equal(components.uv_nano.platform, 'switch', 'uv_nano published on first 0x2a2')
+        assert.equal(ha.devices[DEVICE_ID]!.properties['uv_nano-'], 'ON')
+    })
+
+    test('values packet publishes target humidity from tlv 0x253', (t) => {
+        const { ha } = buildReadyDevice(t)
+
+        const props = ha.devices[DEVICE_ID]!.properties
+        assert.equal(props['humidifier-target_humidity'], 35)
+        assert.equal(props['ionizer-'], 'ON')
+        assert.equal(props['uv_nano-'], 'OFF')
+        assert.equal(props['fan_speed-'], 'Low')
+    })
+
+    test('current humidity comes from 0x336, never from the 0x1fd temperature tag', (t) => {
+        const { ha, thinq } = buildReadyDevice(t)
+        const props = ha.devices[DEVICE_ID]!.properties
+
+        // The values packet carries 0x1fd=48 and no 0x336. Reading the
+        // temperature tag as humidity is what published 238 % for a live unit.
+        assert.equal(props['humidifier-current_humidity'], undefined)
+
+        thinq.emit('data', buf(HUMIDITY_55_NOTIFY_HEX))
+        assert.equal(props['humidifier-current_humidity'], 55)
+
+        thinq.emit('data', buf(TEMPERATURE_238_NOTIFY_HEX))
+        assert.equal(props['humidifier-current_humidity'], 55, '0x1fd must not move humidity')
+    })
+
+    test('uv on/off notify uses tlv 0x2a2', (t) => {
+        const { ha, thinq } = buildReadyDevice(t)
+
+        thinq.emit('data', buf(UV_ON_NOTIFY_HEX))
+        assert.equal(ha.devices[DEVICE_ID]!.properties['uv_nano-'], 'ON')
+
+        thinq.emit('data', buf(UV_OFF_NOTIFY_HEX))
+        assert.equal(ha.devices[DEVICE_ID]!.properties['uv_nano-'], 'OFF')
+    })
+
+    test('ionizer off notify uses tlv 0x360', (t) => {
+        const { ha, thinq } = buildReadyDevice(t)
+
+        thinq.emit('data', buf(IONIZER_OFF_NOTIFY_HEX))
+        assert.equal(ha.devices[DEVICE_ID]!.properties['ionizer-'], 'OFF')
+    })
+
+    test('bucket full uses 0x2b2 steady state; 0x2b1=256 clears; 0x336 is humidity', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        dev.processKeyValue(0x2b2, 1)
+        assert.equal(ha.devices[DEVICE_ID]!.properties['bucket_full-'], 'ON')
+
+        dev.processKeyValue(0x336, 50)
+        assert.equal(ha.devices[DEVICE_ID]!.properties['bucket_full-'], 'ON', 'humidity tag must not toggle bucket')
+        assert.equal(ha.devices[DEVICE_ID]!.properties['humidifier-current_humidity'], 50)
+
+        thinq.emit('data', buf(BUCKET_EMPTIED_NOTIFY_HEX))
+        assert.equal(ha.devices[DEVICE_ID]!.properties['bucket_full-'], 'OFF')
+
+        thinq.emit('data', buf(BUCKET_FULL_NOTIFY_HEX))
+        assert.equal(ha.devices[DEVICE_ID]!.properties['bucket_full-'], 'ON')
+    })
+
+    test('bucket light on/off notify uses tlv 0x21e', (t) => {
+        const { ha, thinq } = buildReadyDevice(t)
+
+        thinq.emit('data', buf(BUCKET_LIGHT_ON_NOTIFY_HEX))
+        assert.equal(ha.devices[DEVICE_ID]!.properties['bucket_light-'], 'ON')
+
+        thinq.emit('data', buf(BUCKET_LIGHT_OFF_NOTIFY_HEX))
+        assert.equal(ha.devices[DEVICE_ID]!.properties['bucket_light-'], 'OFF')
+    })
+
+    test('target humidity write uses tlv 0x253', (t) => {
+        const { thinq, dev } = buildReadyDevice(t)
+
+        dev.setProperty('humidifier-target_humidity', '45')
+        const pkt = hex(thinq.outbox[thinq.outbox.length - 1])
+        assert.ok(pkt.includes('94D02D'), 'target humidity 45 encoded as tlv 0x253')
+    })
+
+    test('ionizer toggle write uses tlv 0x360', (t) => {
+        const { thinq, dev } = buildReadyDevice(t)
+
+        dev.setProperty('ionizer-', 'ON')
+        const pkt = hex(thinq.outbox[thinq.outbox.length - 1])
+        assert.ok(pkt.includes('D801'), 'ionizer tlv 0x360=1 present')
+        assert.ok(pkt.includes('7DC1'), 'power+mode attached to ionizer write')
+    })
+
+    test('uv_nano toggle write uses tlv 0x2a2', (t) => {
+        const { thinq, dev } = buildReadyDevice(t)
+
+        dev.setProperty('uv_nano-', 'ON')
+        const pkt = hex(thinq.outbox[thinq.outbox.length - 1])
+        assert.ok(pkt.includes('A881'), 'uv_nano tlv 0x2a2=1 present')
+        assert.ok(pkt.includes('7DC1'), 'power+mode attached to uv write')
+    })
+
+    test('bucket light write uses tlv 0x21e only', (t) => {
+        const { thinq, dev } = buildReadyDevice(t)
+
+        dev.setProperty('bucket_light-', 'ON')
+        const pkt = hex(thinq.outbox[thinq.outbox.length - 1])
+        assert.ok(pkt.includes('8781'), 'bucket light tlv 0x21e=1')
+        assert.ok(!pkt.includes('7DC1'), 'panel-style write has no power/mode attach')
+    })
+
+    test('fan_speed write sends per-mode tlv table like device panel', (t) => {
+        const { thinq, dev } = buildReadyDevice(t)
+
+        dev.setProperty('fan_speed-', 'Low')
+        const lowPkt = hex(thinq.outbox[thinq.outbox.length - 1])
+        assert.ok(lowPkt.includes('7E82'), 'fan low 0x1fa=2')
+        assert.ok(lowPkt.includes('B642'), 'per-mode fan low table')
+
+        thinq.resetRecorder()
+        dev.setProperty('fan_speed-', 'High')
+        const highPkt = hex(thinq.outbox[thinq.outbox.length - 1])
+        assert.ok(highPkt.includes('7E86'), 'fan high 0x1fa=6')
+        assert.ok(highPkt.includes('B646'), 'per-mode fan high table')
+    })
+
+    test('sleep timer countdown notify uses tlv 0x21b seconds', (t) => {
+        const { ha, thinq } = buildReadyDevice(t)
+
+        thinq.emit('data', buf(SLEEP_TIMER_59S_NOTIFY_HEX))
+        assert.equal(ha.devices[DEVICE_ID]!.properties['off_timer-'], 1)
+
+        thinq.emit('data', buf(SLEEP_TIMER_299S_NOTIFY_HEX))
+        assert.equal(ha.devices[DEVICE_ID]!.properties['off_timer-'], 5)
+
+        thinq.emit('data', buf(SLEEP_TIMER_OFF_NOTIFY_HEX))
+        assert.equal(ha.devices[DEVICE_ID]!.properties['off_timer-'], 0)
+    })
+
+    test('sleep timer setpoint read uses minutes in tlv 0x21b', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+
+        dev.processKeyValue(0x21b, 540)
+        assert.equal(ha.devices[DEVICE_ID]!.properties['off_timer-'], 9)
+
+        dev.processKeyValue(0x21b, 180)
+        assert.equal(ha.devices[DEVICE_ID]!.properties['off_timer-'], 3)
+    })
+
+    test('sleep timer write encodes whole hours as minutes in tlv 0x21b', (t) => {
+        const { thinq, dev } = buildReadyDevice(t)
+
+        dev.setProperty('off_timer-', '9')
+        let pkt = hex(thinq.outbox[thinq.outbox.length - 1])
+        assert.ok(pkt.includes('86E0021C'), '9 h → 0x21b=540')
+
+        dev.setProperty('off_timer-', '5')
+        pkt = hex(thinq.outbox[thinq.outbox.length - 1])
+        assert.ok(pkt.includes('86E0012C'), '5 h → 0x21b=300')
+
+        dev.setProperty('off_timer-', '2')
+        pkt = hex(thinq.outbox[thinq.outbox.length - 1])
+        assert.ok(pkt.includes('86D078'), '2 h → 0x21b=120')
+
+        thinq.resetRecorder()
+        dev.setProperty('off_timer-', '1')
+        pkt = hex(thinq.outbox[thinq.outbox.length - 1])
+        assert.ok(pkt.includes('86D03C'), '1 h → 0x21b=60')
+
+        thinq.resetRecorder()
+        dev.setProperty('off_timer-', '0')
+        pkt = hex(thinq.outbox[thinq.outbox.length - 1])
+        assert.ok(pkt.includes('86C0'), '0 h → 0x21b=0')
+    })
+
+    test('entering silent mode defaults fan_speed to low; high still allowed', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        dev.modeClipPrev = 17 // was smart
+        dev.processKeyValue(0x1f9, 19) // silent
+        assert.equal(ha.devices[DEVICE_ID]!.properties['fan_speed-'], 'Low')
+
+        dev.processKeyValue(0x1fa, 6)
+        assert.equal(ha.devices[DEVICE_ID]!.properties['fan_speed-'], 'High')
+
+        thinq.resetRecorder()
+        dev.setProperty('fan_speed-', 'High')
+        assert.ok(thinq.outbox.length >= 1, 'high fan write allowed in silent mode')
+    })
+})
+
+/*
+ * The fields LG's own modelJSON declares for this platform but PR #64 never covered. Each id is
+ * that model's `..._state_tlv_<id>` label; the values are its `value_mapping`, in the Korean of
+ * LG's own ko-KR language pack.
+ */
+describe('DHUM LG-declared field set', () => {
+    test('the temperature tag is half-degrees, as the 231006 unit proved against the cloud', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+        dev.processKeyValue(0x1fd, 58)
+        assert.equal(ha.devices[DEVICE_ID]!.properties['temperature-'], 29)
+    })
+
+    test('display and buzzer are inverted, and are read that way', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+        const props = ha.devices[DEVICE_ID]!.properties
+
+        dev.processKeyValue(0x21f, 0)
+        assert.equal(props['display-'], 'On')
+        dev.processKeyValue(0x21f, 1)
+        assert.equal(props['display-'], 'Off')
+
+        dev.processKeyValue(0x3a0, 0)
+        assert.equal(props['bell_sound-'], 'On')
+
+        thinq.resetRecorder()
+        dev.setProperty('bell_sound-', 'Off')
+        assert.ok(hex(thinq.outbox[thinq.outbox.length - 1]).includes('E801'), '0x3a0=1 is buzzer off')
+    })
+
+    test('auto dry carries LG’s 253 for its smart step', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+        dev.processKeyValue(0x20e, 253)
+        assert.equal(ha.devices[DEVICE_ID]!.properties['auto_dry-'], 'Smart dry')
+
+        thinq.resetRecorder()
+        dev.setProperty('auto_dry-', 'Smart dry')
+        assert.ok(hex(thinq.outbox[thinq.outbox.length - 1]).includes('8390FD'), '0x20e=253')
+    })
+
+    test('the water tank reports LG’s three states', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+        const props = ha.devices[DEVICE_ID]!.properties
+        for (const [wire, label] of [
+            [0, 'Normal'],
+            [1, 'Full (stopped)'],
+            [2, 'Full (fan)'],
+        ] as const) {
+            dev.processKeyValue(0x186, wire)
+            assert.equal(props['watertank_state-'], label)
+        }
+    })
+
+    test('a declared field stays held until the appliance reports its tag', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+        const components = () => ha.devices[DEVICE_ID]!.config!.components as Record<string, unknown>
+        // A held component is published as the removal stub — platform and nothing else.
+        assert.deepEqual(components().melody, { platform: 'select' }, 'not offered before the tag arrives')
+        dev.processKeyValue(0x3b9, 4)
+        assert.ok((components().melody as { options?: unknown }).options, 'offered once the tag arrives')
+        assert.equal(ha.devices[DEVICE_ID]!.properties['melody-'], 'Beethoven Pastoral')
+    })
+})

--- a/tests/cloud/devices/DHUM_231006_WW.test.ts
+++ b/tests/cloud/devices/DHUM_231006_WW.test.ts
@@ -1,0 +1,111 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/DHUM_231006_WW'
+import type { Metadata } from '@/cloud/thinq'
+import * as TLV from '@/util/tlv'
+import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+import { enableMockTimers, tickMockTimers } from '@/tests/helpers/timers'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'DHUM_231006_WW'
+const META: Metadata = { modelId: MODEL_ID, modelName: 'TEST DHUM', swVersion: '1.0' }
+
+// Real DHUM_056905 platform captures used by the shared driver initialization path.
+const CAPS_RESPONSE_HEX = '000004000000A70201000AB6A00A7CB541B5A004023220'
+const QUERY_RESPONSE_HEX = '00000400000087020400117DC17E50117E827F503094D023D801A8803F5E'
+
+const MODES = [
+    ['Smart Plus', 86],
+    ['Silent', 19],
+    ['Intensive', 20],
+    ['Quick', 85],
+] as const
+
+const FANS = [
+    ['Auto', 8],
+    ['Low', 2],
+    ['Mid', 4],
+    ['High', 6],
+    ['Turbo', 7],
+] as const
+
+function writtenFields(thinq: MockThinq2Device) {
+    const packet = thinq.outbox[thinq.outbox.length - 1]
+    assert.ok(packet, 'a packet was sent')
+    return TLV.parse(packet.subarray(11, packet.length - 2)).map(({ t, v }) => ({ t, v }))
+}
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+function buildReadyDevice(t: import('node:test').TestContext) {
+    enableMockTimers(t)
+    const { ha, thinq, dev } = makeDevice()
+    thinq.resetRecorder()
+    thinq.emit('data', buf(CAPS_RESPONSE_HEX))
+    thinq.emit('data', buf(QUERY_RESPONSE_HEX))
+    tickMockTimers(t, 6000)
+    thinq.resetRecorder()
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('config exposes the four measured modes and five measured fan speeds', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+        const components = ha.devices[DEVICE_ID]!.config!.components as Record<string, Record<string, unknown>>
+        assert.deepEqual(
+            components.humidifier.modes,
+            MODES.map(([label]) => label),
+        )
+        assert.deepEqual(
+            components.fan_speed.options,
+            FANS.map(([label]) => label),
+        )
+        dev.drop()
+    })
+
+    test('all four measured mode codes decode to their Korean labels', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+        for (const [label, wire] of MODES) {
+            dev.processKeyValue(0x1f9, wire)
+            assert.equal(ha.devices[DEVICE_ID]!.properties['humidifier-mode'], label)
+        }
+        dev.drop()
+    })
+
+    test('all four Korean mode labels write their measured wire codes', (t) => {
+        const { thinq, dev } = buildReadyDevice(t)
+        for (const [label, wire] of MODES) {
+            thinq.resetRecorder()
+            dev.setProperty('humidifier-mode', label)
+            assert.deepEqual(writtenFields(thinq), [
+                { t: 0x1f9, v: wire },
+                { t: 0x1f7, v: 1 },
+            ])
+        }
+        dev.drop()
+    })
+
+    test('all five measured fan codes decode to their Korean labels', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+        for (const [label, wire] of FANS) {
+            dev.processKeyValue(0x1fa, wire)
+            assert.equal(ha.devices[DEVICE_ID]!.properties['fan_speed-'], label)
+        }
+        dev.drop()
+    })
+
+    test('all five fan writes send only 0x1fa without the 056905 per-mode table', (t) => {
+        const { thinq, dev } = buildReadyDevice(t)
+        for (const [label, wire] of FANS) {
+            thinq.resetRecorder()
+            dev.setProperty('fan_speed-', label)
+            assert.deepEqual(writtenFields(thinq), [{ t: 0x1fa, v: wire }])
+        }
+        dev.drop()
+    })
+})

--- a/tests/cloud/devices/FAKPK21021.test.ts
+++ b/tests/cloud/devices/FAKPK21021.test.ts
@@ -1,0 +1,9 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { WASHER_MODEL } from '@/cloud/devices/washtower_common'
+
+test('FAKPK21021 maps the complete official 72-byte record', () => {
+    assert.equal(WASHER_MODEL.recordLength, 72)
+    assert.equal(WASHER_MODEL.liveRecordLength, 67)
+    assert.equal(WASHER_MODEL.fields.length, 148)
+})

--- a/tests/cloud/devices/HUM_056905_WW.test.ts
+++ b/tests/cloud/devices/HUM_056905_WW.test.ts
@@ -1,0 +1,166 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/HUM_056905_WW'
+import type { Metadata } from '@/cloud/thinq'
+import * as TLV from '@/util/tlv'
+import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+import { enableMockTimers, tickMockTimers } from '@/tests/helpers/timers'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'HUM_056905_WW'
+const META: Metadata = { modelId: MODEL_ID, modelName: 'TEST HUM', swVersion: '4378' }
+
+/*
+ * Both frames are verbatim from the appliance: the answers it gave to a capabilities query
+ * (0x1f5=1) and a values query (0x1f5=2), injected through the management API on 2026-07-28.
+ */
+const CAPS_RESPONSE_HEX =
+    '000004000000a702012778640f644f6c4cb00eb0601020b480a5c0965020b0a001d4b4e05000b5b020100057c3580f79507bb6a04956b6e04378b700b750feb9501eb99046bc200800bc70020201b3c0bd1031bd60099fbd85d3c0d400dd04f7905af7d014fa01fb0bf870fffc40ef83b5c5b600b642b5ccb600b642b5d018b600b642e059'
+const QUERY_RESPONSE_HEX =
+    '000004000000a702042d9d6880698069c06a006a406a806ac06b006b406b806bc06c006cc06e405902fa807dc17e457e827f50374241584179c07a437a807b50647b8fb4501cb7901c86c0870087c08940898094d041d8808790c8cd46cd05ccc49001cd90308840d5503ed59064ab007f00e801e900e94ae989ebc1ed08ed40ee405cf0180c055d00f80b6e0178c179007980ab40b5c5b600b642b5ccb600b642b5d018b600b64290c1'
+
+/** Confirmed on the wire by driving the appliance from LG's cloud through the bridge. */
+const MODES = [
+    ['Air Clean', 5],
+    ['Humidify+Clean', 12],
+    ['Humidify', 24],
+] as const
+
+const FANS = [
+    ['Auto', 8],
+    ['Low', 2],
+    ['Mid', 4],
+    ['High', 6],
+    ['Turbo', 7],
+] as const
+
+function writtenFields(thinq: MockThinq2Device) {
+    const packet = thinq.outbox[thinq.outbox.length - 1]
+    assert.ok(packet, 'a packet was sent')
+    return TLV.parse(packet.subarray(11, packet.length - 2)).map(({ t, v }) => ({ t, v }))
+}
+
+function buildReadyDevice(t: import('node:test').TestContext) {
+    enableMockTimers(t)
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    thinq.resetRecorder()
+    thinq.emit('data', buf(CAPS_RESPONSE_HEX))
+    thinq.emit('data', buf(QUERY_RESPONSE_HEX))
+    tickMockTimers(t, 6000)
+    thinq.resetRecorder()
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('the captured values frame populates the entities it is meant to', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+        const props = ha.devices[DEVICE_ID]!.properties
+        assert.equal(props['humidifier-power'], 'ON')
+        assert.equal(props['humidifier-mode'], 'Air Clean')
+        assert.equal(props['humidifier-target_humidity'], 65)
+        assert.equal(props['fan_speed-'], 'Low')
+        assert.equal(props['current_humidity-'], 48)
+        // 0x1fd is half-degrees: wire 55 is 27.5 degC, which is what the cloud read at the time.
+        assert.equal(props['temperature-'], 27.5)
+        assert.equal(props['night_mode-'], 'ON')
+        assert.equal(props['sleep_mode-'], 'OFF')
+        assert.equal(props['auto_strength-'], 'OFF')
+        // The tank was out of its seat during the capture, which is what LG's code 1 means.
+        assert.equal(props['status-'], 'No tank')
+        assert.equal(props['water_lack-'], 'OFF')
+        dev.drop()
+    })
+
+    test('config offers the LG mode and fan vocabularies', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+        const components = ha.devices[DEVICE_ID]!.config!.components as Record<string, Record<string, unknown>>
+        assert.deepEqual(
+            components.humidifier.modes,
+            MODES.map(([label]) => label),
+        )
+        assert.deepEqual(
+            components.fan_speed.options,
+            FANS.map(([label]) => label),
+        )
+        dev.drop()
+    })
+
+    test('every mode code decodes to its Korean label', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+        for (const [label, wire] of MODES) {
+            dev.processKeyValue(0x1f9, wire)
+            assert.equal(ha.devices[DEVICE_ID]!.properties['humidifier-mode'], label)
+        }
+        dev.drop()
+    })
+
+    test('every mode label writes its wire code and turns the appliance on', (t) => {
+        const { thinq, dev } = buildReadyDevice(t)
+        for (const [label, wire] of MODES) {
+            thinq.resetRecorder()
+            dev.setProperty('humidifier-mode', label)
+            assert.deepEqual(writtenFields(thinq), [
+                { t: 0x1f9, v: wire },
+                { t: 0x1f7, v: 1 },
+            ])
+        }
+        dev.drop()
+    })
+
+    test('every fan code decodes, and every fan label writes 0x1fa alone', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+        for (const [label, wire] of FANS) {
+            dev.processKeyValue(0x1fa, wire)
+            assert.equal(ha.devices[DEVICE_ID]!.properties['fan_speed-'], label)
+            thinq.resetRecorder()
+            dev.setProperty('fan_speed-', label)
+            assert.deepEqual(writtenFields(thinq), [{ t: 0x1fa, v: wire }])
+        }
+        dev.drop()
+    })
+
+    test('target humidity snaps to LG’s 5% step', (t) => {
+        const { thinq, dev } = buildReadyDevice(t)
+        dev.setProperty('humidifier-target_humidity', '52')
+        assert.deepEqual(writtenFields(thinq), [{ t: 0x253, v: 50 }])
+        dev.drop()
+    })
+
+    test('auto dry reports and writes LG’s 252 for on, not 1', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+        dev.processKeyValue(0x20e, 252)
+        assert.equal(ha.devices[DEVICE_ID]!.properties['auto_dry-'], 'ON')
+        dev.processKeyValue(0x20e, 0)
+        assert.equal(ha.devices[DEVICE_ID]!.properties['auto_dry-'], 'OFF')
+        thinq.resetRecorder()
+        dev.setProperty('auto_dry-', 'ON')
+        assert.deepEqual(writtenFields(thinq), [{ t: 0x20e, v: 252 }])
+        dev.drop()
+    })
+
+    test('water shortage raises its own binary sensor', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+        const props = ha.devices[DEVICE_ID]!.properties
+        dev.processKeyValue(0x1e3, 2)
+        assert.equal(props['water_lack-'], 'ON')
+        assert.equal(props['status-'], 'Low water')
+        dev.processKeyValue(0x1e3, 0)
+        assert.equal(props['water_lack-'], 'OFF')
+        dev.drop()
+    })
+
+    test('display brightness and air-quality sensor mode round-trip their LG codes', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+        dev.processKeyValue(0x21f, 9)
+        assert.equal(ha.devices[DEVICE_ID]!.properties['display-'], '2Level')
+        thinq.resetRecorder()
+        dev.setProperty('display-', '3Level')
+        assert.deepEqual(writtenFields(thinq), [{ t: 0x21f, v: 10 }])
+
+        dev.processKeyValue(0x337, 1)
+        assert.equal(ha.devices[DEVICE_ID]!.properties['sensor_mon-'], 'Always')
+        dev.drop()
+    })
+})

--- a/tests/cloud/devices/HWWA9K_F2.test.ts
+++ b/tests/cloud/devices/HWWA9K_F2.test.ts
@@ -1,0 +1,307 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/HWWA9K_F2'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'HWWA9K_F2'
+const META: Metadata = { modelId: MODEL_ID, modelName: MODEL_ID, swVersion: '4.5' }
+
+/*
+ * Fixtures.
+ *
+ * STATE is a REAL frame, captured from the appliance on 2026-07-28. Every other frame is that
+ * same frame with ONE byte changed and the checksum recomputed — and each of those was actually
+ * injected into LG's cloud that day, so the expected value below is not a reading of this
+ * driver's own code but what LG's decoder answered. That is the whole point of the oracle: the
+ * fixtures carry LG's verdict, so a wrong offset fails here rather than in the house.
+ */
+
+// Real: docked and fully charged. LG's snapshot for this exact frame read
+// monStatus CHARGING_COMPLETE, cleanMode OFF, filterState NORMAL, passageClogged NORMAL,
+// nozzle IGNORE, batteryLevel NOT_USE, mopWithSucking OFF, completeClean OFF,
+// suctionForce HIGH, chargingMelody MELODY_1, volume HIGH, brightness LOW.
+const STATE = buf('aa14d2eb000c04010101ff00010102010103c3bb')
+
+const MON_CHARGING = buf('aa14d2eb000c03010101ff00010102010103c0bb') // byte[6]=3  -> monStatus CHARGING
+const SUCTION_TURBO = buf('aa14d2eb000c04010101ff00010103010103c2bb') // byte[14]=3 -> suctionForce TURBO
+const BRIGHT_HIGH = buf('aa14d2eb000c04010101ff00010102010102c0bb') // byte[17]=2 -> brightness HIGH
+const NOZZLE_MOP = buf('aa14d2eb000c040101010300010102010103cfbb') // byte[10]=3 -> nozzle WATER_MOP
+// completeClean's OFFSET is from the probe (byte[13]=3 read back as code 3); its ON code is LG's
+// own valueMapping (ON = index 2, and note OFF is 1, not 0).
+const CLEAN_DONE = buf('aa14d2eb000c04010101ff00010202010103c2bb') // byte[13]=2 -> completeClean ON
+
+/*
+ * Real, and the frame that exposed the record-count bug: the appliance's echo after five
+ * settings were written on 2026-07-28. TWO records — previous, then current — under tag
+ * `d2 ec`, where the resting frame uses `d2 eb` and carries one. A decoder keyed on "20 bytes,
+ * tag eb" drops this, which is to say it goes blind at exactly the moment a write lands.
+ *
+ * Its trailing record holds the five values that had just been sent (mopWithSucking 2,
+ * suctionForce 2, chargingMelody 3, volume 3, brightness 4), each on the offset the read probes
+ * had predicted.
+ */
+const ECHO_TWO_RECORDS = buf('aa22d2ec000c04010101ff00020101030304000c04010101ff000201020303049ebb')
+
+// The 44-byte settings frame the appliance also sends. It is a capability list, not values:
+// all four "VC-n" records read 01 while the state frame above says suction 2 and brightness 3.
+// It must therefore be ignored, not decoded.
+const CAPABILITY = buf('aaffd20a002c00005200010a85001a00040456432d31010456432d32010456432d33010456432d34014880bb')
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('publishes only entities the 12-field frame actually fills', () => {
+        const { ha } = makeDevice()
+        const cfg = ha.devices[DEVICE_ID].config
+        assert.ok(cfg, 'config published')
+        const components = cfg!.components as Record<string, Record<string, unknown>>
+        for (const c of [
+            'status',
+            'clean_mode',
+            'suction_force',
+            'battery',
+            'nozzle',
+            'filter_state',
+            'passage',
+            'mop_with_sucking',
+            'charging_melody',
+            'volume',
+            'brightness',
+            'complete_clean',
+        ]) {
+            assert.ok(components[c], `component ${c} present`)
+        }
+        // Twelve fields decoded, twelve entities — no field is published twice and none is
+        // invented. The remaining entries are the generic driver's removals, which carry a
+        // platform and nothing else.
+        const real = Object.values(components).filter((c) => c.unique_id !== undefined)
+        assert.equal(real.length, 12)
+    })
+
+    // Writable exactly where a command frame was captured off LG's own capability API and seen
+    // to take (CL-0000). modelJSON declares five commands for this model and all five are here;
+    // anything else would be a guess.
+    const WRITABLE = new Set(['suction_force', 'mop_with_sucking', 'charging_melody', 'volume', 'brightness'])
+
+    test('exactly the fields with a captured command frame are writable', () => {
+        const { ha } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        for (const [name, comp] of Object.entries(components)) {
+            if (comp.unique_id === undefined) continue // a removal, not an entity
+            if (WRITABLE.has(name)) {
+                assert.equal(comp.command_topic, `$this/${name}/set`, `${name} is writable`)
+                assert.equal(comp.platform, 'select', `${name} is a select`)
+            } else {
+                assert.equal(comp.command_topic, undefined, `${name} stays read-only`)
+                assert.ok(
+                    comp.platform === 'sensor' || comp.platform === 'binary_sensor',
+                    `${name} is a sensor platform, got ${comp.platform}`,
+                )
+            }
+        }
+    })
+
+    test("every select's options are exactly the labels it can report", () => {
+        const { ha } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as Record<
+            string,
+            { platform?: string; options?: string[] }
+        >
+        // A select whose reported state is not among its options is rejected by Home Assistant
+        // and logged, so the two lists have to be the same list.
+        for (const [name, comp] of Object.entries(components)) {
+            if (comp.platform !== 'select') continue
+            assert.ok(comp.options && comp.options.length > 0, `${name} offers options`)
+            for (const o of comp.options!) assert.match(o, /[A-Za-z]/, `${name} option is English: ${o}`)
+        }
+    })
+
+    /*
+     * The frames below are REAL. LG's capability API was asked to change each setting
+     * (`convert/control`; every one answered CL-0000) and these are the cloud→appliance frames
+     * rethink relayed as a result, on 2026-07-28. So the assertion is that this driver emits byte
+     * for byte what LG emits — not that it agrees with its own idea of the format.
+     *
+     * Every option of every command is here, seventeen frames, because a select that ships an
+     * option nobody ever drove is shipping a guess for that option.
+     */
+    test('each write reproduces the frame LG itself sent for that command', () => {
+        for (const [prop, value, want] of [
+            // MOP_SETTING (controlDataType 0x01)
+            ['mop_with_sucking', 'Mop only', 'aa09f0240101019fbb'],
+            ['mop_with_sucking', 'Mop and suction together', 'aa09f0240101029ebb'],
+            // SUCTION_FORCE (0x02)
+            ['suction_force', 'Standard', 'aa09f0240201019ebb'],
+            ['suction_force', 'High', 'aa09f02402010299bb'],
+            ['suction_force', 'Turbo', 'aa09f02402010398bb'],
+            // CHARGING_MELODY (0x03)
+            ['charging_melody', 'Lucky', 'aa09f02403010199bb'],
+            ['charging_melody', 'Marble', 'aa09f02403010298bb'],
+            ['charging_melody', 'Ice', 'aa09f0240301039bbb'],
+            ['charging_melody', 'Breeze', 'aa09f0240301049abb'],
+            ['charging_melody', 'Nebula', 'aa09f02403010585bb'],
+            // VOLUME (0x04)
+            ['volume', 'High', 'aa09f02404010198bb'],
+            ['volume', 'Normal', 'aa09f0240401029bbb'],
+            ['volume', 'Low', 'aa09f0240401039abb'],
+            // BRIGHTNESS (0x05)
+            ['brightness', 'Very bright', 'aa09f0240501019bbb'],
+            ['brightness', 'Bright', 'aa09f0240501029abb'],
+            ['brightness', 'Normal', 'aa09f02405010385bb'],
+            ['brightness', 'Dim', 'aa09f02405010484bb'],
+            ['brightness', 'Off', 'aa09f02405010587bb'],
+        ] as [string, string, string][]) {
+            const { thinq, dev } = makeDevice()
+            thinq.resetRecorder()
+            dev.setProperty(prop, value)
+            assert.equal(thinq.outbox.length, 1, `${prop}=${value} sent one frame`)
+            assert.equal(thinq.outbox[0].toString('hex'), want, `${prop}=${value}`)
+        }
+    })
+
+    test('an unknown option is refused rather than guessed', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('suction_force', 'InvalidForce')
+        dev.setProperty('brightness', 'InvalidBrightness')
+        dev.setProperty('status', 'Charging') // read-only
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('every user-facing name and option is English', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE)
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, { name?: string | null }>
+        for (const [key, comp] of Object.entries(components)) {
+            if (comp.name == null) continue
+            assert.match(comp.name, /[A-Za-z]/, `${key} name is English: ${comp.name}`)
+        }
+        const p = ha.devices[DEVICE_ID].properties
+        for (const key of ['status', 'clean_mode', 'suction_force', 'battery', 'nozzle', 'volume', 'brightness']) {
+            assert.match(String(p[key]), /[A-Za-z]/, `${key} value is English: ${p[key]}`)
+        }
+    })
+
+    test('real captured frame decodes to what LG read from the same frame', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE)
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.status, 'Charging complete')
+        assert.equal(p.clean_mode, 'Off')
+        assert.equal(p.filter_state, 'Normal')
+        assert.equal(p.passage, 'Normal')
+        assert.equal(p.mop_with_sucking, 'Mop only')
+        assert.equal(p.suction_force, 'High')
+        assert.equal(p.charging_melody, 'Lucky')
+        assert.equal(p.volume, 'High')
+        assert.equal(p.brightness, 'Normal')
+        assert.equal(p.complete_clean, 'OFF')
+        // nozzle 0xff and batteryLevel 0 are LG's IGNORE sentinels on this model, not real values.
+        assert.equal(p.nozzle, 'Unknown')
+        assert.equal(p.battery, 'Off')
+    })
+
+    test('each probed offset moves exactly the field LG said it moves', () => {
+        for (const [frame, key, want] of [
+            [MON_CHARGING, 'status', 'Charging'],
+            [SUCTION_TURBO, 'suction_force', 'Turbo'],
+            [BRIGHT_HIGH, 'brightness', 'Bright'],
+            [NOZZLE_MOP, 'nozzle', 'PowerDrive Mop'],
+            [CLEAN_DONE, 'complete_clean', 'ON'],
+        ] as [Buffer, string, string][]) {
+            const { ha, thinq } = makeDevice()
+            thinq.emit('data', STATE)
+            thinq.emit('data', frame)
+            assert.equal(ha.devices[DEVICE_ID].properties[key], want, `${key} after single-byte probe`)
+        }
+    })
+
+    test('a single-byte probe changes nothing else', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE)
+        const before = { ...ha.devices[DEVICE_ID].properties }
+        thinq.emit('data', SUCTION_TURBO)
+        const after = ha.devices[DEVICE_ID].properties
+        for (const key of Object.keys(before)) {
+            if (key === 'suction_force') continue
+            assert.equal(after[key], before[key], `${key} unchanged`)
+        }
+    })
+
+    test('the 44-byte capability frame is ignored, not decoded as state', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE)
+        const before = { ...ha.devices[DEVICE_ID].properties }
+        thinq.emit('data', CAPABILITY)
+        assert.deepEqual(ha.devices[DEVICE_ID].properties, before)
+    })
+
+    test('the two-record echo is read, and its LAST record is the current state', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE)
+        thinq.emit('data', ECHO_TWO_RECORDS)
+        const p = ha.devices[DEVICE_ID].properties
+        // The trailing record's five settings, not the leading record's (which still says
+        // mopWithSucking 1 and suctionForce 1).
+        assert.equal(p.mop_with_sucking, 'Mop and suction together')
+        assert.equal(p.suction_force, 'High')
+        assert.equal(p.charging_melody, 'Ice')
+        assert.equal(p.volume, 'Low')
+        assert.equal(p.brightness, 'Dim')
+        // ...and the rest of the record still decodes on the same offsets.
+        assert.equal(p.status, 'Charging complete')
+        assert.equal(p.clean_mode, 'Off')
+        assert.equal(p.battery, 'Off')
+        assert.equal(p.nozzle, 'Unknown')
+    })
+
+    test('a code the table does not list leaves the select where it was', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE)
+        assert.equal(ha.devices[DEVICE_ID].properties.suction_force, 'High')
+        const odd = Buffer.from(STATE)
+        odd[14] = 9 // not a suctionForce code; publishing it would be an invalid select state
+        odd[odd.length - 2] = (odd.subarray(0, odd.length - 2).reduce((a, c) => a + c, 0) & 0xff) ^ 0x55
+        thinq.emit('data', odd)
+        assert.equal(ha.devices[DEVICE_ID].properties.suction_force, 'High')
+    })
+
+    test('a frame whose field count is not 12 is left alone', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE)
+        const before = { ...ha.devices[DEVICE_ID].properties }
+        const short = Buffer.from(STATE)
+        short[5] = 3 // a different record shape; decoding it with this map would publish nonsense
+        thinq.emit('data', short)
+        assert.deepEqual(ha.devices[DEVICE_ID].properties, before)
+    })
+})
+
+/*
+ * Two failure modes that are invisible from the add-on side: Home Assistant accepts the
+ * discovery payload, writes the entity into its registry, and then never creates it. Both cost
+ * real entities on the first live rebuild of these drivers, so both are pinned here and in the
+ * styler's and purifier's suites.
+ */
+describe(`${MODEL_ID} discovery contract`, () => {
+    test("no read-only component claims entity_category 'config'", () => {
+        const ha = new MockHAConnection()
+        const thinq = new MockThinq2Device(DEVICE_ID, META)
+        new DUT(ha.asConnection(), thinq, META)
+        const components = ha.devices[DEVICE_ID].config!.components as Record<
+            string,
+            { platform?: string; entity_category?: string }
+        >
+        for (const [name, comp] of Object.entries(components)) {
+            if (comp.platform !== 'sensor' && comp.platform !== 'binary_sensor') continue
+            assert.notEqual(comp.entity_category, 'config', `${name} must not be entity_category 'config'`)
+        }
+    })
+})

--- a/tests/cloud/devices/ST_B_E4H01Y_APL.test.ts
+++ b/tests/cloud/devices/ST_B_E4H01Y_APL.test.ts
@@ -1,0 +1,657 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/ST_B_E4H01Y_APL'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'ST_B_E4H01Y_APL'
+const META: Metadata = { modelId: MODEL_ID, modelName: MODEL_ID, swVersion: '2.11.255' }
+
+/*
+ * Fixtures.
+ *
+ * STATE and STATE2 are REAL frames captured from the appliance on 2026-07-28 (same content,
+ * different sequence number). The rest are STATE with ONE byte changed and the CRC16 recomputed;
+ * every one of them was injected into LG's cloud that day, so what each test expects is LG's own
+ * decode of that exact frame.
+ */
+
+// Real, appliance idle. LG read this as state POWEROFF, preState INITIAL, course NONE,
+// error ERROR_NO, childLock OFF, buzzer BUZZER_4, applyBuzzer ON, applyRemoteMaintain ON,
+// remoteMaintain OFF, endMelody END_MELODY_0, currentDownloadCourse1 FUR_LEATHER (78),
+// currentDownloadCourseCount 1, TCLCount 37, energyMonitoring 0.
+const STATE = buf(
+    'aaff310a003a0053ea000100eb002800000000010001000001000000000000200000000000000000014e420000040300000000000000257205bb',
+)
+const STATE2 = buf(
+    'aaff310a003a005504000100eb002800000000010001000001000000000000200000000000000000014e420000040300000000000000251351bb',
+)
+
+const READY = buf(
+    'aaff310a003a0053ea000100eb002800000100010001000001000000000000200000000000000000014e42000004030000000000000025969ebb',
+) // byte[17]=1 -> state INITIAL
+const COURSE_STANDARD = buf(
+    'aaff310a003a0053ea000100eb002800000000010001010001000000000000200000000000000000014e42000004030000000000000025ffd9bb',
+) // byte[22]=1 -> course STANDARD (id 1)
+const ERROR_TE1 = buf(
+    'aaff310a003a0053ea000100eb002800000000010001000101000000000000200000000000000000014e420000040300000000000000252b43bb',
+) // byte[23]=1 -> error ERROR_TE1
+const PRESTATE_RUNNING = buf(
+    'aaff310a003a0053ea000100eb002800000000010001000002000000000000200000000000000000014e42000004030000000000000025f05fbb',
+) // byte[24]=2 -> preState RUNNING
+const FLAGS_A_ALL = buf(
+    'aaff310a003a0053ea000100eb0028000000000100010000010000000000000f0000000000000000014e42000004030000000000000025df93bb',
+) // byte[31]=0x0f -> childLock + nightDry + initialBit + remoteStart all ON
+const REMOTE_MAINTAIN = buf(
+    'aaff310a003a0053ea000100eb002800000000010001000001000000000000200000000000000000014e42000004040000000000000025c3aebb',
+) // byte[46]=0x04 -> remoteMaintain ON (and both apply* bits cleared)
+const FLAGS_C_ALL = buf(
+    'aaff310a003a0053ea000100eb002800000000010001000001000000000000200000000000000000014e420000040300003f0000000025988abb',
+) // byte[49]=0x3f -> isLastCourse + 3x smartCare + smartPairing + currentTimeDisplay all ON
+const BUZZER_LOW = buf(
+    'aaff310a003a0053ea000100eb002800000000010001000001000000000000200000000000000000014e42000001030000000000000025b075bb',
+) // byte[45]=1 -> buzzer BUZZER_1
+const MELODY_1 = buf(
+    'aaff310a003a0053ea000100eb002800000000010001000001000000000000200000000000000000014e4200000403010000000000002535d6bb',
+) // byte[47]=1 -> endMelody END_MELODY_1
+const ENERGY_HI = buf(
+    'aaff310a003a0053ea000100eb002800000000010001000001000000000000200000010000000000014e42000004030000000000000025a7f3bb',
+) // byte[34]=1 -> energyMonitoring 256, i.e. the byte is the high half of a 16-bit value
+const SMART_COURSE_1 = buf(
+    'aaff310a003a0053ea000100eb002800000000010001000001000000000000200000000000010000014e420000040300000000000000258234bb',
+) // byte[37]=1 -> smartCourse PAIRING_PANEL_COURSE (id 1)
+const TCL_1 = buf(
+    'aaff310a003a0053ea000100eb002800000000010001000001000000000000200000000000000000014e4200000403000000000000000116e3bb',
+) // byte[54]=1 -> TCLCount 1
+
+// REAL 98-byte two-record frames, captured 2026-07-28 the moment the appliance was switched on and
+// a course selected. LG read these as state INITIAL, course STANDARD, remoteStart ON — while a
+// decoder keyed on "58 bytes" was still publishing Power off off the last idle frame. Record B (the
+// trailing one) is the current state.
+const RUNNING_READY = buf(
+    'aaff310a0062005cd0000100ec005000000000010001000001000000000000200000000000000000014e4200000403000000000000002500000100010001000000000000000000200000000000000000014e42000004030000000000000025ee3ebb',
+) // record B: state 1 (Standby)
+const RUNNING_COURSE = buf(
+    'aaff310a0062005ce5000100ec0050000001011e011e0f0000000000000000280000000000000000014e4200000403000000000000002500000100230023010000000000000000280000000000000000014e42000004030000000000000025042abb',
+) // record B: state 1, course 1 (Styling Standard), 35 min, flagsA 0x28 -> remoteStart ON
+// The downloadable-course name list — 112 bytes, which is NOT a whole number of 40-byte records.
+const COURSE_LIST = buf(
+    'aaff310a0070005ccc00010a86005e0d053230332d3101073230332d312d3101073230332d312d3201073230332d312d3301073230332d312d34010453542d34010453542d35010453542d36010453542d37010453542d38010453542d39010553542d3130000553542d313201ed79bb',
+)
+
+// The 35-byte frame shares the header but is NOT state: probing bytes 9..31 of it with 0xff moved
+// no field in LG's snapshot at all.
+const NOT_STATE_35 = buf('aaff310a00230053ed000101030011100b0306100000008a00000000000000059317bb')
+// Heartbeat.
+const HEARTBEAT = buf('aa0731c302f2bb')
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    /*
+     * Writable exactly where a command frame was captured off LG's own capability API and seen to
+     * take (CL-0000). Deliberately absent: `remoteControlStatus setRemoteControlType`, which
+     * answers CL-0000 but sends the SAME frame for on and off, and course start/pause/resume,
+     * which were never driven — an entity for either would be a control that guesses.
+     */
+    const WRITABLE = new Set([
+        'power',
+        'buzzer',
+        'end_melody',
+        'keep_last_course',
+        'smart_care_finedust',
+        'smart_care_humidity',
+        'smart_care_nightcare',
+        'night_care_start',
+        'night_care_end',
+        'remote_maintain',
+        'course_select',
+        'start_course',
+        'pause_course',
+        'resume_course',
+    ])
+
+    test('exactly the fields with a captured command frame are writable', () => {
+        const { ha } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        for (const [name, comp] of Object.entries(components)) {
+            if (comp.unique_id === undefined) continue // a removal, not an entity
+            if (WRITABLE.has(name)) {
+                assert.equal(comp.command_topic, `$this/${name}/set`, `${name} is writable`)
+            } else if (comp.platform === 'button') {
+                assert.fail(`${name} is a button with no command topic`)
+            } else {
+                assert.equal(comp.command_topic, undefined, `${name} stays read-only`)
+                assert.ok(
+                    comp.platform === 'sensor' || comp.platform === 'binary_sensor',
+                    `${name} is a sensor platform, got ${comp.platform}`,
+                )
+            }
+        }
+    })
+
+    /*
+     * The frames below are REAL. LG's capability API was asked to make each change
+     * (`convert/control`; every one answered CL-0000, and the appliance ACKed each with
+     * `aa 08 31 00 24 00 …`) and these are the cloud→appliance frames rethink relayed as a
+     * result, on 2026-07-28. So the assertion is that this driver emits byte for byte what LG
+     * emits — not that it agrees with its own idea of the format.
+     *
+     * Every option of every enum is here, because a select that offers an option nobody ever
+     * drove is shipping a guess for that option.
+     */
+    test('each write reproduces the frame LG itself sent for that command', () => {
+        for (const [prop, value, want] of [
+            // POWERON / POWEROFF (controlDataType 0x01)
+            ['power', 'ON', 'aa09f0240101019fbb'],
+            ['power', 'OFF', 'aa09f0240101009cbb'],
+            // UPCENTER 0x13, sub 0x01 ENDMELODY — the value is the melody's index
+            ['end_melody', 'Default sound', 'aa0af0241301010088bb'],
+            ['end_melody', 'Vivaldi Winter', 'aa0af024130101018bbb'],
+            ['end_melody', 'Bach Minuet', 'aa0af024130101028abb'],
+            ['end_melody', 'Home Sweet Home', 'aa0af02413010103b5bb'],
+            ['end_melody', 'Breeze', 'aa0af02413010104b4bb'],
+            ['end_melody', 'Old MacDonald', 'aa0af02413010105b7bb'],
+            ['end_melody', 'Verdi Brindisi', 'aa0af02413010106b6bb'],
+            ['end_melody', 'Bubble', 'aa0af02413010107b1bb'],
+            ['end_melody', 'Beethoven Symphony No.5 5', 'aa0af02413010108b0bb'],
+            ['end_melody', 'Arirang', 'aa0af02413010109b3bb'],
+            ['end_melody', 'Pachelbel Canon', 'aa0af0241301010ab2bb'],
+            ['end_melody', 'Beethoven Choral', 'aa0af0241301010bbdbb'],
+            // sub 0x03 UPBUZZER
+            ['buzzer', 'Mute', 'aa0af024130103008abb'],
+            ['buzzer', 'Small', 'aa0af02413010301b5bb'],
+            ['buzzer', 'Normal', 'aa0af02413010302b4bb'],
+            ['buzzer', 'Large', 'aa0af02413010303b7bb'],
+            ['buzzer', 'Very large', 'aa0af02413010304b6bb'],
+            // subs 0x04 / 0x05 / 0x06 — the three smart-care flags
+            ['smart_care_finedust', 'ON', 'aa0af02413010401b4bb'],
+            ['smart_care_finedust', 'OFF', 'aa0af02413010400b5bb'],
+            ['smart_care_humidity', 'ON', 'aa0af02413010501b7bb'],
+            ['smart_care_humidity', 'OFF', 'aa0af02413010500b4bb'],
+            ['smart_care_nightcare', 'ON', 'aa0af02413010601b6bb'],
+            ['smart_care_nightcare', 'OFF', 'aa0af02413010600b7bb'],
+            // sub 0x09 CTRL_IS_LAST_COURSE
+            ['keep_last_course', 'ON', 'aa0af02413010901b3bb'],
+            ['keep_last_course', 'OFF', 'aa0af02413010900b0bb'],
+        ] as [string, string, string][]) {
+            const { thinq, dev } = makeDevice()
+            thinq.resetRecorder()
+            dev.setProperty(prop, value)
+            assert.equal(thinq.outbox.length, 1, `${prop}=${value} sent one frame`)
+            assert.equal(thinq.outbox[0].toString('hex'), want, `${prop}=${value}`)
+        }
+    })
+
+    /*
+     * Remote control allowed has no LG-emitted ON frame: setRemoteControlType answers CL-0000 for every
+     * argument and always emits the OFF frame. The ON frame below was built and sent to the
+     * appliance directly on 2026-07-28; it ACKed (`aa 08 31 00 24 00`) and the next state frame
+     * came back with the bit set, which is the appliance confirming it and not a guess.
+     */
+    test('Remote control allowed writes the frame the appliance acknowledged', () => {
+        for (const [value, want] of [
+            ['ON', 'aa09f0241001018cbb'],
+            ['OFF', 'aa09f0241001008dbb'],
+        ] as [string, string][]) {
+            const { thinq, dev } = makeDevice()
+            thinq.resetRecorder()
+            dev.setProperty('remote_maintain', value)
+            assert.equal(thinq.outbox[0].toString('hex'), want, `remote_maintain=${value}`)
+        }
+    })
+
+    /*
+     * REAL start frames: LG's converter was asked to run Standard and Quick
+     * (`operationState startCycle {"cycle":{"id":"1"}}` / `"3"`, both CL-0000) and these are the
+     * frames rethink relayed, on 2026-07-28. The appliance ran the course each time.
+     *
+     * Only two of the twenty-one courses were driven, and the rest of the table is the same rule
+     * applied to the same modelJSON declaration — so these two are what proves the rule, and
+     * they have to match to the byte, checksum included.
+     */
+    test('Start course reproduces the frame LG itself sent, for both captured courses', () => {
+        for (const [course, want] of [
+            [
+                'Styling Standard',
+                'aa34f02601010004000000000002645a00000005005a05b45a01b4001ab40000000000000000000000000000000000000000fabb',
+            ],
+            [
+                'Styling Quick',
+                'aa34f02603010004000000000082645a00000003005a00000001b4000eb4000000000000000000000000000000000000000045bb',
+            ],
+        ] as [string, string][]) {
+            const { thinq, dev } = makeDevice()
+            dev.setProperty('course_select', course)
+            thinq.resetRecorder()
+            dev.setProperty('start_course', '')
+            assert.equal(thinq.outbox.length, 1, `${course} sent one frame`)
+            assert.equal(thinq.outbox[0].toString('hex'), want, course)
+        }
+    })
+
+    test('Pause and Resume reproduce their captured frames', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('course_select', 'Styling Standard')
+        thinq.resetRecorder()
+        dev.setProperty('pause_course', '')
+        // PAUSE, LG's controlDataType 0x04, value 0 — exactly modelJSON's pauseCourse dataForm
+        assert.equal(thinq.outbox[0].toString('hex'), 'aa09f02404010099bb')
+        thinq.resetRecorder()
+        dev.setProperty('resume_course', '')
+        assert.equal(
+            thinq.outbox[0].toString('hex'),
+            'aa33f026010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a1bb',
+        )
+    })
+
+    test('a write shows up straight away instead of waiting for the appliance', () => {
+        // The appliance reports on its own schedule — a course start can go a minute without a
+        // state frame — so a control that waits for confirmation reads as broken and gets
+        // pressed twice. What is published here is overwritten by the next real frame.
+        const { ha, thinq, dev } = makeDevice()
+        const enabled = Buffer.from(READY)
+        enabled[49] |= 0x08 // smartCareNightCare ON
+        thinq.emit('data', enabled)
+        dev.setProperty('buzzer', 'Small')
+        dev.setProperty('smart_care_humidity', 'ON')
+        dev.setProperty('night_care_start', '22:30')
+        dev.setProperty('course_select', 'Styling Standard')
+        dev.setProperty('start_course', '')
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.buzzer, 'Small')
+        assert.equal(p.smart_care_humidity, 'ON')
+        assert.equal(p.night_care_start, '22:30')
+        assert.equal(p.course, 'Styling Standard')
+        // ...and the appliance still has the last word.
+        thinq.emit('data', enabled)
+        assert.equal(p.buzzer, 'Very large')
+        assert.equal(p.course, 'None')
+    })
+
+    test('a setting rejected while powered off is not optimistically published', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', STATE)
+        thinq.resetRecorder()
+
+        dev.setProperty('buzzer', 'Small')
+        dev.setProperty('smart_care_humidity', 'ON')
+        dev.setProperty('course_select', 'Styling Standard')
+        dev.setProperty('start_course', '')
+
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(thinq.outbox.length, 3, 'commands are still sent so the appliance has the final say')
+        assert.equal(p.buzzer, 'Very large')
+        assert.equal(p.smart_care_humidity, 'OFF')
+        assert.equal(p.course, 'None')
+        assert.equal(p.course_select, 'Styling Standard', 'the local-only course choice still updates')
+    })
+
+    test('night-care times rejected while night care is disabled are not optimistically published', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', READY)
+        thinq.resetRecorder()
+
+        dev.setProperty('night_care_start', '22:30')
+        dev.setProperty('night_care_end', '06:00')
+
+        assert.equal(thinq.outbox.length, 2, 'valid command frames are still sent')
+        assert.equal(ha.devices[DEVICE_ID].properties.night_care_start, '00:00')
+        assert.equal(ha.devices[DEVICE_ID].properties.night_care_end, '00:00')
+    })
+
+    test('no setting is optimistically published before the first authoritative state', () => {
+        const { ha, thinq, dev } = makeDevice()
+        dev.setProperty('buzzer', 'Small')
+        dev.setProperty('course_select', 'Styling Standard')
+        dev.setProperty('start_course', '')
+
+        assert.equal(thinq.outbox.length, 2, 'valid frames still reach the appliance')
+        assert.equal(ha.devices[DEVICE_ID].properties.buzzer, undefined)
+        assert.equal(ha.devices[DEVICE_ID].properties.course, undefined)
+        assert.equal(ha.devices[DEVICE_ID].properties.course_select, 'Styling Standard')
+    })
+
+    test('a course rejected by a standing error is not optimistically published', () => {
+        const { ha, thinq, dev } = makeDevice()
+        const poweredError = Buffer.from(ERROR_TE1)
+        poweredError[17] = 1 // state INITIAL: powered on while error TE1 is standing
+        thinq.emit('data', poweredError)
+        thinq.resetRecorder()
+
+        dev.setProperty('course_select', 'Styling Standard')
+        dev.setProperty('start_course', '')
+
+        assert.equal(thinq.outbox.length, 1, 'the appliance still receives the valid course frame')
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.problem, 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'None')
+    })
+
+    test('Course select chooses without commanding the appliance', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('course_select', 'Sterilize Standard')
+        assert.equal(thinq.outbox.length, 0, 'selecting sends nothing')
+        assert.equal(ha.devices[DEVICE_ID].properties.course_select, 'Sterilize Standard')
+        // ...and Start course then runs the one that was chosen.
+        dev.setProperty('start_course', '')
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(thinq.outbox[0][4], 11, 'course id 11 leads the block')
+    })
+
+    test('a course the appliance is running takes over the selection', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', COURSE_STANDARD)
+        assert.equal(ha.devices[DEVICE_ID].properties.course_select, 'Styling Standard')
+        // Idle it reports NONE, which is no course at all — the last choice has to stand.
+        thinq.emit('data', STATE)
+        assert.equal(ha.devices[DEVICE_ID].properties.course_select, 'Styling Standard')
+    })
+
+    test('an unknown course is refused rather than started', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('course_select', 'InvalidCourse')
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('the night-care window writes hour and minute in one frame', () => {
+        for (const [prop, value, want] of [
+            // subs 0x07 / 0x08, valueLength 2 — exactly as LG's own setStartTime/setEndTime sent them
+            ['night_care_start', '23:30', 'aa0bf024130207171e4fbb'],
+            ['night_care_start', '00:00', 'aa0bf0241302070000b0bb'],
+            ['night_care_end', '06:00', 'aa0bf0241302080600b9bb'],
+            ['night_care_end', '00:00', 'aa0bf0241302080000b3bb'],
+        ] as [string, string, string][]) {
+            const { thinq, dev } = makeDevice()
+            thinq.resetRecorder()
+            dev.setProperty(prop, value)
+            assert.equal(thinq.outbox[0].toString('hex'), want, `${prop}=${value}`)
+        }
+    })
+
+    test('a time the appliance would refuse is not written', () => {
+        // LG's own schema is `^(0[0-9]|1[0-9]|2[0-3]):(00|30)$` — whole and half hours only.
+        for (const bad of ['23:45', '24:00', '9:30', 'abc', '', '07:1']) {
+            const { thinq, dev } = makeDevice()
+            thinq.resetRecorder()
+            dev.setProperty('night_care_start', bad)
+            assert.equal(thinq.outbox.length, 0, `refused ${JSON.stringify(bad)}`)
+        }
+    })
+
+    test('an unknown option is refused rather than guessed', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('buzzer', 'InvalidVolume')
+        dev.setProperty('end_melody', 'Jingle Bells (intro)') // a read label, but not one LG offers here
+        dev.setProperty('course', 'Styling Standard') // read-only
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('the power switch reports OFF as soon as it is switched off', () => {
+        // Powered off, this appliance stops sending any frame this driver can decode, so a switch
+        // that waited for confirmation would never leave ON.
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', READY)
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
+        dev.setProperty('power', 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'OFF')
+        // ...and a real frame still has the last word.
+        thinq.emit('data', READY)
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
+    })
+
+    test('every user-facing name and enum option is English', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE)
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, { name?: string | null }>
+        for (const [key, comp] of Object.entries(components)) {
+            if (comp.name == null) continue
+            assert.match(comp.name, /[A-Za-z]/, `${key} name is English: ${comp.name}`)
+        }
+        const p = ha.devices[DEVICE_ID].properties
+        for (const key of ['status', 'previous_status', 'course', 'smart_course', 'buzzer', 'end_melody', 'error']) {
+            assert.match(String(p[key]), /[A-Za-z]/, `${key} value is English: ${p[key]}`)
+        }
+    })
+
+    test('real captured frame decodes to what LG read from the same frame', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE)
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.status, 'Power off')
+        assert.equal(p.previous_status, 'Standby')
+        assert.equal(p.course, 'None')
+        assert.equal(p.smart_course, 'None')
+        assert.equal(p.error, 'Normal')
+        assert.equal(p.remaining, 1)
+        assert.equal(p.total, 1)
+        assert.equal(p.reserved_at, 'No reservation')
+        assert.equal(p.child_lock, 'OFF')
+        assert.equal(p.night_dry, 'OFF')
+        assert.equal(p.remote_start, 'OFF')
+        assert.equal(p.remote_maintain, 'OFF')
+        assert.equal(p.buzzer, 'Very large')
+        assert.equal(p.end_melody, 'Default sound')
+        assert.equal(p.smart_care_finedust, 'OFF')
+        assert.equal(p.smart_care_humidity, 'OFF')
+        assert.equal(p.smart_care_nightcare, 'OFF')
+        assert.equal(p.keep_last_course, 'OFF')
+        assert.equal(p.night_care_start, '00:00')
+        assert.equal(p.night_care_end, '00:00')
+        assert.equal(p.power, 'OFF')
+        assert.equal(p.tcl_count, 37)
+        assert.equal(p.energy, 0)
+        // Slot 1 holds course id 78, which LG names FUR_LEATHER.
+        assert.equal(p.download_course, 'Fur/Leather Care')
+    })
+
+    test('a second real frame with a different sequence number decodes identically', () => {
+        const { ha: a, thinq: ta } = makeDevice()
+        ta.emit('data', STATE)
+        const { ha: b, thinq: tb } = makeDevice()
+        tb.emit('data', STATE2)
+        assert.deepEqual(b.devices[DEVICE_ID].properties, a.devices[DEVICE_ID].properties)
+    })
+
+    test('each probed offset moves exactly the field LG said it moves', () => {
+        for (const [frame, key, want] of [
+            [READY, 'status', 'Standby'],
+            [COURSE_STANDARD, 'course', 'Styling Standard'],
+            [ERROR_TE1, 'error', 'TE1'],
+            [PRESTATE_RUNNING, 'previous_status', 'Styling'],
+            [BUZZER_LOW, 'buzzer', 'Small'],
+            [MELODY_1, 'end_melody', 'Vivaldi Winter'],
+            [ENERGY_HI, 'energy', 256],
+            [SMART_COURSE_1, 'smart_course', 'Panel course'],
+            [TCL_1, 'tcl_count', 1],
+            [REMOTE_MAINTAIN, 'remote_maintain', 'ON'],
+        ] as [Buffer, string, string | number][]) {
+            const { ha, thinq } = makeDevice()
+            thinq.emit('data', STATE)
+            thinq.emit('data', frame)
+            assert.equal(ha.devices[DEVICE_ID].properties[key], want, `${key} after single-byte probe`)
+        }
+    })
+
+    /*
+     * The state codes are not the declaration order, and believing they were is what published
+     * `Code 52` while the appliance was mid-course. Each pair below was measured by injecting that
+     * code and reading LG's own name back on 2026-07-28; 10..49 answered NOT_DEFINE_VALUE.
+     */
+    test('the running-state codes decode, not just the idle ones', () => {
+        for (const [code, want] of [
+            [0, 'Power off'],
+            [3, 'Pause'],
+            [9, 'Power-save running'],
+            [50, 'Steam preparing'], // PRESTEAM
+            [52, 'Refreshing'], // STEAM
+            [55, 'Drying'], // DRYING
+            [57, 'Sterilizing'], // STERILIZE
+            [58, 'Course complete'], // RUNNINGEND
+        ] as [number, string][]) {
+            const { ha, thinq } = makeDevice()
+            const frame = Buffer.from(STATE)
+            frame[17] = code
+            thinq.emit('data', frame)
+            assert.equal(ha.devices[DEVICE_ID].properties.status, want, `state ${code}`)
+        }
+    })
+
+    test('a code LG itself does not define is shown as a code, not as a wrong name', () => {
+        const { ha, thinq } = makeDevice()
+        const frame = Buffer.from(STATE)
+        frame[17] = 20 // NOT_DEFINE_VALUE on this model
+        thinq.emit('data', frame)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Code 20')
+    })
+
+    /*
+     * Same lesson as the state codes: LG's Error table skips values, so a positional reading
+     * drifts from E2 onward. Each pair was measured by injection on 2026-07-28.
+     */
+    test('the error codes decode, and Water refill is not off by one', () => {
+        for (const [code, want, problem] of [
+            [0, 'Normal', 'OFF'],
+            [8, 'Water refill', 'ON'], // ERROR_E3 — the one that stops a course every day
+            [11, 'AE', 'ON'],
+            [18, 'LE', 'ON'],
+            [23, 'Normal', 'OFF'], // ERROR_NONE, LG's second way of saying nothing is wrong
+            [25, 'Water drain', 'ON'],
+            [26, 'Door open', 'ON'],
+            [34, 'No filter', 'ON'],
+            [12, 'Code 12', 'ON'], // NOT_DEFINE_VALUE on this model
+        ] as [number, string, string][]) {
+            const { ha, thinq } = makeDevice()
+            const frame = Buffer.from(STATE)
+            frame[23] = code
+            thinq.emit('data', frame)
+            const p = ha.devices[DEVICE_ID].properties
+            assert.equal(p.error, want, `error ${code}`)
+            assert.equal(p.problem, problem, `problem for error ${code}`)
+        }
+    })
+
+    test('byte 31 is a bitfield, not an enum', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', FLAGS_A_ALL)
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.child_lock, 'ON')
+        assert.equal(p.night_dry, 'ON')
+        assert.equal(p.remote_start, 'ON')
+        // Bit 0x04 (initialBit) is LG's internal first-boot marker and gets no entity; bit 0x20,
+        // set in every captured frame, moved no field and is deliberately not decoded.
+    })
+
+    test('byte 49 is a bitfield carrying six independent flags', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', FLAGS_C_ALL)
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.smart_care_finedust, 'ON')
+        assert.equal(p.smart_care_humidity, 'ON')
+        assert.equal(p.smart_care_nightcare, 'ON')
+        assert.equal(p.keep_last_course, 'ON')
+    })
+
+    test('the night-care window reads back as two clock times', () => {
+        const { ha, thinq } = makeDevice()
+        const scheduled = Buffer.from(STATE)
+        scheduled[50] = 23 // nightCareStartTime_Hour
+        scheduled[51] = 30 // nightCareStartTime_Minute
+        scheduled[52] = 6 // nightCareEndTime_Hour
+        scheduled[53] = 0 // nightCareEndTime_Minute
+        thinq.emit('data', scheduled)
+        assert.equal(ha.devices[DEVICE_ID].properties.night_care_start, '23:30')
+        assert.equal(ha.devices[DEVICE_ID].properties.night_care_end, '06:00')
+    })
+
+    test('the retired night-care summary is published as a removal', () => {
+        const { ha } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        // Its two settable halves replace it, but dropping it from the config would leave the old
+        // entity behind, frozen at whatever it last read.
+        assert.deepEqual(components.night_care_window, { platform: 'sensor' })
+    })
+
+    test('the 35-byte frame and the heartbeat carry no state', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE)
+        const before = { ...ha.devices[DEVICE_ID].properties }
+        thinq.emit('data', NOT_STATE_35)
+        thinq.emit('data', HEARTBEAT)
+        assert.deepEqual(ha.devices[DEVICE_ID].properties, before)
+    })
+
+    test('hours and minutes are folded into one duration', () => {
+        const { ha, thinq } = makeDevice()
+        const running = Buffer.from(STATE)
+        running[18] = 1 // remainTimeHour
+        running[19] = 25 // remainTimeMinute
+        running[20] = 2 // initialTimeHour
+        running[21] = 0 // initialTimeMinute
+        thinq.emit('data', running)
+        assert.equal(ha.devices[DEVICE_ID].properties.remaining, 85)
+        assert.equal(ha.devices[DEVICE_ID].properties.total, 120)
+    })
+
+    test('a two-record frame is decoded, and it is the LAST record that counts', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE) // idle: 58 bytes, one record
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Power off')
+        thinq.emit('data', RUNNING_READY)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Standby', 'the 98-byte frame must decode')
+        thinq.emit('data', RUNNING_COURSE)
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.status, 'Standby')
+        assert.equal(p.course, 'Styling Standard')
+        assert.equal(p.remaining, 35)
+        assert.equal(p.total, 35)
+        // flagsA 0x28 = the always-set 0x20 bit | 0x08 remoteStart
+        assert.equal(p.remote_start, 'ON')
+        assert.equal(p.child_lock, 'OFF')
+    })
+
+    test('the course-name list frame is not mistaken for state', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE)
+        const before = { ...ha.devices[DEVICE_ID].properties }
+        thinq.emit('data', COURSE_LIST)
+        assert.deepEqual(ha.devices[DEVICE_ID].properties, before)
+    })
+
+    test('a set reservation reads as a clock time', () => {
+        const { ha, thinq } = makeDevice()
+        const reserved = Buffer.from(STATE)
+        reserved[29] = 7
+        reserved[30] = 5
+        thinq.emit('data', reserved)
+        assert.equal(ha.devices[DEVICE_ID].properties.reserved_at, '07:05')
+    })
+})
+
+/*
+ * Two failure modes that are invisible from the add-on side: Home Assistant accepts the
+ * discovery payload, writes the entity into its registry, and then never creates it. Both cost
+ * real entities on the first live rebuild of these drivers.
+ */
+describe(`${MODEL_ID} discovery contract`, () => {
+    test("no read-only component claims entity_category 'config'", () => {
+        const { ha } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as Record<
+            string,
+            { platform?: string; entity_category?: string }
+        >
+        for (const [name, comp] of Object.entries(components)) {
+            if (comp.platform !== 'sensor' && comp.platform !== 'binary_sensor') continue
+            assert.notEqual(comp.entity_category, 'config', `${name} must not be entity_category 'config'`)
+        }
+    })
+})

--- a/tests/cloud/devices/washtower_common.test.ts
+++ b/tests/cloud/devices/washtower_common.test.ts
@@ -1,0 +1,1185 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import Washer from '@/cloud/devices/FAKPK21021'
+import Dryer from '@/cloud/devices/BDH_D39301_KR'
+import {
+    buildWashtowerControlFrame,
+    buildWashtowerDownloadPayload,
+    buildWashtowerExtendedFrame,
+    buildWashtowerStartPayload,
+    DRYER_MODEL,
+    isWashtowerPowerOnSuccess,
+    selectCurrentWashtowerRecord,
+    WASHER_MODEL,
+    WASHTOWER_IMPLEMENTATION_MANIFEST,
+    WASH_TOWER_SIMPLE_CONTROLS,
+    type WashTowerModel,
+} from '@/cloud/devices/washtower_common'
+import type HADevice from '@/cloud/devices/base'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device } from '@/tests/helpers/mocks'
+
+// 2026-07-28 running add-on log, packet-only sanitized (no UUID/SSID/secret).
+const WASHER_EB = Buffer.from(
+    'aaff330a005500bc84000100eb004300000000000000000000000000000000000002005e01009a000000001a0400000000000000410000300000000000000400006000000000000000f00000000408000000fc1cbb',
+    'hex',
+)
+const DRYER_EB = Buffer.from(
+    'aaff340a0044006320000100eb003200000000000000000000000000000100000000040000008f20000000070000870100000000000000000000000000000000008343bb',
+    'hex',
+)
+const DRYER_EC = Buffer.from(
+    'aaff340a0076008217000100ec006400000000000000000000000000010000000000040000008f200000800700008701000000000000000000000000000000000000000000000000000000000000010000000000040000008f20000082070000870100000000000000000000000000000000008320bb',
+    'hex',
+)
+const DRYER_POWER_ON_E6 = Buffer.from(
+    'aa3f34e6000201ff01020000000000000000000000000000000100000000040000008f00000000070000870100000000000000000000000000000000007ebb',
+    'hex',
+)
+
+function make(
+    Driver: new (HA: ReturnType<MockHAConnection['asConnection']>, thinq: MockThinq2Device, meta: Metadata) => HADevice,
+    modelId: string,
+    ha = new MockHAConnection(),
+) {
+    const meta: Metadata = {
+        modelId,
+        modelName: modelId,
+        swVersion: 'test',
+    }
+    const thinq = new MockThinq2Device('test-device', meta)
+    const dev = new Driver(ha.asConnection(), thinq, meta)
+    return { ha, thinq, dev }
+}
+
+function setRaw(record: Buffer, model: WashTowerModel, key: string, raw: number) {
+    const field = model.fields.find((candidate) => candidate.key === key)!
+    if (field.bit === undefined) {
+        record.writeUIntBE(raw, field.offset, field.length)
+    } else {
+        const width = field.bits || 1
+        const mask = ((1 << width) - 1) << field.bit
+        record[field.offset] = (record[field.offset] & ~mask) | ((raw << field.bit) & mask)
+    }
+}
+
+function label(model: WashTowerModel, key: string, raw: number) {
+    return model.fields.find((field) => field.key === key)!.values![String(raw)]
+}
+
+function powerOnResponse(model: WashTowerModel, returnCode = 0, snapshot = Buffer.alloc(0)) {
+    const frame = Buffer.concat([
+        Buffer.from([0xaa, 13 + snapshot.length, model.tag, 0xe6, 0x00, 0x02, 0x01, 0xff, 0x01, 0x02, returnCode]),
+        snapshot,
+        Buffer.from([0, 0xbb]),
+    ])
+    frame[frame.length - 2] = (frame.subarray(0, -2).reduce((sum, byte) => sum + byte, 0) & 0xff) ^ 0x55
+    return frame
+}
+
+describe('WashTower official codec', () => {
+    test('CRC-valid short 0xEB captures decode every present field', () => {
+        const washer = make(Washer, 'FAKPK21021')
+        washer.thinq.emit('data', WASHER_EB)
+        assert.equal(Object.keys(washer.ha.devices['test-device'].properties).length, 141)
+        assert.equal(washer.ha.devices['test-device'].properties.download_course, 'Wool/Delicate')
+        assert.equal(washer.ha.devices['test-device'].properties.laundry_care_setting_time, 240)
+
+        const dryer = make(Dryer, 'BDH_D39301_KR')
+        dryer.thinq.emit('data', DRYER_EB)
+        assert.equal(Object.keys(dryer.ha.devices['test-device'].properties).length, 84)
+        assert.equal(dryer.ha.devices['test-device'].properties.download_course, 'Wool/Delicate')
+        assert.equal(dryer.ha.devices['test-device'].properties.end_melody, 'Vivaldi Winter')
+    })
+
+    test('frame builder reproduces both real 0xEB captures byte-for-byte', () => {
+        assert.deepEqual(buildWashtowerExtendedFrame(0x33, 0xeb, WASHER_EB.subarray(15, -3), 0x84bc), WASHER_EB)
+        assert.deepEqual(buildWashtowerExtendedFrame(0x34, 0xeb, DRYER_EB.subarray(15, -3), 0x2063), DRYER_EB)
+    })
+
+    test('captured short dryer 0xEC selects the current record and publishes live controls', () => {
+        assert.equal(DRYER_EC.readUInt16BE(13), DRYER_MODEL.liveRecordLength * 2)
+        assert.deepEqual(
+            selectCurrentWashtowerRecord(DRYER_EC, DRYER_MODEL),
+            DRYER_EC.subarray(15 + DRYER_MODEL.liveRecordLength, -3),
+        )
+
+        const dryer = make(Dryer, 'BDH_D39301_KR')
+        dryer.thinq.emit('data', DRYER_EC)
+        assert.equal(dryer.ha.devices['test-device'].properties.state, 'On')
+        assert.equal(dryer.ha.devices['test-device'].properties.remote_maintain, 'On')
+        assert.equal(dryer.ha.devices['test-device'].properties.power, 'ON')
+    })
+
+    test('washer 0xEC distinguishes exact short and full previous+current layouts', () => {
+        for (const recordLength of [WASHER_MODEL.liveRecordLength, WASHER_MODEL.recordLength]) {
+            const previous = Buffer.alloc(recordLength)
+            const current = Buffer.alloc(recordLength)
+            setRaw(previous, WASHER_MODEL, 'state', 0)
+            setRaw(current, WASHER_MODEL, 'state', 1)
+            current[recordLength - 1] = recordLength
+            const frame = buildWashtowerExtendedFrame(WASHER_MODEL.tag, 0xec, Buffer.concat([previous, current]))
+            assert.deepEqual(selectCurrentWashtowerRecord(frame, WASHER_MODEL), current)
+        }
+
+        const mixed = Buffer.alloc(WASHER_MODEL.liveRecordLength + WASHER_MODEL.recordLength)
+        assert.equal(
+            selectCurrentWashtowerRecord(buildWashtowerExtendedFrame(WASHER_MODEL.tag, 0xec, mixed), WASHER_MODEL),
+            undefined,
+        )
+    })
+
+    test('0xEC accepts exactly two official short or full records and selects current', () => {
+        for (const model of [WASHER_MODEL, DRYER_MODEL]) {
+            for (const recordLength of [model.liveRecordLength, model.recordLength]) {
+                const previous = Buffer.alloc(recordLength)
+                const current = Buffer.alloc(recordLength)
+                setRaw(previous, model, 'state', 0)
+                setRaw(current, model, 'state', 1)
+                const frame = buildWashtowerExtendedFrame(model.tag, 0xec, Buffer.concat([previous, current]))
+                assert.deepEqual(selectCurrentWashtowerRecord(frame, model), current)
+                assert.equal(
+                    selectCurrentWashtowerRecord(buildWashtowerExtendedFrame(model.tag, 0xec, current), model),
+                    undefined,
+                )
+            }
+        }
+    })
+
+    test('both models reject a wrong tag, three 0xEC records, and a trailing byte', () => {
+        for (const model of [WASHER_MODEL, DRYER_MODEL]) {
+            const record = Buffer.alloc(model.recordLength)
+            const twoRecords = Buffer.concat([record, record])
+            const wrongTag = model.tag === WASHER_MODEL.tag ? DRYER_MODEL.tag : WASHER_MODEL.tag
+            const invalid = [
+                buildWashtowerExtendedFrame(wrongTag, 0xec, twoRecords),
+                buildWashtowerExtendedFrame(model.tag, 0xec, Buffer.concat([twoRecords, record])),
+                buildWashtowerExtendedFrame(model.tag, 0xec, Buffer.concat([twoRecords, Buffer.from([0])])),
+            ]
+
+            for (const frame of invalid) assert.equal(selectCurrentWashtowerRecord(frame, model), undefined)
+        }
+    })
+
+    test('course lists, heartbeat, ACK, unknown FID, bad CRC and bad length are ignored', () => {
+        const { ha, thinq } = make(Washer, 'FAKPK21021')
+        const invalid = [
+            Buffer.from('aa0733c302fcbb', 'hex'),
+            Buffer.from('aa083300240000bb', 'hex'),
+            buildWashtowerExtendedFrame(0x33, 0x0a86, Buffer.alloc(72)),
+            buildWashtowerExtendedFrame(0x33, 0xeb, Buffer.alloc(66)),
+            Buffer.from(WASHER_EB),
+        ]
+        invalid[invalid.length - 1][invalid[invalid.length - 1].length - 2] ^= 1
+        for (const frame of invalid) thinq.emit('data', frame)
+        assert.deepEqual(ha.devices['test-device'].properties, {})
+    })
+
+    test('every official ref bitfield is decoded independently', () => {
+        for (const [Driver, model, modelId] of [
+            [Washer, WASHER_MODEL, 'FAKPK21021'],
+            [Dryer, DRYER_MODEL, 'BDH_D39301_KR'],
+        ] as const) {
+            for (const field of model.fields.filter((candidate) => candidate.bit !== undefined)) {
+                const { ha, thinq } = make(Driver, modelId)
+                const record = Buffer.alloc(model.recordLength)
+                setRaw(record, model, field.key, 1)
+                thinq.emit('data', buildWashtowerExtendedFrame(model.tag, 0xeb, record))
+                const key = field.key
+                    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+                    .replace(/[^a-zA-Z0-9_]/g, '_')
+                    .toLowerCase()
+                assert.equal(
+                    ha.devices['test-device'].properties[key],
+                    field.values ? (field.values['1'] ?? 'Unknown(1)') : 1,
+                    field.key,
+                )
+            }
+        }
+    })
+
+    test('all display labels are English', () => {
+        for (const [Driver, modelId, name] of [
+            [Washer, 'FAKPK21021', 'LG WashTower Washer'],
+            [Dryer, 'BDH_D39301_KR', 'LG WashTower Dryer'],
+        ] as const) {
+            const { ha } = make(Driver, modelId)
+            const config = ha.devices['test-device'].config!
+            assert.equal(config.device.name, name)
+            const power = config.components.power as unknown as
+                | { platform: string; state_topic: string; command_topic: string }
+                | undefined
+            assert.ok(power)
+            assert.equal(power.platform, 'switch')
+            assert.equal(power.state_topic, '$this/power')
+            assert.equal(power.command_topic, '$this/power/set')
+            assert.equal(config.components.wake.name, 'Exit power-save')
+            assert.equal(config.components.power.name, 'Power')
+            assert.equal(config.components.power_transition.name, 'Power transition state')
+            assert.equal(config.components.remote_maintain.name, 'Remote control lock')
+            assert.equal(config.components.send_course, undefined)
+            assert.equal(config.components.start_course.name, 'Start course')
+            for (const component of Object.values(config.components)) {
+                if (typeof component.name === 'string') assert.match(component.name, /[A-Za-z]/)
+            }
+        }
+    })
+
+    test('single-source manifest references real entities and declared English enums only', () => {
+        for (const identity of WASHTOWER_IMPLEMENTATION_MANIFEST) {
+            const entities = new Set(identity.entities.map(({ key }) => key))
+            for (const option of identity.enumOptions) {
+                assert.ok(entities.has(option.entityKey), `${identity.model}: ${option.entityKey}`)
+                assert.doesNotMatch(option.label, /^Value \d+$/)
+            }
+            const writes = identity.writes.map(({ entityKey, protocolFrameId, controlWifiPath }) => [
+                entityKey,
+                protocolFrameId,
+                controlWifiPath,
+            ])
+            assert.ok(writes.some(([key, frame, path]) => key === 'wake' && frame === '0x2A' && path === 'WMWakeup'))
+            assert.ok(
+                writes.some(([key, frame, path]) => key === 'power' && frame === '0xE5' && path === 'vtCtrl/power'),
+            )
+            assert.ok(
+                writes.some(
+                    ([key, frame, path]) => key === 'power_transition' && frame === '0xED' && path === 'statusQuery',
+                ),
+            )
+            assert.ok(writes.some(([key, frame, path]) => key === 'power' && frame === '0x24' && path === 'WMControl'))
+            assert.ok(!writes.some(([key, frame, path]) => key === 'power' && frame === '0x2A'))
+            assert.ok(writes.some(([key, frame, path]) => key === 'off' && frame === '0x24' && path === 'WMControl'))
+            assert.ok(writes.some(([key, frame, path]) => key === 'stop' && frame === '0x24' && path === 'WMControl'))
+            assert.ok(
+                writes.some(
+                    ([key, frame, path]) => key === 'remote_maintain' && frame === '0x24' && path === 'remoteMaintain',
+                ),
+            )
+            assert.ok(
+                !writes.some(
+                    ([key, frame, path]) => key === 'send_course' && frame === '0x25' && path === 'WMDownload',
+                ),
+            )
+            assert.ok(
+                writes.some(([key, frame, path]) => key === 'start_course' && frame === '0x26' && path === 'WMStart'),
+            )
+            assert.equal(
+                identity.writes.find(
+                    ({ entityKey, controlWifiPath }) => entityKey === 'power' && controlWifiPath === 'vtCtrl/power',
+                )?.validator,
+                'value=ON && state=POWEROFF && no pending power-on within 120s',
+            )
+            assert.equal(
+                identity.writes.find(({ entityKey }) => entityKey === 'remote_maintain')?.validator,
+                '(value=ON && state in [POWEROFF,INITIAL]) || (value=OFF && state=INITIAL)',
+            )
+            assert.match(
+                identity.writes.find(({ entityKey }) => entityKey === 'start_course')!.validator,
+                /remoteStart=true/,
+            )
+        }
+        assert.deepEqual(
+            WASHTOWER_IMPLEMENTATION_MANIFEST.map(({ codec }) => ({
+                protocol: [codec.protocol.name, codec.protocol.jsonVersion, codec.protocol.sha256],
+                convert: [codec.convert.name, codec.convert.jsonVersion, codec.convert.sha256],
+            })),
+            [
+                {
+                    protocol: [
+                        'WASHER_PROTOCOL_EX',
+                        '8.3',
+                        'dfb39d74f18664e92dc8839b623a347154a4f9ae3cb354859c1fbef6a45c13b9',
+                    ],
+                    convert: [
+                        'WASHER_CONVERT_EX',
+                        '2.3',
+                        '4311a33597a88fac5c32bc26f12ef65edeab0c4fc1173ca3665b4ad0685beab4',
+                    ],
+                },
+                {
+                    protocol: [
+                        'DRYER_PROTOCOL_EX',
+                        '4.1',
+                        '0428bcd76f1df325d3142fc2541083b3cc094d025c78e11e17f44f5f970dc348',
+                    ],
+                    convert: [
+                        'DRYER_CONVERT_EX',
+                        '7.8',
+                        'ff3dfc7f7974f18ed6c4a73bea1b03998b8f6c0213d1f08394482bc34844125b',
+                    ],
+                },
+            ],
+        )
+    })
+
+    test('course selects expose only control-enabled built-in model courses', () => {
+        const washer = make(Washer, 'FAKPK21021').ha.devices['test-device'].config!.components.setting_course as {
+            options?: string[]
+        }
+        const dryer = make(Dryer, 'BDH_D39301_KR').ha.devices['test-device'].config!.components.setting_course as {
+            options?: string[]
+        }
+        assert.deepEqual(washer.options, ['Bedding', 'Standard', 'Small Quick', 'Eco Boil', 'Tub Sterilize', 'AI Wash'])
+        assert.deepEqual(dryer.options, [
+            'Steam Refresh',
+            'Bedding',
+            'Standard',
+            'Small Quick',
+            'Bedding shake',
+            'Steam Sterilize',
+            'Condenser Care',
+            'Tub Sterilize',
+            'Timed Dry',
+            'AI Dry',
+        ])
+    })
+
+    test('every official converter Course raw value has an English read-only label', () => {
+        const washerCourse = WASHER_MODEL.fields.find(({ key }) => key === 'course')!.values!
+        const dryerCourse = DRYER_MODEL.fields.find(({ key }) => key === 'course')!.values!
+        assert.deepEqual(Object.keys(washerCourse).map(Number), [...Array.from({ length: 170 }, (_, raw) => raw), 255])
+        assert.deepEqual(Object.keys(dryerCourse).map(Number), [
+            ...Array.from({ length: 59 }, (_, raw) => raw),
+            114,
+            255,
+        ])
+        for (const [model, values] of [
+            [WASHER_MODEL, washerCourse],
+            [DRYER_MODEL, dryerCourse],
+        ] as const) {
+            for (const [raw, label] of Object.entries(values)) {
+                assert.match(label, /[A-Za-z]/, `${model.deviceName} Course raw ${raw}`)
+                assert.doesNotMatch(label, /Unknown/, `${model.deviceName} Course raw ${raw}`)
+            }
+        }
+    })
+
+    test('dryer Course raw 2 publishes the English towels label', () => {
+        const { ha, thinq } = make(Dryer, 'BDH_D39301_KR')
+        const record = Buffer.alloc(DRYER_MODEL.recordLength)
+        setRaw(record, DRYER_MODEL, 'course', 2)
+        thinq.emit('data', buildWashtowerExtendedFrame(DRYER_MODEL.tag, 0xeb, record))
+        assert.equal(ha.devices['test-device'].properties.course, 'Towels')
+    })
+})
+
+describe('WashTower official control frame', () => {
+    test('power-on/wake/off/stop/remoteMaintain frames are byte exact', () => {
+        const expected = {
+            powerOn: 'aa0df0e5000201ff010201c7bb',
+            statusQuery: 'aa12f0ed1121010000001804111200005ebb',
+            wake: 'aa08f02a010098bb',
+            off: 'aa09f0240101009cbb',
+            stop: 'aa09f02404010099bb',
+            remoteMaintainOn: 'aa09f0241001018cbb',
+            remoteMaintainOff: 'aa09f0241001008dbb',
+        }
+        for (const key of [
+            'powerOn',
+            'statusQuery',
+            'wake',
+            'off',
+            'stop',
+            'remoteMaintainOn',
+            'remoteMaintainOff',
+        ] as const) {
+            const command = WASH_TOWER_SIMPLE_CONTROLS[key]
+            assert.equal(buildWashtowerControlFrame(command.frameId, command.payload).toString('hex'), expected[key])
+        }
+    })
+
+    test('power-on E6 accepts only the three explicit official response shapes', () => {
+        assert.equal(DRYER_POWER_ON_E6.length, 13 + DRYER_MODEL.liveRecordLength)
+        assert.equal(isWashtowerPowerOnSuccess(DRYER_POWER_ON_E6, DRYER_MODEL), true)
+
+        for (const model of [WASHER_MODEL, DRYER_MODEL]) {
+            assert.equal(isWashtowerPowerOnSuccess(powerOnResponse(model), model), true)
+            assert.equal(
+                isWashtowerPowerOnSuccess(powerOnResponse(model, 0, Buffer.alloc(model.liveRecordLength)), model),
+                true,
+            )
+            assert.equal(
+                isWashtowerPowerOnSuccess(powerOnResponse(model, 0, Buffer.alloc(model.recordLength)), model),
+                true,
+            )
+            assert.equal(isWashtowerPowerOnSuccess(powerOnResponse(model, 0, Buffer.alloc(1)), model), false)
+            assert.equal(
+                isWashtowerPowerOnSuccess(powerOnResponse(model, 0, Buffer.alloc(model.liveRecordLength - 1)), model),
+                false,
+            )
+        }
+
+        assert.equal(isWashtowerPowerOnSuccess(DRYER_POWER_ON_E6.subarray(0, -1), DRYER_MODEL), false)
+    })
+
+    test('WMDownload builders reproduce official offsets and option bit packing', () => {
+        const washer = new Map<string, number>([
+            ['course', 46],
+            ['soilWash', 3],
+            ['spin', 6],
+            ['temp', 3],
+            ['rinse', 2],
+            ['turboWash', 1],
+            ['freshCare', 1],
+            ['remoteStart', 1],
+        ])
+        assert.equal(
+            buildWashtowerDownloadPayload(WASHER_MODEL, washer).toString('hex'),
+            '03152e0306030200002000402e00000000000000000000',
+        )
+        const dryer = new Map<string, number>([
+            ['course', 7],
+            ['ecoHybrid', 2],
+            ['moreLessTime', 5],
+            ['reserveTimeMinute', 30],
+            ['wrinkleCare', 1],
+            ['remoteStart', 1],
+            ['dryLevel', 4],
+        ])
+        assert.equal(
+            buildWashtowerDownloadPayload(DRYER_MODEL, dryer).toString('hex'),
+            '03150002050000001e0800000700000000040000000000',
+        )
+        assert.equal(
+            buildWashtowerControlFrame(0x25, buildWashtowerDownloadPayload(WASHER_MODEL, washer)).toString('hex'),
+            'aa1df02503152e0306030200002000402e00000000000000000000ebbb',
+        )
+    })
+
+    test('WMStart builders reproduce official model lengths, offsets and option bit packing', () => {
+        const washer = new Map<string, number>([
+            ['course', 46],
+            ['soilWash', 3],
+            ['spin', 6],
+            ['temp', 3],
+            ['rinse', 2],
+            ['reserveTimeMinute', 30],
+            ['turboWash', 1],
+            ['freshCare', 1],
+            ['downloadCourse', 9],
+            ['dryLevel', 4],
+        ])
+        const washerPayload = buildWashtowerStartPayload(WASHER_MODEL, washer)
+        assert.equal(washerPayload.length, 21)
+        assert.equal(washerPayload.toString('hex'), '2e0306030200002000402e09000000040000000000')
+
+        const dryer = new Map<string, number>([
+            ['course', 7],
+            ['dryLevel', 4],
+            ['ecoHybrid', 2],
+            ['moreLessTime', 5],
+            ['reserveTimeMinute', 30],
+            ['wrinkleCare', 1],
+            ['downloadCourse', 9],
+        ])
+        const dryerPayload = buildWashtowerStartPayload(DRYER_MODEL, dryer)
+        assert.equal(dryerPayload.length, 14)
+        assert.equal(dryerPayload.toString('hex'), '070402050000001e000800000900')
+        assert.equal(
+            buildWashtowerControlFrame(0x26, washerPayload).toString('hex'),
+            'aa1bf0262e0306030200002000402e09000000040000000000e7bb',
+        )
+        assert.equal(
+            buildWashtowerControlFrame(0x26, dryerPayload).toString('hex'),
+            'aa14f026070402050000001e00080000090040bb',
+        )
+    })
+
+    test('state/remote gates reject unsafe commands without optimistic actual-state echo', () => {
+        const { ha, thinq, dev } = make(Washer, 'FAKPK21021')
+        const off = Buffer.alloc(WASHER_MODEL.recordLength)
+        setRaw(off, WASHER_MODEL, 'state', 0)
+        thinq.emit('data', buildWashtowerExtendedFrame(0x33, 0xeb, off))
+        dev.setProperty('wake', '')
+        assert.equal(thinq.outbox.length, 1)
+        const before = ha.devices['test-device'].properties.state
+        dev.setProperty('off', '')
+        dev.setProperty('stop', '')
+        dev.setProperty('send_course', '')
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(ha.devices['test-device'].properties.state, before)
+    })
+
+    test('all packet commands fail closed as Status unknown before the first valid state observation', () => {
+        const commands = [
+            ['wake', ''],
+            ['power', 'ON'],
+            ['power', 'OFF'],
+            ['remote_maintain', 'On'],
+            ['remote_maintain', 'Off'],
+            ['send_course', ''],
+            ['start_course', ''],
+            ['off', ''],
+            ['stop', ''],
+        ] as const
+        const originalWarn = console.warn
+        const warnings: unknown[][] = []
+        console.warn = (...args: unknown[]) => warnings.push(args)
+        try {
+            for (const [Driver, modelId, deviceName] of [
+                [Washer, 'FAKPK21021', 'LG WashTower Washer'],
+                [Dryer, 'BDH_D39301_KR', 'LG WashTower Dryer'],
+            ] as const) {
+                const { thinq, dev } = make(Driver, modelId)
+                for (const [prop, value] of commands) dev.setProperty(prop, value)
+                assert.equal(thinq.outbox.length, 0, deviceName)
+                assert.deepEqual(
+                    warnings.splice(0),
+                    commands.map(([prop]) => [
+                        deviceName +
+                            (prop === 'send_course'
+                                ? ': Built-in course can only be applied via the start-course command'
+                                : ': Status unknown'),
+                    ]),
+                )
+            }
+        } finally {
+            console.warn = originalWarn
+        }
+    })
+
+    test('power switch uses vtCtrl power for ON, preserves state echo, and remote-gates OFF', () => {
+        for (const [Driver, model, modelId] of [
+            [Washer, WASHER_MODEL, 'FAKPK21021'],
+            [Dryer, DRYER_MODEL, 'BDH_D39301_KR'],
+        ] as const) {
+            const { ha, thinq, dev } = make(Driver, modelId)
+            const record = Buffer.alloc(model.recordLength)
+            thinq.emit('data', buildWashtowerExtendedFrame(model.tag, 0xeb, record))
+            assert.equal(ha.devices['test-device'].properties.power, 'OFF')
+
+            dev.setProperty('power', 'ON')
+            assert.equal(thinq.outbox[thinq.outbox.length - 1]!.toString('hex'), 'aa0df0e5000201ff010201c7bb')
+            assert.equal(ha.devices['test-device'].properties.power, 'OFF')
+
+            setRaw(record, model, 'state', 1)
+            thinq.emit('data', buildWashtowerExtendedFrame(model.tag, 0xeb, record))
+            assert.equal(ha.devices['test-device'].properties.power, 'ON')
+            dev.setProperty('power', 'OFF')
+            assert.equal(thinq.outbox.length, 1)
+
+            setRaw(record, model, 'remoteStart', 1)
+            thinq.emit('data', buildWashtowerExtendedFrame(model.tag, 0xeb, record))
+            dev.setProperty('power', 'OFF')
+            assert.equal(thinq.outbox[thinq.outbox.length - 1]!.toString('hex'), 'aa09f0240101009cbb')
+            assert.equal(ha.devices['test-device'].properties.power, 'ON')
+        }
+    })
+
+    test('power-on pending suppresses duplicate ON and a strict successful E6 triggers one best-effort refresh', () => {
+        for (const [Driver, model, modelId] of [
+            [Washer, WASHER_MODEL, 'FAKPK21021'],
+            [Dryer, DRYER_MODEL, 'BDH_D39301_KR'],
+        ] as const) {
+            const { ha, thinq, dev } = make(Driver, modelId)
+            const record = Buffer.alloc(model.recordLength)
+            thinq.emit('data', buildWashtowerExtendedFrame(model.tag, 0xeb, record))
+            assert.equal(ha.devices['test-device'].properties.power_transition, 'Standby')
+
+            dev.setProperty('power', 'ON')
+            dev.setProperty('power', 'ON')
+            assert.equal(thinq.outbox.length, 1)
+            assert.equal(thinq.outbox[0].toString('hex'), 'aa0df0e5000201ff010201c7bb')
+            assert.equal(ha.devices['test-device'].properties.power, 'OFF')
+            assert.equal(ha.devices['test-device'].properties.power_transition, 'Turning on')
+
+            const malformed = [
+                Buffer.from(powerOnResponse(model).map((byte, index) => (index === 2 ? byte ^ 1 : byte))),
+                Buffer.from(powerOnResponse(model).map((byte, index) => (index === 11 ? byte ^ 1 : byte))),
+                powerOnResponse(model, 1),
+            ]
+            for (const frame of malformed) {
+                assert.equal(isWashtowerPowerOnSuccess(frame, model), false)
+                thinq.emit('data', frame)
+            }
+            assert.equal(thinq.outbox.length, 1)
+
+            const success = powerOnResponse(model)
+            assert.equal(isWashtowerPowerOnSuccess(success, model), true)
+            thinq.emit('data', success)
+            assert.equal(ha.devices['test-device'].properties.power_transition, 'Command accepted')
+            thinq.emit('data', success)
+            dev.setProperty('power', 'ON')
+            assert.equal(thinq.outbox.length, 2)
+            assert.equal(thinq.outbox[1].toString('hex'), 'aa12f0ed1121010000001804111200005ebb')
+
+            setRaw(record, model, 'state', 1)
+            thinq.emit(
+                'data',
+                buildWashtowerExtendedFrame(
+                    model.tag,
+                    model === DRYER_MODEL ? 0xec : 0xeb,
+                    model === DRYER_MODEL ? Buffer.concat([Buffer.alloc(model.recordLength), record]) : record,
+                ),
+            )
+            assert.equal(ha.devices['test-device'].properties.power, 'ON')
+            assert.equal(ha.devices['test-device'].properties.power_transition, 'Complete')
+            setRaw(record, model, 'state', 0)
+            thinq.emit('data', buildWashtowerExtendedFrame(model.tag, 0xeb, record))
+            assert.equal(ha.devices['test-device'].properties.power_transition, 'Complete')
+        }
+    })
+
+    test('power-on pending times out at 120s with fake time and allows one new attempt', () => {
+        const originalNow = Date.now
+        const originalSetTimeout = globalThis.setTimeout
+        const originalClearTimeout = globalThis.clearTimeout
+        let now = 1_000
+        let timeoutCallback: (() => void) | undefined
+        let clearTimeoutCalls = 0
+        Date.now = () => now
+        globalThis.setTimeout = ((callback: () => void) => {
+            timeoutCallback = callback
+            return 1 as unknown as NodeJS.Timeout
+        }) as typeof setTimeout
+        globalThis.clearTimeout = (() => {
+            clearTimeoutCalls++
+        }) as typeof clearTimeout
+        try {
+            const { ha, thinq, dev } = make(Washer, 'FAKPK21021')
+            const off = Buffer.alloc(WASHER_MODEL.recordLength)
+            thinq.emit('data', buildWashtowerExtendedFrame(WASHER_MODEL.tag, 0xeb, off))
+            dev.setProperty('power', 'ON')
+            assert.equal(thinq.outbox.length, 1)
+
+            now += 119_999
+            dev.setProperty('power', 'ON')
+            assert.equal(thinq.outbox.length, 1)
+
+            now += 1
+            timeoutCallback!()
+            assert.equal(ha.devices['test-device'].properties.power, 'OFF')
+            assert.equal(ha.devices['test-device'].properties.power_transition, 'Timeout')
+            thinq.emit('data', buildWashtowerExtendedFrame(WASHER_MODEL.tag, 0xeb, off))
+            assert.equal(ha.devices['test-device'].properties.power_transition, 'Timeout')
+
+            dev.setProperty('power', 'ON')
+            assert.equal(thinq.outbox.length, 2)
+            assert.equal(thinq.outbox[1].toString('hex'), 'aa0df0e5000201ff010201c7bb')
+            dev.drop()
+            assert.equal(clearTimeoutCalls, 1)
+        } finally {
+            Date.now = originalNow
+            globalThis.setTimeout = originalSetTimeout
+            globalThis.clearTimeout = originalClearTimeout
+        }
+    })
+
+    test('failed power-on send does not leave a stuck pending attempt', () => {
+        const { thinq, dev } = make(Washer, 'FAKPK21021')
+        const off = Buffer.alloc(WASHER_MODEL.recordLength)
+        thinq.emit('data', buildWashtowerExtendedFrame(WASHER_MODEL.tag, 0xeb, off))
+        const sendPacket = thinq.send_packet.bind(thinq)
+        let fail = true
+        thinq.send_packet = ((frame: Buffer) => {
+            if (fail) {
+                fail = false
+                throw new Error('synthetic send failure')
+            }
+            sendPacket(frame)
+        }) as typeof thinq.send_packet
+
+        assert.throws(() => dev.setProperty('power', 'ON'), /synthetic send failure/)
+        dev.setProperty('power', 'ON')
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(thinq.outbox[0].toString('hex'), 'aa0df0e5000201ff010201c7bb')
+        dev.drop()
+    })
+
+    test('remoteMaintain follows the POWEROFF/INITIAL state matrix without remoteStart and remains non-optimistic', () => {
+        for (const [Driver, model, modelId] of [
+            [Washer, WASHER_MODEL, 'FAKPK21021'],
+            [Dryer, DRYER_MODEL, 'BDH_D39301_KR'],
+        ] as const) {
+            const { ha, thinq, dev } = make(Driver, modelId)
+            const record = Buffer.alloc(model.recordLength)
+            setRaw(record, model, 'state', 0)
+            thinq.emit('data', buildWashtowerExtendedFrame(model.tag, 0xeb, record))
+            assert.equal(ha.devices['test-device'].properties.remote_maintain, 'Off')
+
+            dev.setProperty('remote_maintain', 'On')
+            assert.equal(thinq.outbox[0]!.toString('hex'), 'aa09f0241001018cbb')
+            assert.equal(ha.devices['test-device'].properties.remote_maintain, 'Off')
+            dev.setProperty('remote_maintain', 'Off')
+            assert.equal(thinq.outbox.length, 1)
+
+            setRaw(record, model, 'state', 1)
+            thinq.emit('data', buildWashtowerExtendedFrame(model.tag, 0xeb, record))
+            dev.setProperty('remote_maintain', 'On')
+            dev.setProperty('remote_maintain', 'Off')
+            assert.equal(thinq.outbox[1]!.toString('hex'), 'aa09f0241001018cbb')
+            assert.equal(thinq.outbox[2]!.toString('hex'), 'aa09f0241001008dbb')
+            assert.equal(ha.devices['test-device'].properties.remote_maintain, 'Off')
+
+            thinq.emit('data', Buffer.from(`aa08${model.tag.toString(16)}00240000bb`, 'hex'))
+            assert.equal(ha.devices['test-device'].properties.remote_maintain, 'Off')
+
+            setRaw(record, model, 'state', 2)
+            thinq.emit('data', buildWashtowerExtendedFrame(model.tag, 0xeb, record))
+            dev.setProperty('remote_maintain', 'On')
+            dev.setProperty('remote_maintain', 'Off')
+            assert.equal(thinq.outbox.length, 3)
+        }
+    })
+
+    test('observed remoteMaintain keeps stop and OFF available after remoteStart drops', () => {
+        for (const [Driver, model, modelId] of [
+            [Washer, WASHER_MODEL, 'FAKPK21021'],
+            [Dryer, DRYER_MODEL, 'BDH_D39301_KR'],
+        ] as const) {
+            for (const prop of ['off', 'stop', 'power'] as const) {
+                const { thinq, dev } = make(Driver, modelId)
+                const record = Buffer.alloc(model.recordLength)
+                setRaw(record, model, 'state', 1)
+                setRaw(record, model, 'remoteStart', 1)
+                setRaw(record, model, 'remoteMaintain', 1)
+                thinq.emit('data', buildWashtowerExtendedFrame(model.tag, 0xeb, record))
+
+                setRaw(record, model, 'state', 2)
+                setRaw(record, model, 'remoteStart', 0)
+                thinq.emit('data', buildWashtowerExtendedFrame(model.tag, 0xeb, record))
+                dev.setProperty(prop, prop === 'power' ? 'OFF' : '')
+
+                assert.equal(thinq.outbox.length, 1, `${model.deviceName} ${prop}`)
+                assert.equal(
+                    thinq.outbox[0].toString('hex'),
+                    prop === 'stop' ? 'aa09f02404010099bb' : 'aa09f0240101009cbb',
+                )
+            }
+        }
+    })
+
+    test('gate matrix: send_course is unsupported and start needs INITIAL, valid draft, and actual remoteStart', () => {
+        const attempt = (
+            Driver: typeof Washer | typeof Dryer,
+            model: WashTowerModel,
+            prop: 'send_course' | 'start_course',
+            state: number,
+            remoteKey?: 'remoteStart' | 'remoteMaintain',
+            validDraft = true,
+        ) => {
+            const { thinq, dev } = make(Driver, model === WASHER_MODEL ? 'FAKPK21021' : 'BDH_D39301_KR')
+            const record = Buffer.alloc(model.recordLength)
+            setRaw(record, model, 'state', state)
+            if (remoteKey) setRaw(record, model, remoteKey, 1)
+            thinq.emit('data', buildWashtowerExtendedFrame(model.tag, 0xeb, record))
+            if (validDraft) {
+                dev.setProperty('setting_course', label(model, 'course', model === WASHER_MODEL ? 46 : 7))
+            } else if (model === WASHER_MODEL) {
+                dev.setProperty('setting_temp', label(model, 'temp', 6))
+            } else {
+                dev.setProperty('setting_eco_hybrid', label(model, 'ecoHybrid', 0))
+            }
+            dev.setProperty(prop, '')
+            return thinq.outbox.length
+        }
+
+        for (const [Driver, model] of [
+            [Washer, WASHER_MODEL],
+            [Dryer, DRYER_MODEL],
+        ] as const) {
+            assert.equal(attempt(Driver, model, 'send_course', 1), 0)
+            assert.equal(attempt(Driver, model, 'send_course', 0, 'remoteStart'), 0)
+            assert.equal(attempt(Driver, model, 'send_course', 1, undefined, false), 0)
+
+            assert.equal(attempt(Driver, model, 'start_course', 1), 0)
+            assert.equal(attempt(Driver, model, 'start_course', 1, 'remoteStart'), 1)
+            assert.equal(attempt(Driver, model, 'start_course', 1, 'remoteMaintain'), 0)
+            assert.equal(attempt(Driver, model, 'start_course', 2, 'remoteStart'), 0)
+            assert.equal(attempt(Driver, model, 'start_course', 1, 'remoteStart', false), 0)
+        }
+    })
+
+    test('restart reconciles a retained staged course to NORMAL without sending and starts the valid default draft', () => {
+        const ha = new MockHAConnection()
+        const previous = make(Dryer, 'BDH_D39301_KR', ha)
+        previous.dev.setProperty('setting_course', label(DRYER_MODEL, 'course', 15))
+        assert.equal(ha.devices['test-device'].properties.setting_course, 'Bedding shake')
+
+        const restarted = make(Dryer, 'BDH_D39301_KR', ha)
+        const ready = Buffer.alloc(DRYER_MODEL.recordLength)
+        setRaw(ready, DRYER_MODEL, 'state', 1)
+        setRaw(ready, DRYER_MODEL, 'remoteStart', 1)
+        setRaw(ready, DRYER_MODEL, 'course', 0)
+        restarted.thinq.emit('data', buildWashtowerExtendedFrame(DRYER_MODEL.tag, 0xeb, ready))
+
+        assert.equal(restarted.thinq.outbox.length, 0)
+        assert.equal(ha.devices['test-device'].properties.course, 'None')
+        assert.equal(ha.devices['test-device'].properties.setting_course, 'Standard')
+        for (const key of [
+            'setting_course',
+            'setting_eco_hybrid',
+            'setting_wrinkle_care',
+            'setting_steam',
+            'setting_dry_level',
+        ])
+            assert.match(String(ha.devices['test-device'].properties[key]), /[A-Za-z]/, key)
+
+        restarted.dev.setProperty('start_course', '')
+        const expectedDraft = new Map<string, number>([
+            ['course', 7],
+            ['dryLevel', 3],
+            ['ecoHybrid', 2],
+            ['moreLessTime', 0],
+            ['reserveTimeMinute', 0],
+            ['steam', 0],
+            ['wrinkleCare', 0],
+            ['baseDownloadCourseData', 0],
+            ['downloadCourse', 0],
+        ])
+        assert.deepEqual(restarted.thinq.outbox, [
+            buildWashtowerControlFrame(0x26, buildWashtowerStartPayload(DRYER_MODEL, expectedDraft)),
+        ])
+    })
+
+    test('first supported telemetry initializes its official draft and later telemetry preserves a user-dirty draft', () => {
+        const { ha, thinq, dev } = make(Dryer, 'BDH_D39301_KR')
+        const ready = Buffer.alloc(DRYER_MODEL.recordLength)
+        setRaw(ready, DRYER_MODEL, 'state', 1)
+        setRaw(ready, DRYER_MODEL, 'remoteStart', 1)
+        setRaw(ready, DRYER_MODEL, 'course', 15)
+        thinq.emit('data', buildWashtowerExtendedFrame(DRYER_MODEL.tag, 0xeb, ready))
+
+        assert.equal(thinq.outbox.length, 0)
+        assert.equal(ha.devices['test-device'].properties.course, 'Bedding shake')
+        assert.equal(ha.devices['test-device'].properties.setting_course, 'Bedding shake')
+        assert.equal(ha.devices['test-device'].properties.setting_eco_hybrid, label(DRYER_MODEL, 'ecoHybrid', 2))
+
+        dev.setProperty('setting_course', label(DRYER_MODEL, 'course', 7))
+        dev.setProperty('setting_dry_level', label(DRYER_MODEL, 'dryLevel', 4))
+        setRaw(ready, DRYER_MODEL, 'course', 15)
+        setRaw(ready, DRYER_MODEL, 'dryLevel', 0)
+        thinq.emit('data', buildWashtowerExtendedFrame(DRYER_MODEL.tag, 0xeb, ready))
+
+        assert.equal(ha.devices['test-device'].properties.course, 'Bedding shake')
+        assert.equal(ha.devices['test-device'].properties.setting_course, 'Standard')
+        assert.equal(ha.devices['test-device'].properties.setting_dry_level, label(DRYER_MODEL, 'dryLevel', 4))
+        dev.setProperty('start_course', '')
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(thinq.outbox[0][4], 7)
+        assert.equal(thinq.outbox[0][5], 4)
+    })
+
+    test('a course selected before first telemetry survives NOT_SELECTED reconciliation', () => {
+        const { ha, thinq, dev } = make(Dryer, 'BDH_D39301_KR')
+        dev.setProperty('setting_course', label(DRYER_MODEL, 'course', 15))
+        const ready = Buffer.alloc(DRYER_MODEL.recordLength)
+        setRaw(ready, DRYER_MODEL, 'state', 1)
+        setRaw(ready, DRYER_MODEL, 'remoteStart', 1)
+        thinq.emit('data', buildWashtowerExtendedFrame(DRYER_MODEL.tag, 0xeb, ready))
+
+        assert.equal(thinq.outbox.length, 0)
+        assert.equal(ha.devices['test-device'].properties.course, 'None')
+        assert.equal(ha.devices['test-device'].properties.setting_course, 'Bedding shake')
+        dev.setProperty('start_course', '')
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(thinq.outbox[0][4], 15)
+    })
+
+    test('a compatible dryer option selected before first telemetry is preserved in the reconciled F026 draft', () => {
+        const { ha, thinq, dev } = make(Dryer, 'BDH_D39301_KR')
+        dev.setProperty('setting_dry_level', label(DRYER_MODEL, 'dryLevel', 4))
+        const ready = Buffer.alloc(DRYER_MODEL.recordLength)
+        setRaw(ready, DRYER_MODEL, 'state', 1)
+        setRaw(ready, DRYER_MODEL, 'remoteStart', 1)
+        setRaw(ready, DRYER_MODEL, 'course', 7)
+        thinq.emit('data', buildWashtowerExtendedFrame(DRYER_MODEL.tag, 0xeb, ready))
+
+        assert.equal(thinq.outbox.length, 0)
+        assert.equal(ha.devices['test-device'].properties.course, 'Standard')
+        assert.equal(ha.devices['test-device'].properties.setting_course, 'Standard')
+        assert.equal(ha.devices['test-device'].properties.setting_dry_level, label(DRYER_MODEL, 'dryLevel', 4))
+        for (const key of [
+            'setting_course',
+            'setting_eco_hybrid',
+            'setting_wrinkle_care',
+            'setting_steam',
+            'setting_dry_level',
+        ])
+            assert.equal(typeof ha.devices['test-device'].properties[key], 'string', key)
+
+        dev.setProperty('start_course', '')
+        const expectedDraft = new Map<string, number>([
+            ['course', 7],
+            ['dryLevel', 4],
+            ['ecoHybrid', 2],
+            ['moreLessTime', 0],
+            ['reserveTimeMinute', 0],
+            ['steam', 0],
+            ['wrinkleCare', 0],
+            ['baseDownloadCourseData', 0],
+            ['downloadCourse', 0],
+        ])
+        assert.deepEqual(thinq.outbox, [
+            buildWashtowerControlFrame(0x26, buildWashtowerStartPayload(DRYER_MODEL, expectedDraft)),
+        ])
+    })
+
+    test('an incompatible washer option selected before first telemetry stays visible and start fails closed', () => {
+        const { ha, thinq, dev } = make(Washer, 'FAKPK21021')
+        dev.setProperty('setting_temp', label(WASHER_MODEL, 'temp', 6))
+        const ready = Buffer.alloc(WASHER_MODEL.recordLength)
+        setRaw(ready, WASHER_MODEL, 'state', 1)
+        setRaw(ready, WASHER_MODEL, 'remoteStart', 1)
+        thinq.emit('data', buildWashtowerExtendedFrame(WASHER_MODEL.tag, 0xeb, ready))
+
+        assert.equal(thinq.outbox.length, 0)
+        assert.equal(ha.devices['test-device'].properties.course, 'None')
+        assert.equal(ha.devices['test-device'].properties.setting_course, 'Standard')
+        assert.equal(ha.devices['test-device'].properties.setting_temp, label(WASHER_MODEL, 'temp', 6))
+        for (const key of [
+            'setting_course',
+            'setting_soil_wash',
+            'setting_spin',
+            'setting_temp',
+            'setting_rinse',
+            'setting_fresh_care',
+            'setting_steam',
+            'setting_turbo_wash',
+        ])
+            assert.equal(typeof ha.devices['test-device'].properties[key], 'string', key)
+
+        dev.setProperty('start_course', '')
+        assert.equal(thinq.outbox.length, 0)
+        assert.equal(ha.devices['test-device'].properties.setting_course, 'Standard')
+        assert.equal(ha.devices['test-device'].properties.setting_temp, label(WASHER_MODEL, 'temp', 6))
+    })
+
+    test('selected command draft survives interleaved telemetry until start', () => {
+        const { thinq, dev } = make(Washer, 'FAKPK21021')
+        const ready = Buffer.alloc(WASHER_MODEL.recordLength)
+        setRaw(ready, WASHER_MODEL, 'state', 1)
+        setRaw(ready, WASHER_MODEL, 'remoteStart', 1)
+        setRaw(ready, WASHER_MODEL, 'course', 27)
+        setRaw(ready, WASHER_MODEL, 'temp', 8)
+        thinq.emit('data', buildWashtowerExtendedFrame(WASHER_MODEL.tag, 0xeb, ready))
+
+        dev.setProperty('setting_course', label(WASHER_MODEL, 'course', 46))
+        dev.setProperty('setting_temp', label(WASHER_MODEL, 'temp', 5))
+
+        const interleaved = Buffer.from(ready)
+        setRaw(interleaved, WASHER_MODEL, 'course', 27)
+        setRaw(interleaved, WASHER_MODEL, 'temp', 8)
+        thinq.emit('data', buildWashtowerExtendedFrame(WASHER_MODEL.tag, 0xeb, interleaved))
+        dev.setProperty('start_course', '')
+
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(thinq.outbox[0][3], 0x26)
+        assert.equal(thinq.outbox[0][4], 46)
+        assert.equal(thinq.outbox[0][7], 5)
+    })
+
+    test('interleaved dryer telemetry still updates non-setting reservation bytes', () => {
+        const { thinq, dev } = make(Dryer, 'BDH_D39301_KR')
+        const ready = Buffer.alloc(DRYER_MODEL.recordLength)
+        setRaw(ready, DRYER_MODEL, 'state', 1)
+        setRaw(ready, DRYER_MODEL, 'remoteStart', 1)
+        thinq.emit('data', buildWashtowerExtendedFrame(DRYER_MODEL.tag, 0xeb, ready))
+
+        dev.setProperty('setting_course', label(DRYER_MODEL, 'course', 7))
+
+        const interleaved = Buffer.from(ready)
+        setRaw(interleaved, DRYER_MODEL, 'reserveTimeMinute', 30)
+        thinq.emit('data', buildWashtowerExtendedFrame(DRYER_MODEL.tag, 0xeb, interleaved))
+        dev.setProperty('start_course', '')
+
+        const expectedDraft = new Map<string, number>([
+            ['course', 7],
+            ['dryLevel', 3],
+            ['ecoHybrid', 2],
+            ['moreLessTime', 0],
+            ['reserveTimeMinute', 30],
+            ['steam', 0],
+            ['wrinkleCare', 0],
+            ['baseDownloadCourseData', 0],
+            ['downloadCourse', 0],
+        ])
+        assert.equal(thinq.outbox.length, 1)
+        assert.deepEqual(
+            thinq.outbox[0],
+            buildWashtowerControlFrame(0x26, buildWashtowerStartPayload(DRYER_MODEL, expectedDraft)),
+        )
+    })
+
+    test('washer WMStart rejects observed nonzero reservation time', () => {
+        for (const reserveTimeMinute of [1, 0x0100]) {
+            const { thinq, dev } = make(Washer, 'FAKPK21021')
+            const ready = Buffer.alloc(WASHER_MODEL.recordLength)
+            setRaw(ready, WASHER_MODEL, 'state', 1)
+            setRaw(ready, WASHER_MODEL, 'remoteStart', 1)
+            setRaw(ready, WASHER_MODEL, 'reserveTimeMinute', reserveTimeMinute)
+            thinq.emit('data', buildWashtowerExtendedFrame(WASHER_MODEL.tag, 0xeb, ready))
+
+            dev.setProperty('setting_course', label(WASHER_MODEL, 'course', 46))
+            dev.setProperty('start_course', '')
+            assert.equal(thinq.outbox.length, 0)
+        }
+    })
+
+    test('course defaults/selectable and ControlValidator reject every unsafe example', () => {
+        const attempt = (
+            Driver: typeof Washer | typeof Dryer,
+            model: WashTowerModel,
+            course: number,
+            fieldKey: string,
+            raw: number,
+        ) => {
+            const { thinq, dev } = make(Driver, model === WASHER_MODEL ? 'FAKPK21021' : 'BDH_D39301_KR')
+            const ready = Buffer.alloc(model.recordLength)
+            setRaw(ready, model, 'state', 1)
+            setRaw(ready, model, 'remoteStart', 1)
+            thinq.emit('data', buildWashtowerExtendedFrame(model.tag, 0xeb, ready))
+            dev.setProperty('setting_course', label(model, 'course', course))
+            const settingKey = fieldKey.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase()
+            dev.setProperty('setting_' + settingKey, label(model, fieldKey, raw))
+            dev.setProperty('start_course', '')
+            return thinq.outbox
+        }
+
+        assert.equal(attempt(Washer, WASHER_MODEL, 46, 'temp', 6).length, 0) // NORMAL + 95 ℃
+        assert.equal(attempt(Washer, WASHER_MODEL, 27, 'spin', 8).length, 0) // DUVET + 1200 rpm
+        assert.equal(attempt(Washer, WASHER_MODEL, 85, 'turboWash', 1).length, 0) // TUB_CLEAN override
+        assert.equal(attempt(Dryer, DRYER_MODEL, 44, 'dryLevel', 4).length, 0) // AI dry level
+        assert.equal(attempt(Dryer, DRYER_MODEL, 9, 'ecoHybrid', 2).length, 0) // QUICKDRY non-TURBO
+        assert.equal(attempt(Dryer, DRYER_MODEL, 1, 'steam', 0).length, 0) // REFRESH steam OFF
+        assert.equal(attempt(Dryer, DRYER_MODEL, 18, 'wrinkleCare', 1).length, 0) // CONDENSERCARE wrinkle
+    })
+
+    test('official positive course combinations start once and do not echo actual state', () => {
+        for (const [Driver, model, course, settings] of [
+            [Washer, WASHER_MODEL, 46, { temp: 5, spin: 8, turboWash: 0 }],
+            [Dryer, DRYER_MODEL, 7, { ecoHybrid: 3, dryLevel: 4, steam: 1 }],
+        ] as const) {
+            const { ha, thinq, dev } = make(Driver, model === WASHER_MODEL ? 'FAKPK21021' : 'BDH_D39301_KR')
+            const ready = Buffer.alloc(model.recordLength)
+            setRaw(ready, model, 'state', 1)
+            setRaw(ready, model, 'remoteStart', 1)
+            thinq.emit('data', buildWashtowerExtendedFrame(model.tag, 0xeb, ready))
+            const stateBefore = ha.devices['test-device'].properties.state
+            dev.setProperty('setting_course', label(model, 'course', course))
+            for (const [key, raw] of Object.entries(settings))
+                dev.setProperty(
+                    'setting_' + key.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase(),
+                    label(model, key, raw),
+                )
+            dev.setProperty('start_course', '')
+            assert.equal(thinq.outbox.length, 1)
+            assert.equal(thinq.outbox[0][3], 0x26)
+            assert.equal(ha.devices['test-device'].properties.state, stateBefore)
+        }
+    })
+
+    test('changing course atomically resets fixed defaults before start', () => {
+        const { thinq, dev } = make(Washer, 'FAKPK21021')
+        const ready = Buffer.alloc(WASHER_MODEL.recordLength)
+        setRaw(ready, WASHER_MODEL, 'state', 1)
+        setRaw(ready, WASHER_MODEL, 'remoteStart', 1)
+        thinq.emit('data', buildWashtowerExtendedFrame(0x33, 0xeb, ready))
+
+        dev.setProperty('setting_course', label(WASHER_MODEL, 'course', 46))
+        dev.setProperty('setting_temp', label(WASHER_MODEL, 'temp', 3))
+        dev.setProperty('setting_turbo_wash', label(WASHER_MODEL, 'turboWash', 1))
+        dev.setProperty('setting_course', label(WASHER_MODEL, 'course', 85))
+        dev.setProperty('start_course', '')
+
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(thinq.outbox[0].subarray(4, -2).toString('hex'), '550304050200000000005500000000000000000000')
+    })
+
+    test('built-in Course stays local, send_course emits nothing, and start emits exact F026 once', () => {
+        for (const [Driver, model, modelId, course, expectedFrame] of [
+            [Washer, WASHER_MODEL, 'FAKPK21021', 46, 'aa1bf0262e0306030200002000002e0000000000000000000030bb'],
+            [Dryer, DRYER_MODEL, 'BDH_D39301_KR', 7, 'aa14f0260703020000000000000000000000b5bb'],
+        ] as const) {
+            const { thinq, dev } = make(Driver, modelId)
+            const ready = Buffer.alloc(model.recordLength)
+            setRaw(ready, model, 'state', 1)
+            setRaw(ready, model, 'remoteStart', 1)
+            setRaw(ready, model, 'baseDownloadCourseData', 9)
+            setRaw(ready, model, 'downloadCourse', 9)
+            thinq.emit('data', buildWashtowerExtendedFrame(model.tag, 0xeb, ready))
+
+            dev.setProperty('setting_course', label(model, 'course', course))
+            assert.equal(thinq.outbox.length, 0, model.deviceName + ' local draft selection')
+            dev.setProperty('send_course', '')
+            assert.equal(thinq.outbox.length, 0, model.deviceName + ' unsupported send_course')
+            dev.setProperty('start_course', '')
+            assert.equal(thinq.outbox.length, 1, model.deviceName + ' WMStart count')
+            assert.equal(thinq.outbox[0].toString('hex'), expectedFrame)
+        }
+    })
+
+    // The individual gates are covered above one at a time. This pins the whole
+    // operator journey — Power ON, the appliance's own acknowledgement, the
+    // standard course and Start course — as one ordered frame sequence, so a change
+    // that keeps every single gate passing but breaks the run still fails here.
+    test('Power ON → Standard Course → Start course emits exactly the official frames in order', () => {
+        for (const [Driver, model, modelId, standard, startFrame] of [
+            [Washer, WASHER_MODEL, 'FAKPK21021', 46, 'aa1bf0262e0306030200002000002e0000000000000000000030bb'],
+            [Dryer, DRYER_MODEL, 'BDH_D39301_KR', 7, 'aa14f0260703020000000000000000000000b5bb'],
+        ] as const) {
+            const { ha, thinq, dev } = make(Driver, modelId)
+            const properties = () => ha.devices['test-device'].properties
+            assert.equal(label(model, 'course', standard), 'Standard', model.deviceName + ' Standard course index')
+
+            // 1. The appliance reports Power off, so Start course must fail closed.
+            const powerOff = Buffer.alloc(model.recordLength)
+            thinq.emit('data', buildWashtowerExtendedFrame(model.tag, 0xeb, powerOff))
+            assert.equal(properties().power, 'OFF')
+            assert.equal(properties().power_transition, 'Standby')
+            dev.setProperty('start_course', '')
+            assert.equal(thinq.outbox.length, 0, model.deviceName + ' start before power on')
+
+            // 2. Power ON, and a second press while the appliance has not answered
+            //    must not put a second frame on the wire.
+            dev.setProperty('power', 'ON')
+            assert.equal(properties().power_transition, 'Turning on')
+            assert.equal(properties().power, 'OFF', model.deviceName + ' no optimistic power echo')
+            dev.setProperty('power', 'ON')
+
+            // 3. The appliance acknowledges, which buys exactly one state refresh.
+            thinq.emit('data', powerOnResponse(model))
+            thinq.emit('data', powerOnResponse(model))
+
+            // 4. It then reports On with Remote start armed.
+            const ready = Buffer.alloc(model.recordLength)
+            setRaw(ready, model, 'state', 1)
+            setRaw(ready, model, 'remoteStart', 1)
+            thinq.emit('data', buildWashtowerExtendedFrame(model.tag, 0xeb, ready))
+            assert.equal(properties().power, 'ON')
+            assert.equal(properties().power_transition, 'Complete')
+            assert.equal(properties().remote_start, 'On')
+
+            // 5. Standard Course only moves the local draft.
+            dev.setProperty('setting_course', 'Standard')
+            assert.equal(thinq.outbox.length, 2, model.deviceName + ' course selection is local')
+
+            // 6. Start course.
+            dev.setProperty('start_course', '')
+
+            assert.deepEqual(
+                thinq.outbox.map((frame) => frame.toString('hex')),
+                [
+                    'aa0df0e5000201ff010201c7bb', // vtCtrl 0xE5 Power ON
+                    'aa12f0ed1121010000001804111200005ebb', // 0xED State Cho x, once
+                    startFrame, // WMStart 0x26 Standard Course
+                ],
+                model.deviceName + ' full journey frames',
+            )
+            assert.equal(properties().state, 'On', model.deviceName + ' no optimistic state echo')
+        }
+    })
+
+    test('dryer fixed steam defaults pass for REFRESH, ALLERGYCARE and TUBCLEAN', () => {
+        for (const course of [1, 16, 19]) {
+            const { thinq, dev } = make(Dryer, 'BDH_D39301_KR')
+            const ready = Buffer.alloc(DRYER_MODEL.recordLength)
+            setRaw(ready, DRYER_MODEL, 'state', 1)
+            setRaw(ready, DRYER_MODEL, 'remoteStart', 1)
+            thinq.emit('data', buildWashtowerExtendedFrame(0x34, 0xeb, ready))
+            dev.setProperty('setting_course', label(DRYER_MODEL, 'course', course))
+            dev.setProperty('start_course', '')
+            assert.equal(thinq.outbox.length, 1)
+        }
+    })
+})

--- a/util/device-id.ts
+++ b/util/device-id.ts
@@ -1,0 +1,5 @@
+const DEVICE_ID_RE = /^[A-Za-z0-9._:-]{1,64}$/
+
+export function validDeviceId(deviceId: unknown): deviceId is string {
+    return typeof deviceId === 'string' && DEVICE_ID_RE.test(deviceId)
+}


### PR DESCRIPTION
This adds support for nine Korean-market LG appliances I've been running daily through rethink, each verified against a live unit with bridge mode on (so every mapping had three witnesses: the value HA set, the tag the appliance reported, and `lge_thinq`'s decode of the same appliance), and each covered by decode-vector regression tests.

## Credit where it's due

**`DHUM_056905_WW` builds directly on @BluSyn's #64** — that driver, the `tlv_device` 0xA7 acceptance, and the `HumidifierComponent` discovery type all originate there (the in-code comments say so too). This PR's version extends it: properties beyond the panel's reach mapped from the model JSON, English labels, and a `ModeTables` export that the newer `DHUM_231006_WW` generation reuses. **If #64 lands first I'll gladly rebase on top of it** — it deserves to land on its own merits.

## New device handlers

| model | appliance | deviceType | notes |
|---|---|---|---|
| `CST_170004_WW` | wall/built-in DualCool IDU | 401 | on a new **`ac_common`** base |
| `DHUM_056905_WW` | dehumidifier | 402 | builds on #64, see above |
| `DHUM_231006_WW` | dehumidifier | 402 | RTL8720cm generation, reuses the 056905 tables |
| `HUM_056905_WW` | PuriCare humidifier | 404 | wire map from LG's own modelJSON `tlv_*` labels |
| `ST_B_E4H01Y_APL` | Styler S5BBP | 203 | AA FF frame layout |
| `HWWA9K_F2` | CordZero A9 stick vacuum | 504 | 12-field AA..BB frame |
| `1WPU4CIGCR__2` | water purifier ATOM-U | 103 | with local usage history |
| `FAKPK21021` | WashTower washer (KR) | 221 | dedicated 0xEB/0xEC decoder |
| `BDH_D39301_KR` | WashTower dryer (KR) | 222 | shared `washtower_common` base |

**About `ac_common`**: in #101 you suggested splitting a shared AC base class instead of translating packets to RAC's expectations — this PR contains that split, and `CST_170004_WW` is its first user. @3735943886's `CST_570004_WW` ceiling cassette should be able to sit on the same base.

The Korean WashTower models are complementary to #102's `WTL_FXU_BDV_NA_01` (different generation, different frame format — these speak a dedicated 0xEB/0xEC encoding decoded in `washtower_common`).

## Infrastructure the drivers stand on

- **`TLVDevice`**: byte 6 may be `0xA7` as well as `0x87` — the dehumidifier family frames with `0xA7` (from #64).
- **Persistent driver stores**: a `ReservationStore` (absolute reservation deadlines survive restarts, used by the AC) and a `PurifierHistoryStore` (water-purifier usage history), both small JSON stores threaded through the bridge as optional constructor parameters. Without a bridge storage path the drivers run stateless.
- **Discovery types**: `HumidifierComponent` (from #64), plus `modes`/`preset_modes` on `ClimateComponent`.
## Verification

- `npm test` — **502 passed, 0 failed** (251 upstream + 251 new)
- `tsc -p tsconfig.build.json --noEmit` — clean
- `prettier --check` — clean

Independent of #110 (only trivially-mergeable overlap in `cloud/homeassistant.ts` type declarations). Happy to split this into per-device PRs if that's easier to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

