### PR TITLE
RAC_056905_WW: Small fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ aid, or simply to allow the user to still use the original LG app alongside Home
 The following appliances are currently supported in rethink:
 
 - Air Conditioners:
-    - 👍 LG DualCool family (Standard 2, Deluxe with and without air purifier, etc.) wall-mounted Air Conditioner IDUs - high level of support. What's missing are mostly some features of higher-end models, energy reporting for Single devices and more diagnostic coverage,
+    - 👍 LG DualCool family (Standard 2, Deluxe with and without air purifier, etc.) wall-mounted Air Conditioner IDUs - high level of support. What's missing are mostly some features of higher-end models and more diagnostic coverage,
     - 👍 LW1822HRSM, Smart Window Air Conditioner - mostly working,
     - 👍 LP1022FVSM Portable Air Conditioner - mostly working,
 - Fridges:

--- a/cloud/devices/RAC_056905_WW.ts
+++ b/cloud/devices/RAC_056905_WW.ts
@@ -27,6 +27,7 @@ export default class Device extends TLVDevice {
     filterChangedDate: number = 0
     filterInitialQueryTimeout: ReturnType<typeof setTimeout> | undefined
     filterQueryTimer: ReturnType<typeof setInterval> | undefined
+    filterDoReset: boolean = false
 
     constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
         super(HA, thinq)
@@ -148,6 +149,11 @@ export default class Device extends TLVDevice {
         } else {
             // if this was not the initial query just update the HA values
             this.publishFilterData()
+        }
+
+        if (this.filterDoReset) {
+            this.filterDoReset = false
+            this.sendFilterReset()
         }
     }
 
@@ -694,7 +700,11 @@ export default class Device extends TLVDevice {
                 comp: '',
                 write_xform: (val) => (val === 'PRESS' ? 1 : 0),
                 write_callback: (val) => {
-                    if (val === 1) this.sendFilterReset()
+                    if (val === 1) {
+                        this.filterDoReset = true
+                        // do a query first to get the most recent pre-reset values
+                        this.sendFilterQuery()
+                    }
                     return false
                 },
             }

--- a/cloud/devices/RAC_056905_WW.ts
+++ b/cloud/devices/RAC_056905_WW.ts
@@ -305,9 +305,19 @@ export default class Device extends TLVDevice {
             write_attach: (raw) => (raw ? [0x1f9, 0x1fa, 0x1fe] : []),
             read_xform: (raw) => (raw ? 'ON' : 'OFF'),
             read_callback: (val) => {
-                // update 'mode' instead
+                /*
+                 * Update 'mode' instead.
+                 *
+                 * This means that power state change will effectively also
+                 * call mode change hooks since mode will switch between 'off'
+                 * and the actual set mode.
+                 */
                 this.processKeyValue(0x1f9, this.raw_clip_state[0x1f9])
 
+                /*
+                 * Call these hooks only after updating 'mode' in case
+                 * they depend on it being correctly set.
+                 */
                 const powerState = val === 'ON'
                 if (this.powerStatePrev !== powerState) for (const hook of this.powerChangeHooks) hook()
                 this.powerStatePrev = powerState
@@ -641,9 +651,6 @@ export default class Device extends TLVDevice {
             )
         }
 
-        this.powerChangeHooks.push(() => {
-            this.updateClimateAction()
-        })
         this.modeChangeHooks.push(() => {
             this.updateClimateAction()
         })
@@ -860,10 +867,6 @@ export default class Device extends TLVDevice {
          * This value needs to be written at each power up in heat/cool mode,
          * but in a separate message.
          */
-        this.powerChangeHooks.push(() => {
-            if (this.getPowerTLV() === 0) return
-            this.setProperty(name + '-', this.jetMode ? 'ON' : 'OFF')
-        })
         this.modeChangeHooks.push(() => {
             this.setProperty(name + '-', this.jetMode ? 'ON' : 'OFF')
         })
@@ -996,17 +999,17 @@ export default class Device extends TLVDevice {
             },
         })
 
-        this.powerChangeHooks.push(() => {
-            if (this.getPowerTLV() === 0) return
-            /*
-             * This value needs to be written at each power up,
-             * but in a separate message.
-             */
-            this.setProperty(name + '-', this[field_name] ? 'ON' : 'OFF')
-        })
-
         if (!!check_mode) {
             this.modeChangeHooks.push(() => {
+                this.setProperty(name + '-', this[field_name] ? 'ON' : 'OFF')
+            })
+        } else {
+            this.powerChangeHooks.push(() => {
+                if (this.getPowerTLV() === 0) return
+                /*
+                 * This value needs to be written at each power up,
+                 * but in a separate message.
+                 */
                 this.setProperty(name + '-', this[field_name] ? 'ON' : 'OFF')
             })
         }


### PR DESCRIPTION
A set of 3 almost trivial small fixups for `RAC_056905_WW`:

* Do a filter query immediately before filter reset to make sure the most recent pre-reset values are stored in HA.

* Update `README` to drop "energy reporting for Single devices" from DualCool missing features as this was already implemented by @anszom some time ago.

* Remove unnecessary/duplicated power change hooks.