### PR TITLE
Add LG dehumidifiers DHUM_056905_WW and DHUM_231006_WW

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The following appliances are currently supported in rethink:
     - 👍 WKEX200HBA (WTL_FXU_BDV_NA_01), WashTower - mostly working
 - Dehumidifiers
     - 👍 MD19GQGE0, Smart Dehumidifier - mostly working
+    - 👍 DHUM_231006_WW, Dehumidifier - mostly working
 - Range Hoods:
     - 👍 HCED3015D (STUDIO_HOOD), Generic identifier and probably works with multiple models. Working.
 - Stylers:

--- a/cloud/devices/DHUM_056905_WW.ts
+++ b/cloud/devices/DHUM_056905_WW.ts
@@ -1,428 +1,57 @@
-import TLVDevice from './tlv_device'
-import { Device as Thinq2Device } from '../thinq2/device'
-import { DeviceDiscovery, type Connection, type HumidifierComponent } from '../homeassistant'
-import { type Metadata } from '../thinq'
-import { allowExtendedType } from '@/util/casting'
+import DhumDevice, { defineDhumProfile } from './dhum_common'
 import * as TLV from '@/util/tlv'
-import HADevice from './base'
 
-/**
- * TLV tags present in capability (0xA7/0x01) packets — store during the caps query phase
- * but do not publish as entity values. After caps are received, 0x336 is handled as
- * current humidity via its field definition.
- */
-const CAPS_ONLY_TAGS = new Set([0x2d5, 0x2d6, 0x336, 0x2e5, 0x2e6, 0x2da])
-
-/** Observed on bucket-empty notify when the tank is reinstalled (0x2b1=256, 0x2b2=0). */
-const BUCKET_EMPTIED_EVENT = 256
-
-/** Entering these modes resets fan speed to low (high remains user-selectable). */
-const SILENT_MODES = new Set([2, 19])
-
-const HA_MODES = ['Smart', 'Jet', 'Silent', 'Spot', 'Laundry'] as const
-
-const CLIP_TO_HA_MODE: Record<number, string> = {
-    0: 'Smart',
-    1: 'Jet',
-    2: 'Silent',
-    4: 'Spot',
-    5: 'Laundry',
-    17: 'Smart',
-    18: 'Jet',
-    19: 'Silent',
-    20: 'Spot',
-    21: 'Laundry',
-}
-
-const HA_TO_CLIP_MODE: Record<string, number> = {
-    Smart: 17,
-    Jet: 18,
-    Silent: 19,
-    Spot: 20,
-    Laundry: 21,
-}
-
-/**
- * Per-mode fan capability table resent with every fan-speed write.
- *
- * The panel/device does not treat fan speed as a single global value alone: a write of
- * 0x1fa must be accompanied by a repeating 3-tuple capability declaration:
- *   0x2d7 = operating-mode id
- *   0x2d8 = 0 (always observed)
- *   0x2d9 = fan speed that mode should run at (2 = low, 6 = high)
- *
- * Most modes accept the requested fan speed. Laundry is fixed at high — that is a
- * property of the mode, not a special-case in the write path. Mode 22 appears in the
- * on-wire table on observed units but is not exposed in the ThinQ app / HA modes list.
- *
- * This is a capability declaration, not device state: it must not be stored in
- * raw_clip_state (those tags are not globally unique — they repeat once per mode row).
- */
-type ModeFanCap = {
-    mode: number
-    /** When set, 0x2d9 is always this value; otherwise it follows the requested fan. */
-    fixedFan?: 2 | 6
-}
-
-const MODE_FAN_CAPS: readonly ModeFanCap[] = [
-    { mode: 17 }, // Smart
-    { mode: 18 }, // Jet
-    { mode: 20 }, // Spot
-    { mode: 21, fixedFan: 6 }, // Laundry — high fan only
-    { mode: 22 }, // present on-wire; not exposed in app
-]
-
-function normalizeHaMode(val: string): string {
-    return val.charAt(0).toUpperCase() + val.slice(1).toLowerCase()
-}
-
-/**
- * LG Dehumidifier DHUM_056905_WW (e.g. models using 056905 platform, deviceType 403)
- */
-export default class Device extends TLVDevice {
-    powerStatePrev?: boolean
-    modePrev?: string
-    modeClipPrev?: number
-    initialValuesReceived = false
-    /** Last bucket-full state published to HA (retained). */
-    bucketFullHaState?: boolean
-
-    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
-        super(HA, thinq)
-        const config: DeviceDiscovery & { components: { humidifier: HumidifierComponent } } = allowExtendedType({
-            ...HADevice.config(meta, { name: 'LG Dehumidifier' }),
-            components: {
-                humidifier: {
-                    platform: 'humidifier',
-                    unique_id: '$deviceid-humidifier',
-                    name: null,
-                    device_class: 'dehumidifier',
-                    modes: [...HA_MODES],
-                    min_humidity: 30,
-                    max_humidity: 70,
-                } satisfies HumidifierComponent,
-                ionizer: {
-                    platform: 'switch',
-                    unique_id: '$deviceid-ionizer',
-                    name: 'Ionizer',
-                    icon: 'mdi:air-filter',
-                },
-                uv_nano: {
-                    platform: 'switch',
-                    unique_id: '$deviceid-uv_nano',
-                    name: 'UVnano',
-                    icon: 'mdi:lightbulb',
-                },
-                bucket_light: {
-                    platform: 'switch',
-                    unique_id: '$deviceid-bucket_light',
-                    name: 'Bucket Light',
-                    icon: 'mdi:lightbulb-on',
-                },
-                // MQTT humidifier platform has no fan_mode support; use a select entity instead.
-                fan_speed: {
-                    platform: 'select',
-                    unique_id: '$deviceid-fan_speed',
-                    name: 'Fan speed',
-                    icon: 'mdi:fan',
-                    options: ['low', 'high'],
-                },
-                current_humidity: {
-                    platform: 'sensor',
-                    unique_id: '$deviceid-current_humidity',
-                    name: 'Current humidity',
-                    device_class: 'humidity',
-                    unit_of_measurement: '%',
-                    state_class: 'measurement',
-                    state_topic: '$this/humidifier-current_humidity',
-                },
-                bucket_full: {
-                    platform: 'binary_sensor',
-                    unique_id: '$deviceid-bucket_full',
-                    name: 'Bucket full',
-                    icon: 'mdi:water-alert',
-                    device_class: 'problem',
-                    payload_on: 'ON',
-                    payload_off: 'OFF',
-                    state_topic: '$this/bucket_full-',
-                },
-            },
-        })
-
-        // power (0x1f7) - registered as humidifier-power; we wire bare state/command below
-        this.addField(
-            config,
-            {
-                id: 0x1f7,
-                name: 'power',
-                comp: 'humidifier',
-                write_xform: (val) => (val === 'ON' ? 1 : 0),
-                write_attach: (raw) => (raw ? [0x1f9] : []),
-                read_xform: (raw) => (raw ? 'ON' : 'OFF'),
-                read_callback: (val) => {
-                    const powerState = val === 'ON'
-                    if (this.powerStatePrev !== powerState) {
-                        // future hooks
-                    }
-                    this.powerStatePrev = powerState
-                    return true // allow the power state publish
-                },
-            },
-            false,
-        )
-
-        // mode / op mode
-        this.addField(config, {
-            id: 0x1f9,
-            name: 'mode',
-            comp: 'humidifier',
-            read_xform: (raw) => CLIP_TO_HA_MODE[raw] ?? `mode${raw}`,
-            read_callback: () => {
-                const mode = this.raw_clip_state[0x1f9]
-                if (
-                    mode != null &&
-                    SILENT_MODES.has(mode) &&
-                    (this.modeClipPrev == null || !SILENT_MODES.has(this.modeClipPrev))
-                ) {
-                    this.publishFanSpeedState('low')
-                }
-                if (mode != null) this.modeClipPrev = mode
-                return true
-            },
-            write_xform: (val) => {
-                if (val === 'off' || val === undefined) {
-                    this.setProperty('humidifier-power', 'OFF')
-                    return undefined
-                }
-
-                // Power on via attached 0x1f7
-                this.raw_clip_state[0x1f7] = 1
-
-                const mode = normalizeHaMode(val)
-                const clip = HA_TO_CLIP_MODE[mode] ?? Number(val)
-                if (mode === 'Silent' && (this.modeClipPrev == null || !SILENT_MODES.has(this.modeClipPrev))) {
-                    this.raw_clip_state[0x1fa] = 2
-                    this.publishFanSpeedState('low')
-                }
-                if (typeof clip === 'number') this.modeClipPrev = clip
-                return clip
-            },
-            write_attach: [0x1f7],
-        })
-
-        this.addField(config, {
-            id: 0x1fa,
-            name: '',
-            comp: 'fan_speed',
-            read_xform: (raw) => {
-                const modes2ha: Record<number, string> = { 2: 'low', 6: 'high' }
-                return modes2ha[raw] ?? raw.toString()
-            },
-            read_callback: (val) => {
-                this.publishFanSpeedState(typeof val === 'string' ? val : String(val))
-                return false
-            },
-            write_xform: (val) => {
-                const modes2clip: Record<string, number> = { low: 2, high: 6 }
-                return modes2clip[val] ?? Number(val)
-            },
-            write_callback: (val) => {
-                if (val !== 2 && val !== 6) return false
-                this.sendFanSpeedTlvs(val)
-                return false
-            },
-        })
-
-        // current humidity: ThinQ maps 0x336 → airState.humidity.current (live packets).
-        // 0x1fd is a different property on this platform family (temperature on RAC/WIN).
-        this.addField(config, {
-            id: 0x336,
-            name: 'current_humidity',
-            comp: 'humidifier',
-            state_topic: 'topic',
-            writable: false,
-        })
-
-        // target humidity setpoint (0x253 on live A7/0x04 notify packets, e.g. v=35)
-        this.addField(config, {
-            id: 0x253,
-            name: 'target_humidity',
-            comp: 'humidifier',
-            read_xform: (raw) => raw,
-            read_callback: (val) => {
-                const n = typeof val === 'number' ? val : Number(val)
-                return n >= 30 && n <= 70
-            },
-            write_xform: (valStr) => {
-                let val = Number(valStr)
-                if (val < 30) val = 30
-                if (val > 70) val = 70
-                val = Math.round(val)
-                this.raw_clip_state[0x1f7] = 1
-                return val
-            },
-            write_attach: [0x1f7, 0x1f9],
-        })
-
-        // ionizer on/off (0x360 on live notify packets: 0=OFF, 1=ON)
-        this.addField(config, {
-            id: 0x360,
-            name: '',
-            comp: 'ionizer',
-            read_xform: (raw) => (raw ? 'ON' : 'OFF'),
-            write_xform: (val) => (val === 'ON' ? 1 : 0),
-            write_attach: [0x1f7, 0x1f9],
-        })
-
-        // UVnano (0x2a2 on live notify packets: 0=OFF, 1=ON)
-        this.addField(config, {
-            id: 0x2a2,
-            name: '',
-            comp: 'uv_nano',
-            read_xform: (raw) => (raw ? 'ON' : 'OFF'),
-            write_xform: (val) => (val === 'ON' ? 1 : 0),
-            write_attach: [0x1f7, 0x1f9],
-        })
-
-        // bucket light (0x21e on live notify packets: 0=OFF, 1=ON)
-        this.addField(config, {
-            id: 0x21e,
-            name: '',
-            comp: 'bucket_light',
-            read_xform: (raw) => (raw ? 'ON' : 'OFF'),
-            write_xform: (val) => (val === 'ON' ? 1 : 0),
-        })
-
-        this.addTimerField(config, 0x21b, 'off_timer', 'Sleep timer', 'mdi:bed-clock', 9)
-
-        // Wire bare state_topic/command_topic (expected by humidifier platform) to our 'power' property
-        const hum = (config.components as any).humidifier
-        hum.state_topic = '$this/humidifier-power'
-        hum.command_topic = '$this/humidifier-power/set'
-
-        this.setConfig(config)
-    }
-
-    addTimerField(config: DeviceDiscovery, id: number, name: string, desc: string, icon: string, max: number) {
-        const step = 1
-        const comp = {
-            platform: 'number',
-            unique_id: '$deviceid-' + name,
-            name: desc,
-            icon: icon,
-            device_class: 'duration',
-            unit_of_measurement: 'h',
-            min: 0,
-            max: max,
-            step: step,
-            mode: 'slider',
-        } as const
-        config['components'][name] = comp
-
-        /*
-         * HA unit is hours; TLV is minutes (hours×60), same as RAC timers on 0x21b.
-         * Countdown notifies also report remaining time in minutes.
-         */
-        this.addField(config, {
-            id: id,
-            name: '',
-            comp: name,
-            read_xform: (raw) => Math.ceil(raw / 60 / step) * step,
-            write_xform: (val) => Math.round(Number(val) * 60),
-        })
-    }
-
-    private fanSpeedFromClip(raw?: number): string {
-        const v = raw ?? this.raw_clip_state[0x1fa]
-        if (v === 6) return 'high'
-        if (v === 2) return 'low'
-        return v != null ? String(v) : 'low'
-    }
-
-    private publishFanSpeedState(override?: string) {
-        const state = override ?? this.fanSpeedFromClip()
-        this.HA.publishProperty(this.id, 'fan_speed-', state)
-    }
+/** LG Dehumidifier DHUM_056905_WW (deviceType 403). */
+export default class Device extends DhumDevice {
+    static profile = defineDhumProfile({
+        modes: [
+            [0, 'Smart'],
+            [1, 'Jet'],
+            [2, 'Silent'],
+            [4, 'Spot'],
+            [5, 'Laundry'],
+            [17, 'Smart'],
+            [18, 'Jet'],
+            [19, 'Silent'],
+            [20, 'Spot'],
+            [21, 'Laundry'],
+        ],
+        fans: [
+            [2, 'low'],
+            [6, 'high'],
+        ],
+        silentModes: [2, 19],
+        lowFanClip: 2,
+        features: {
+            ionizer: true,
+            uvNano: true,
+            bucketLight: true,
+            bucketFull: true,
+            offTimer: true,
+        },
+    })
 
     /**
-     * Build the fan-speed write payload: requested speed (0x1fa) plus MODE_FAN_CAPS rows.
-     * Equivalent expanded form for fan=2:
-     *   0x1fa=2,
-     *   modeFan(17, 2), modeFan(18, 2), modeFan(20, 2),
-     *   modeFan(21, 6), // Laundry always high
-     *   modeFan(22, 2)
+     * This model writes its fan setpoint together with the captured per-mode table.
+     * Laundry is fixed high; mode 22 is present on-wire but is not exposed in HA.
      */
-    private buildFanSpeedTlvs(fan: 2 | 6): TLV.TLV[] {
-        const modeFanRow = (mode: number, fanSpeed: number): TLV.TLV[] => [
+    protected sendFanSpeedTlvs(fan: number): boolean {
+        const row = (mode: number, fanSpeed: number): TLV.TLV[] => [
             { t: 0x2d7, v: mode },
             { t: 0x2d8, v: 0 },
             { t: 0x2d9, v: fanSpeed },
         ]
+        const tlvs: TLV.TLV[] = [
+            { t: 0x1fa, v: fan },
+            ...row(17, fan),
+            ...row(18, fan),
+            ...row(20, fan),
+            ...row(21, 6),
+            ...row(22, fan),
+        ]
 
-        const tlvs: TLV.TLV[] = [{ t: 0x1fa, v: fan }]
-        for (const { mode, fixedFan } of MODE_FAN_CAPS) {
-            tlvs.push(...modeFanRow(mode, fixedFan ?? fan))
-        }
-
-        // Only the actual fan setpoint is device state; mode rows are a capability declaration.
         this.raw_clip_state[0x1fa] = fan
-        return tlvs
-    }
-
-    private sendFanSpeedTlvs(fan: 2 | 6) {
-        this.send([1, 1, 2, 1, 1], this.buildFanSpeedTlvs(fan))
-    }
-
-    private publishBucketFullState(full: boolean) {
-        if (this.bucketFullHaState === full) return
-        this.bucketFullHaState = full
-        this.HA.publishProperty(this.id, 'bucket_full-', full ? 'ON' : 'OFF', { retain: true })
-    }
-
-    processKeyValue(k: number, v: number) {
-        if (this.query_caps_timeout !== undefined && CAPS_ONLY_TAGS.has(k)) {
-            this.raw_clip_state[k] = v
-            return
-        }
-        // Mode-fan capability rows (0x2d7/0x2d8/0x2d9) repeat once per mode — not global state.
-        if (k === 0x2d7 || k === 0x2d8 || k === 0x2d9) return
-        if (k === 0x2b1) {
-            this.raw_clip_state[k] = v
-            if (v === BUCKET_EMPTIED_EVENT) this.publishBucketFullState(false)
-            return
-        }
-        if (k === 0x2b2) {
-            this.raw_clip_state[k] = v
-            this.publishBucketFullState(v !== 0)
-            return
-        }
-        super.processKeyValue(k, v)
-    }
-
-    isCapsResponse(tlvArray: TLV.TLV[]) {
-        return tlvArray.some(({ t }) => t === 0x2da)
-    }
-
-    isValuesResponse(tlvArray: TLV.TLV[]) {
-        return tlvArray.some(
-            ({ t }) =>
-                t === 0x1f7 ||
-                t === 0x1f9 ||
-                t === 0x1fa ||
-                t === 0x21b ||
-                t === 0x21e ||
-                t === 0x2b2 ||
-                t === 0x253 ||
-                t === 0x2a2 ||
-                t === 0x336 ||
-                t === 0x360,
-        )
-    }
-
-    valuesReceived() {
-        if (this.initialValuesReceived) return
-        this.initialValuesReceived = true
-
-        this.thinq.send('setMaskingInfo', 0, { blacklist_tlv: '1200' })
+        this.send([1, 1, 2, 1, 1], tlvs)
+        return false
     }
 }

--- a/cloud/devices/DHUM_231006_WW.ts
+++ b/cloud/devices/DHUM_231006_WW.ts
@@ -1,0 +1,53 @@
+import DhumDevice, { defineDhumProfile } from './dhum_common'
+import type * as TLV from '@/util/tlv'
+
+/**
+ * LG Dehumidifier DHUM_231006_WW (deviceType 403, BEKEN_BK7234, protocolVer 7).
+ *
+ * A captured values packet reports modes 19/20/85/86 and fan-memory rows using
+ * 2/7/8. Captured cloud writes additionally confirm fan 6. LG's model metadata
+ * defines code 4 as the remaining medium fan level.
+ */
+export default class Device extends DhumDevice {
+    static profile = defineDhumProfile({
+        modes: [
+            [86, 'Smart Plus'],
+            [19, 'Silent'],
+            [20, 'Intensive'],
+            [85, 'Quick'],
+        ],
+        fans: [
+            [8, 'auto'],
+            [2, 'low'],
+            [4, 'medium'],
+            [6, 'high'],
+            [7, 'turbo'],
+        ],
+        lowFanClip: 2,
+        combinedInitialResponse: true,
+        features: {
+            ionizer: true,
+            uvNano: true,
+            bucketLight: true,
+            offTimer: true,
+        },
+    })
+
+    isCapsResponse(tlvArray: TLV.TLV[]) {
+        /*
+         * Unlike 056905, this model's captured initial response has no 0x2da
+         * marker. It combines current values with the repeated 0x2d7/0x2d8/
+         * 0x2d9 mode/fan capability rows, so recognize that observed shape.
+         */
+        const tags = new Set(tlvArray.map(({ t }) => t))
+        return (
+            (tags.has(0x1f7) &&
+                tags.has(0x1f9) &&
+                tags.has(0x1fa) &&
+                tags.has(0x2d7) &&
+                tags.has(0x2d8) &&
+                tags.has(0x2d9)) ||
+            super.isCapsResponse(tlvArray)
+        )
+    }
+}

--- a/cloud/devices/dhum_common.ts
+++ b/cloud/devices/dhum_common.ts
@@ -1,0 +1,424 @@
+import TLVDevice from './tlv_device'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { DeviceDiscovery, type Connection, type HumidifierComponent } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import * as TLV from '@/util/tlv'
+import HADevice from './base'
+
+/**
+ * TLV tags present in capability (0xA7/0x01) packets — store during the caps query phase
+ * but do not publish as entity values. After caps are received, 0x336 is handled as
+ * current humidity via its field definition.
+ */
+const CAPS_ONLY_TAGS = new Set([0x2d5, 0x2d6, 0x336, 0x2e5, 0x2e6, 0x2da])
+
+/** Observed on bucket-empty notify when the tank is reinstalled (0x2b1=256, 0x2b2=0). */
+const BUCKET_EMPTIED_EVENT = 256
+
+export type DhumEnumTable = readonly (readonly [clipValue: number, label: string])[]
+
+export type DhumFeatures = {
+    ionizer?: boolean
+    uvNano?: boolean
+    bucketLight?: boolean
+    bucketFull?: boolean
+    offTimer?: boolean
+}
+
+type ExpandedEnumTable = {
+    toHa: Readonly<Record<number, string>>
+    toClip: Readonly<Record<string, number>>
+    options: readonly string[]
+    clipValues: ReadonlySet<number>
+}
+
+export type DhumProfile = {
+    modes: ExpandedEnumTable
+    fans: ExpandedEnumTable
+    silentModes: ReadonlySet<number>
+    lowFanClip: number
+    /** Initial response carries both capability rows and live state. */
+    combinedInitialResponse?: boolean
+    features: DhumFeatures
+}
+
+export type DhumProfileDefinition = {
+    modes: DhumEnumTable
+    fans: DhumEnumTable
+    silentModes?: readonly number[]
+    lowFanClip: number
+    combinedInitialResponse?: boolean
+    features?: DhumFeatures
+}
+
+function expandEnumTable(table: DhumEnumTable): ExpandedEnumTable {
+    const toHa: Record<number, string> = {}
+    const toClip: Record<string, number> = {}
+    const options: string[] = []
+
+    for (const [clipValue, label] of table) {
+        toHa[clipValue] = label
+        toClip[label.toLowerCase()] = clipValue
+        if (!options.includes(label)) options.push(label)
+    }
+
+    return {
+        toHa,
+        toClip,
+        options,
+        clipValues: new Set(table.map(([clipValue]) => clipValue)),
+    }
+}
+
+/** Build every derived lookup from the two model-specific wire tables. */
+export function defineDhumProfile(definition: DhumProfileDefinition): DhumProfile {
+    return {
+        modes: expandEnumTable(definition.modes),
+        fans: expandEnumTable(definition.fans),
+        silentModes: new Set(definition.silentModes),
+        lowFanClip: definition.lowFanClip,
+        combinedInitialResponse: definition.combinedInitialResponse,
+        features: definition.features ?? {},
+    }
+}
+
+export default class Device extends TLVDevice {
+    static profile: DhumProfile
+
+    profile(): DhumProfile {
+        return (this.constructor as typeof Device).profile
+    }
+
+    powerStatePrev?: boolean
+    modePrev?: string
+    modeClipPrev?: number
+    initialValuesReceived = false
+    /** Last bucket-full state published to HA (retained). */
+    bucketFullHaState?: boolean
+
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        const config: DeviceDiscovery & { components: { humidifier: HumidifierComponent } } = allowExtendedType({
+            ...HADevice.config(meta, { name: 'LG Dehumidifier' }),
+            components: {
+                humidifier: {
+                    platform: 'humidifier',
+                    unique_id: '$deviceid-humidifier',
+                    name: null,
+                    device_class: 'dehumidifier',
+                    modes: [...this.profile().modes.options],
+                    min_humidity: 30,
+                    max_humidity: 70,
+                } satisfies HumidifierComponent,
+                ionizer: {
+                    platform: 'switch',
+                    unique_id: '$deviceid-ionizer',
+                    name: 'Ionizer',
+                    icon: 'mdi:air-filter',
+                },
+                uv_nano: {
+                    platform: 'switch',
+                    unique_id: '$deviceid-uv_nano',
+                    name: 'UVnano',
+                    icon: 'mdi:lightbulb',
+                },
+                bucket_light: {
+                    platform: 'switch',
+                    unique_id: '$deviceid-bucket_light',
+                    name: 'Bucket Light',
+                    icon: 'mdi:lightbulb-on',
+                },
+                // MQTT humidifier platform has no fan_mode support; use a select entity instead.
+                fan_speed: {
+                    platform: 'select',
+                    unique_id: '$deviceid-fan_speed',
+                    name: 'Fan speed',
+                    icon: 'mdi:fan',
+                    options: [...this.profile().fans.options],
+                },
+                current_humidity: {
+                    platform: 'sensor',
+                    unique_id: '$deviceid-current_humidity',
+                    name: 'Current humidity',
+                    device_class: 'humidity',
+                    unit_of_measurement: '%',
+                    state_class: 'measurement',
+                    state_topic: '$this/humidifier-current_humidity',
+                },
+                bucket_full: {
+                    platform: 'binary_sensor',
+                    unique_id: '$deviceid-bucket_full',
+                    name: 'Bucket full',
+                    icon: 'mdi:water-alert',
+                    device_class: 'problem',
+                    payload_on: 'ON',
+                    payload_off: 'OFF',
+                    state_topic: '$this/bucket_full-',
+                },
+            },
+        })
+        const features = this.profile().features
+        if (!features.ionizer) delete config.components.ionizer
+        if (!features.uvNano) delete config.components.uv_nano
+        if (!features.bucketLight) delete config.components.bucket_light
+        if (!features.bucketFull) delete config.components.bucket_full
+
+        // power (0x1f7) - registered as humidifier-power; we wire bare state/command below
+        this.addField(
+            config,
+            {
+                id: 0x1f7,
+                name: 'power',
+                comp: 'humidifier',
+                write_xform: (val) => (val === 'ON' ? 1 : 0),
+                write_attach: (raw) => (raw ? [0x1f9] : []),
+                read_xform: (raw) => (raw ? 'ON' : 'OFF'),
+                read_callback: (val) => {
+                    const powerState = val === 'ON'
+                    if (this.powerStatePrev !== powerState) {
+                        // future hooks
+                    }
+                    this.powerStatePrev = powerState
+                    return true // allow the power state publish
+                },
+            },
+            false,
+        )
+
+        // mode / op mode
+        this.addField(config, {
+            id: 0x1f9,
+            name: 'mode',
+            comp: 'humidifier',
+            read_xform: (raw) => this.profile().modes.toHa[raw] ?? 'unknown',
+            read_callback: () => {
+                const mode = this.raw_clip_state[0x1f9]
+                if (
+                    mode != null &&
+                    this.profile().silentModes.has(mode) &&
+                    (this.modeClipPrev == null || !this.profile().silentModes.has(this.modeClipPrev))
+                ) {
+                    this.publishFanSpeedState(this.fanSpeedFromClip(this.profile().lowFanClip))
+                }
+                if (mode != null) this.modeClipPrev = mode
+                return true
+            },
+            write_xform: (val) => {
+                if (val === 'off' || val === undefined) {
+                    this.setProperty('humidifier-power', 'OFF')
+                    return undefined
+                }
+
+                const clip = this.profile().modes.toClip[val.toLowerCase()]
+                if (clip === undefined) return undefined
+
+                // Power on via attached 0x1f7
+                this.raw_clip_state[0x1f7] = 1
+                if (
+                    this.profile().silentModes.has(clip) &&
+                    (this.modeClipPrev == null || !this.profile().silentModes.has(this.modeClipPrev))
+                ) {
+                    this.raw_clip_state[0x1fa] = this.profile().lowFanClip
+                    this.publishFanSpeedState(this.fanSpeedFromClip(this.profile().lowFanClip))
+                }
+                this.modeClipPrev = clip
+                return clip
+            },
+            write_attach: [0x1f7],
+        })
+
+        this.addField(config, {
+            id: 0x1fa,
+            name: '',
+            comp: 'fan_speed',
+            read_xform: (raw) => this.profile().fans.toHa[raw] ?? 'unknown',
+            read_callback: (val) => {
+                this.publishFanSpeedState(typeof val === 'string' ? val : String(val))
+                return false
+            },
+            write_xform: (val) => this.profile().fans.toClip[val.toLowerCase()],
+            write_callback: (val) => {
+                if (!this.profile().fans.clipValues.has(val)) return false
+                return this.sendFanSpeedTlvs(val)
+            },
+        })
+
+        // current humidity: ThinQ maps 0x336 → airState.humidity.current (live packets).
+        // 0x1fd is a different property on this platform family (temperature on RAC/WIN).
+        this.addField(config, {
+            id: 0x336,
+            name: 'current_humidity',
+            comp: 'humidifier',
+            state_topic: 'topic',
+            writable: false,
+        })
+
+        // target humidity setpoint (0x253 on live A7/0x04 notify packets, e.g. v=35)
+        this.addField(config, {
+            id: 0x253,
+            name: 'target_humidity',
+            comp: 'humidifier',
+            read_xform: (raw) => raw,
+            read_callback: (val) => {
+                const n = typeof val === 'number' ? val : Number(val)
+                return n >= 30 && n <= 70
+            },
+            write_xform: (valStr) => {
+                let val = Number(valStr)
+                if (val < 30) val = 30
+                if (val > 70) val = 70
+                val = Math.round(val)
+                this.raw_clip_state[0x1f7] = 1
+                return val
+            },
+            write_attach: [0x1f7, 0x1f9],
+        })
+
+        if (features.ionizer) {
+            // ionizer on/off (0x360 on live notify packets: 0=OFF, 1=ON)
+            this.addField(config, {
+                id: 0x360,
+                name: '',
+                comp: 'ionizer',
+                read_xform: (raw) => (raw ? 'ON' : 'OFF'),
+                write_xform: (val) => (val === 'ON' ? 1 : 0),
+                write_attach: [0x1f7, 0x1f9],
+            })
+        }
+
+        if (features.uvNano) {
+            // UVnano (0x2a2 on live notify packets: 0=OFF, 1=ON)
+            this.addField(config, {
+                id: 0x2a2,
+                name: '',
+                comp: 'uv_nano',
+                read_xform: (raw) => (raw ? 'ON' : 'OFF'),
+                write_xform: (val) => (val === 'ON' ? 1 : 0),
+                write_attach: [0x1f7, 0x1f9],
+            })
+        }
+
+        if (features.bucketLight) {
+            // bucket light (0x21e on live notify packets: 0=OFF, 1=ON)
+            this.addField(config, {
+                id: 0x21e,
+                name: '',
+                comp: 'bucket_light',
+                read_xform: (raw) => (raw ? 'ON' : 'OFF'),
+                write_xform: (val) => (val === 'ON' ? 1 : 0),
+            })
+        }
+
+        if (features.offTimer) this.addTimerField(config, 0x21b, 'off_timer', 'Sleep timer', 'mdi:bed-clock', 9)
+
+        // Wire bare state_topic/command_topic (expected by humidifier platform) to our 'power' property
+        const hum = (config.components as any).humidifier
+        hum.state_topic = '$this/humidifier-power'
+        hum.command_topic = '$this/humidifier-power/set'
+
+        this.setConfig(config)
+    }
+
+    addTimerField(config: DeviceDiscovery, id: number, name: string, desc: string, icon: string, max: number) {
+        const step = 1
+        const comp = {
+            platform: 'number',
+            unique_id: '$deviceid-' + name,
+            name: desc,
+            icon: icon,
+            device_class: 'duration',
+            unit_of_measurement: 'h',
+            min: 0,
+            max: max,
+            step: step,
+            mode: 'slider',
+        } as const
+        config['components'][name] = comp
+
+        /*
+         * HA unit is hours; TLV is minutes (hours×60), same as RAC timers on 0x21b.
+         * Countdown notifies also report remaining time in minutes.
+         */
+        this.addField(config, {
+            id: id,
+            name: '',
+            comp: name,
+            read_xform: (raw) => Math.ceil(raw / 60 / step) * step,
+            write_xform: (val) => Math.round(Number(val) * 60),
+        })
+    }
+
+    private fanSpeedFromClip(raw?: number): string {
+        const v = raw ?? this.raw_clip_state[0x1fa]
+        return this.profile().fans.toHa[v] ?? 'unknown'
+    }
+
+    private publishFanSpeedState(override?: string) {
+        const state = override ?? this.fanSpeedFromClip()
+        this.HA.publishProperty(this.id, 'fan_speed-', state)
+    }
+
+    /** Return true to let TLVDevice send a plain 0x1fa write. */
+    protected sendFanSpeedTlvs(_fan: number): boolean {
+        return true
+    }
+
+    private publishBucketFullState(full: boolean) {
+        if (!this.profile().features.bucketFull) return
+        if (this.bucketFullHaState === full) return
+        this.bucketFullHaState = full
+        this.HA.publishProperty(this.id, 'bucket_full-', full ? 'ON' : 'OFF', { retain: true })
+    }
+
+    processKeyValue(k: number, v: number) {
+        if (
+            this.query_caps_timeout !== undefined &&
+            CAPS_ONLY_TAGS.has(k) &&
+            !(k === 0x336 && this.profile().combinedInitialResponse)
+        ) {
+            this.raw_clip_state[k] = v
+            return
+        }
+        // Mode-fan capability rows (0x2d7/0x2d8/0x2d9) repeat once per mode — not global state.
+        if (k === 0x2d7 || k === 0x2d8 || k === 0x2d9) return
+        if (k === 0x2b1) {
+            this.raw_clip_state[k] = v
+            if (v === BUCKET_EMPTIED_EVENT) this.publishBucketFullState(false)
+            return
+        }
+        if (k === 0x2b2) {
+            this.raw_clip_state[k] = v
+            this.publishBucketFullState(v !== 0)
+            return
+        }
+        super.processKeyValue(k, v)
+    }
+
+    isCapsResponse(tlvArray: TLV.TLV[]) {
+        return tlvArray.some(({ t }) => t === 0x2da)
+    }
+
+    isValuesResponse(tlvArray: TLV.TLV[]) {
+        return tlvArray.some(
+            ({ t }) =>
+                t === 0x1f7 ||
+                t === 0x1f9 ||
+                t === 0x1fa ||
+                t === 0x21b ||
+                t === 0x21e ||
+                t === 0x2b2 ||
+                t === 0x253 ||
+                t === 0x2a2 ||
+                t === 0x336 ||
+                t === 0x360,
+        )
+    }
+
+    valuesReceived() {
+        if (this.initialValuesReceived) return
+        this.initialValuesReceived = true
+
+        this.thinq.send('setMaskingInfo', 0, { blacklist_tlv: '1200' })
+    }
+}

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -22,6 +22,7 @@ import RV13B6BSD_D_US_WIFI from './devices/RV13B6BSD_D_US_WIFI'
 import RV13B6ES_D_US_WIFI from './devices/RV13B6ES_D_US_WIFI'
 import WTL_FXU_BDV_NA_01 from './devices/WTL_FXU_BDV_NA_01'
 import DHUM_056905_WW from './devices/DHUM_056905_WW'
+import DHUM_231006_WW from './devices/DHUM_231006_WW'
 import ST_B_E4H01Y_APL from './devices/ST_B_E4H01Y_APL'
 import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
@@ -68,6 +69,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     // Wrinkle Care sits in a different bitfield, so it needs its own handler rather than an alias
     WTL_FXU_BDV_NA_01, // LG WashTower
     DHUM_056905_WW,
+    DHUM_231006_WW, // same TLV map as the 056905, different mode and fan enums
     ST_B_E4H01Y_APL,
 }
 

--- a/tests/cloud/devices/DHUM_231006_WW.test.ts
+++ b/tests/cloud/devices/DHUM_231006_WW.test.ts
@@ -1,0 +1,142 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/DHUM_231006_WW'
+import type { Metadata } from '@/cloud/thinq'
+import * as TLV from '@/util/tlv'
+import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'DHUM_231006_WW'
+const META: Metadata = { modelId: MODEL_ID, modelName: 'TEST DHUM', swVersion: '311' }
+
+// Captured from DHUM_231006_WW cf69d18f on 2026-07-27.
+const VALUES_RESPONSE_HEX =
+    '000004000000A7020470707DC17E50567E8894D02D7F503686C087008980C900D80187806150B4CD90308840CE80AB00A88187C1E801EE40618089408380EA406241F8008C901B8CD024B5D056B600B648B5D013B600B642B5D055B600B647B5D014B600B648B5D016B600B6485CF05614135D301500FFFA80CDC05DC3'
+const HIGH_RESPONSE_HEX = '000004000000A702047D177E86B5D056B600B646B5D014B600B646B5D016B600B64648F8'
+
+const MODES = [
+    ['Smart Plus', 86],
+    ['Silent', 19],
+    ['Intensive', 20],
+    ['Quick', 85],
+] as const
+
+const FANS = [
+    ['auto', 8],
+    ['low', 2],
+    ['medium', 4],
+    ['high', 6],
+    ['turbo', 7],
+] as const
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    thinq.resetRecorder()
+    return { ha, thinq, dev }
+}
+
+function writtenFields(thinq: MockThinq2Device) {
+    const packet = thinq.outbox[thinq.outbox.length - 1]
+    assert.ok(packet)
+    return TLV.parse(packet.subarray(11, packet.length - 2)).map(({ t, v }) => ({ t, v }))
+}
+
+describe(MODEL_ID, () => {
+    test('discovery exposes only confirmed entities and derives model enum options', () => {
+        const { ha, dev } = makeDevice()
+        const components = ha.devices[DEVICE_ID]!.config!.components as Record<string, Record<string, unknown>>
+
+        assert.deepEqual(
+            components.humidifier.modes,
+            MODES.map(([label]) => label),
+        )
+        assert.deepEqual(
+            components.fan_speed.options,
+            FANS.map(([label]) => label),
+        )
+        assert.ok(components.ionizer)
+        assert.ok(components.uv_nano)
+        assert.ok(components.bucket_light)
+        assert.ok(components.off_timer)
+        assert.equal(components.bucket_full, undefined)
+        dev.drop()
+    })
+
+    test('real initial response completes startup and decodes the confirmed 231006 state', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', buf(VALUES_RESPONSE_HEX))
+        const properties = ha.devices[DEVICE_ID]!.properties
+
+        assert.equal(dev.query_caps_timeout, undefined)
+        assert.equal(dev.query_values_timeout, undefined)
+        assert.equal(properties['humidifier-power'], 'ON')
+        assert.equal(properties['humidifier-mode'], 'Smart Plus')
+        assert.equal(properties['fan_speed-'], 'auto')
+        assert.equal(properties['humidifier-target_humidity'], 45)
+        assert.equal(properties['humidifier-current_humidity'], 48)
+        assert.equal(properties['ionizer-'], 'ON')
+        assert.equal(properties['uv_nano-'], 'ON')
+        assert.equal(properties['bucket_light-'], 'OFF')
+        assert.equal(properties['off_timer-'], 0)
+        dev.drop()
+    })
+
+    test('real fan response decodes high and ignores repeated capability rows as state', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', buf(VALUES_RESPONSE_HEX))
+        thinq.emit('data', buf(HIGH_RESPONSE_HEX))
+
+        assert.equal(ha.devices[DEVICE_ID]!.properties['fan_speed-'], 'high')
+        assert.equal(dev.raw_clip_state[0x2d7], undefined)
+        assert.equal(dev.raw_clip_state[0x2d8], undefined)
+        assert.equal(dev.raw_clip_state[0x2d9], undefined)
+        dev.drop()
+    })
+
+    test('fan writes use the bare 0x1fa shape from captured cloud writes', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.setProperty('fan_speed-', 'high')
+        assert.deepEqual(writtenFields(thinq), [{ t: 0x1fa, v: 6 }])
+        thinq.resetRecorder()
+        dev.setProperty('fan_speed-', 'auto')
+        assert.deepEqual(writtenFields(thinq), [{ t: 0x1fa, v: 8 }])
+        dev.drop()
+    })
+
+    test('derived inverse tables encode every advertised mode and fan', () => {
+        const { thinq, dev } = makeDevice()
+
+        for (const [label, wire] of MODES) {
+            thinq.resetRecorder()
+            dev.setProperty('humidifier-mode', label)
+            assert.deepEqual(writtenFields(thinq), [
+                { t: 0x1f9, v: wire },
+                { t: 0x1f7, v: 1 },
+            ])
+        }
+        for (const [label, wire] of FANS) {
+            thinq.resetRecorder()
+            dev.setProperty('fan_speed-', label)
+            assert.deepEqual(writtenFields(thinq), [{ t: 0x1fa, v: wire }])
+        }
+        dev.drop()
+    })
+
+    test('unknown enum values publish HA unknown and unknown commands are rejected', () => {
+        const { ha, thinq, dev } = makeDevice()
+
+        dev.processKeyValue(0x1f9, 999)
+        dev.processKeyValue(0x1fa, 999)
+        assert.equal(ha.devices[DEVICE_ID]!.properties['humidifier-mode'], 'unknown')
+        assert.equal(ha.devices[DEVICE_ID]!.properties['fan_speed-'], 'unknown')
+
+        thinq.resetRecorder()
+        dev.setProperty('humidifier-mode', 'not-a-mode')
+        dev.setProperty('fan_speed-', 'not-a-fan')
+        assert.equal(thinq.outbox.length, 0)
+        dev.drop()
+    })
+})


### PR DESCRIPTION
First of the per-device-class splits from #111.

Two ThinQ2 dehumidifiers on the existing TLV path (deviceType 403), each verified against the LG cloud's own decode of the same unit while bridged:

- **DHUM_056905_WW** — the base driver.
- **DHUM_231006_WW** (BEKEN_BK7234) — shares the 056905 TLV map, overrides only the mode/fan enums (it uses codes 85/86 where 056905 uses 17/21) and sends fan writes as bare `0x1fa` without the per-mode table.

Shared infrastructure this needs:
- `TLVDevice`'s packet gate accepts `0xA7` in byte 6 as well as `0x87` — the dehumidifier family frames with `0xA7`. This two-line change and the `HumidifierComponent` discovery type both originate in @BluSyn's #64; if #64 lands first I'll rebase on top of it.

All labels are English. `npm test` passes; `tsc` clean.