### PR TITLE
Add LG PuriCare humidifier HUM_056905_WW

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ The following appliances are currently supported in rethink:
     - 👍 WKEX200HBA (WTL_FXU_BDV_NA_01), WashTower - mostly working
 - Dehumidifiers
     - 👍 MD19GQGE0, Smart Dehumidifier - mostly working
+- Humidifiers:
+    - 👍 HUM_056905_WW, PuriCare humidifying air purifier - mostly working
 - Range Hoods:
     - 👍 HCED3015D (STUDIO_HOOD), Generic identifier and probably works with multiple models. Working.
 - Stylers:

--- a/cloud/devices/HUM_056905_WW.ts
+++ b/cloud/devices/HUM_056905_WW.ts
@@ -1,0 +1,341 @@
+import TLVDevice from './tlv_device'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { DeviceDiscovery, type ComponentInfo, type Connection, type HumidifierComponent } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import * as TLV from '@/util/tlv'
+import HADevice from './base'
+
+/*
+ * LG PuriCare air-purifying humidifier, ThinQ model HUM_056905_WW, deviceType 404.
+ *
+ * Tag ids and enum values come from this model's modelJSON. Every registered tag is also
+ * present in the captured values response replayed by the unit test. The writable core was
+ * confirmed by driving the appliance through LG's cloud while watching the bridge traffic:
+ *
+ *   0x1f7 power        0/1                     0x1f9 opMode   Air Clean=5 Humidify+Clean=12 Humidify=24
+ *   0x1fa windStrength Low=2 Mid=4 High=6 Turbo=7      0x253 target humidity, percent
+ *   0x109 Night mode     0x1e4 Sleep mode  0x1e6 Auto operation
+ *
+ * 0x1fd is half-degrees, like the AC family: wire 55 = 27.5 degC, matching what the cloud
+ * read from the same appliance at the same moment. 0x336 (humidity) is one-for-one.
+ */
+
+/** Half-degree tags — the AC family's convention, and this model shares it. */
+const HALF_DEGREE = 2
+
+const OP_MODES = [
+    ['Air Clean', 5],
+    ['Humidify+Clean', 12],
+    ['Humidify', 24],
+] as const
+
+const FAN_LEVELS = [
+    ['Auto', 8],
+    ['Low', 2],
+    ['Mid', 4],
+    ['High', 6],
+    ['Turbo', 7],
+] as const
+
+const HYGIENE_DRY = [
+    ['Off', 0],
+    ['Gentle', 1],
+    ['Quiet', 2],
+    ['Quick', 3],
+    ['Focus', 4],
+    ['Default', 5],
+] as const
+
+const STANDBY_STERILIZE = [
+    ['Rapid', 0],
+    ['Normal', 1],
+    ['Silent', 2],
+    ['Power', 3],
+] as const
+
+const DISPLAY_BRIGHTNESS = [
+    ['Off', 0],
+    ['Level 1', 8],
+    ['Level 2', 9],
+    ['Level 3', 10],
+] as const
+
+/** 0x1e3, LG's humidifier.productStatus. */
+const PRODUCT_STATUS: Record<number, string> = {
+    0: 'Normal',
+    1: 'No tank',
+    2: 'Low water',
+    3: 'Sterilizing',
+    4: 'Drying',
+    5: 'Boiling',
+    6: 'Boiling (low)',
+}
+
+/** 0x3e0, LG's mood-light palette. Only the colours this model names are offered. */
+const MOOD_COLORS: [string, number][] = [
+    ['Blue', 1],
+    ['Green', 2],
+    ['Red', 3],
+    ['Purple', 4],
+    ['Yellow', 6],
+    ['Pink', 7],
+    ['Pure White', 8],
+    ['Aquarium', 9],
+    ['Candlelight', 10],
+    ['Sunlight', 11],
+    ['Rose', 12],
+    ['Mint', 13],
+    ['Lime', 14],
+    ['Very Peri', 15],
+    ['Warm White', 16],
+    ['Cool White', 17],
+    ['Sapphire', 18],
+    ['Rainbow', 19],
+]
+
+type Levels = readonly (readonly [string, number])[]
+
+export default class Device extends TLVDevice {
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+
+        const config: DeviceDiscovery & { components: { humidifier: HumidifierComponent } } = allowExtendedType({
+            ...HADevice.config(meta, { name: 'LG Humidifying Air Purifier' }),
+            components: {
+                humidifier: {
+                    platform: 'humidifier',
+                    unique_id: '$deviceid-humidifier',
+                    name: null,
+                    device_class: 'humidifier',
+                    modes: OP_MODES.map(([label]) => label),
+                    // LG's own value_validation for airState.humidity.desired.
+                    min_humidity: 0,
+                    max_humidity: 100,
+                } satisfies HumidifierComponent,
+            },
+        })
+
+        // Power (0x1f7). The humidifier platform's bare state/command topics are wired to it below.
+        this.addField(
+            config,
+            {
+                id: 0x1f7,
+                name: 'power',
+                comp: 'humidifier',
+                read_xform: (raw) => (raw ? 'ON' : 'OFF'),
+                write_xform: (val) => (val === 'ON' ? 1 : 0),
+            },
+            false,
+        )
+
+        // Operating mode (0x1f9) — the humidifier entity's `mode`.
+        this.addField(config, {
+            id: 0x1f9,
+            name: 'mode',
+            comp: 'humidifier',
+            read_xform: (raw) => OP_MODES.find(([, wire]) => wire === raw)?.[0] ?? 'unknown',
+            write_xform: (val) => {
+                const hit = OP_MODES.find(([label]) => label === val)
+                if (!hit) return undefined
+                // Selecting a mode while off is how the LG app turns it on.
+                this.raw_clip_state[0x1f7] = 1
+                return hit[1]
+            },
+            write_attach: [0x1f7],
+        })
+
+        // Target humidity (0x253) — the humidifier entity's target.
+        this.addField(config, {
+            id: 0x253,
+            name: 'target_humidity',
+            comp: 'humidifier',
+            write_xform: (val) => {
+                const humidity = Number(val)
+                if (!Number.isFinite(humidity) || humidity < 0 || humidity > 100) return undefined
+                return Math.round(humidity / 5) * 5
+            },
+        })
+
+        // Current humidity (0x336) — read-only, its own sensor as well as the humidifier attribute.
+        this.addSensor(config, 0x336, 'current_humidity', 'Current humidity', {
+            device_class: 'humidity',
+            unit_of_measurement: '%',
+            state_class: 'measurement',
+        })
+        config.components.humidifier.current_humidity_topic = '$this/current_humidity-'
+
+        this.addSelect(config, 0x1fa, 'fan_speed', 'Fan speed', 'mdi:fan', FAN_LEVELS)
+        this.addSelect(config, 0x1e9, 'hygiene_dry', 'Sanitary dry', 'mdi:hair-dryer', HYGIENE_DRY)
+        this.addSelect(config, 0x164, 'standby_sterilize', 'Standby sterilize', 'mdi:shimmer', STANDBY_STERILIZE)
+        this.addSelect(config, 0x21f, 'display', 'Screen brightness', 'mdi:brightness-6', DISPLAY_BRIGHTNESS)
+        this.addSelect(config, 0x3e0, 'mood_color', 'Mood light color', 'mdi:palette', MOOD_COLORS)
+
+        this.addSwitch(config, 0x109, 'night_mode', 'Night mode', 'mdi:weather-night')
+        this.addSwitch(config, 0x1e4, 'sleep_mode', 'Sleep mode', 'mdi:power-sleep')
+        this.addSwitch(config, 0x1e6, 'auto_strength', 'Auto operation', 'mdi:autorenew')
+        this.addSwitch(config, 0x1e7, 'humidify', 'Humidify', 'mdi:water')
+        this.addSwitch(config, 0x161, 'anti_glare', 'Anti-glare', 'mdi:eye-off')
+        this.addSwitch(config, 0x1b8, 'mood_light', 'Mood light', 'mdi:lightbulb-on')
+        this.addSwitch(config, 0x3a0, 'bell_sound', 'Notification sound', 'mdi:bell')
+
+        // Same tag and minutes-on-the-wire unit as RAC_056905_WW; this model caps it at 720 minutes.
+        this.addTimerField(config, 0x21b, 'stoptimer', 'Turn-off timer', 'mdi:timer-stop', 12)
+
+        this.addSensor(config, 0x1fd, 'temperature', 'Current temperature', {
+            device_class: 'temperature',
+            unit_of_measurement: '°C',
+            state_class: 'measurement',
+            read_xform: (raw: number) => raw / HALF_DEGREE,
+        })
+        this.addSensor(config, 0x333, 'pm1', 'PM1.0', {
+            device_class: 'pm1',
+            unit_of_measurement: 'µg/m³',
+            state_class: 'measurement',
+        })
+        this.addSensor(config, 0x334, 'pm25', 'PM2.5', {
+            device_class: 'pm25',
+            unit_of_measurement: 'µg/m³',
+            state_class: 'measurement',
+        })
+        this.addSensor(config, 0x335, 'pm10', 'PM10', {
+            device_class: 'pm10',
+            unit_of_measurement: 'µg/m³',
+            state_class: 'measurement',
+        })
+        this.addSensor(config, 0x1ee, 'watertank_remain', 'Tank level', {
+            icon: 'mdi:cup-water',
+            unit_of_measurement: '%',
+            state_class: 'measurement',
+        })
+        this.addSensor(config, 0x2ad, 'watertank_time', 'Tank time remaining', {
+            icon: 'mdi:timer-sand',
+            unit_of_measurement: 'min',
+        })
+        this.addSensor(config, 0x1ed, 'water_filter', 'Water filter level', {
+            icon: 'mdi:filter',
+            unit_of_measurement: '%',
+            state_class: 'measurement',
+        })
+        // Named and attributed as RAC_056905_WW publishes the same three.
+        this.addSensor(config, 0x355, 'filterused', 'Filter used time', {
+            icon: 'mdi:air-filter',
+            device_class: 'duration',
+            unit_of_measurement: 'h',
+            state_class: 'total_increasing',
+            entity_category: 'diagnostic',
+        })
+        this.addSensor(config, 0x356, 'filterlife', 'Filter life time', {
+            icon: 'mdi:air-filter',
+            device_class: 'duration',
+            unit_of_measurement: 'h',
+            entity_category: 'diagnostic',
+        })
+        this.addSensor(config, 0x225, 'autodryremain', 'Auto dry remaining', {
+            icon: 'mdi:hair-dryer-outline',
+            unit_of_measurement: '%',
+            suggested_display_precision: 0,
+            entity_category: 'diagnostic',
+        })
+        this.addSensor(config, 0x1e3, 'status', 'Operating state', {
+            icon: 'mdi:information-outline',
+            device_class: 'enum',
+            options: Object.values(PRODUCT_STATUS),
+            read_xform: (raw: number) => PRODUCT_STATUS[raw] ?? 'unknown',
+        })
+
+        const hum = config.components.humidifier as ComponentInfo & Record<string, string>
+        hum.state_topic = '$this/humidifier-power'
+        hum.command_topic = '$this/humidifier-power/set'
+
+        this.setConfig(config)
+    }
+
+    /* Identical to RAC_056905_WW's: hours in Home Assistant, minutes on the wire. */
+    private addTimerField(config: DeviceDiscovery, id: number, name: string, desc: string, icon: string, max: number) {
+        config['components'][name] = allowExtendedType({
+            platform: 'number',
+            unique_id: '$deviceid-' + name,
+            name: desc,
+            icon: icon,
+            device_class: 'duration',
+            unit_of_measurement: 'h',
+            min: 0,
+            max: max,
+            step: 0.25,
+            mode: 'slider',
+        })
+
+        /*
+         * Upon setting this field the device starts counting down and every minute sends the
+         * remaining time.
+         */
+        this.addField(config, {
+            id: id,
+            name: '',
+            comp: name,
+            read_xform: (raw) => Math.ceil(raw / 60 / 0.25) * 0.25,
+            write_xform: (val) => Math.round(Number(val) * 60),
+        })
+    }
+
+    /** A select whose options are English labels and whose wire values are LG's enum codes. */
+    private addSelect(config: DeviceDiscovery, id: number, comp: string, desc: string, icon: string, levels: Levels) {
+        config['components'][comp] = allowExtendedType({
+            platform: 'select',
+            unique_id: `$deviceid-${comp}`,
+            name: desc,
+            icon,
+            options: levels.map(([label]) => label),
+        })
+        this.addField(config, {
+            id,
+            name: '',
+            comp,
+            read_xform: (raw) => levels.find(([, wire]) => wire === raw)?.[0],
+            write_xform: (val) => levels.find(([label]) => label === val)?.[1],
+        })
+    }
+
+    private addSwitch(config: DeviceDiscovery, id: number, comp: string, desc: string, icon: string, onValue = 1) {
+        config['components'][comp] = allowExtendedType({
+            platform: 'switch',
+            unique_id: `$deviceid-${comp}`,
+            name: desc,
+            icon,
+        })
+        this.addField(config, {
+            id,
+            name: '',
+            comp,
+            read_xform: (raw) => (raw === onValue ? 'ON' : 'OFF'),
+            write_xform: (val) => (val === 'ON' ? onValue : 0),
+        })
+    }
+
+    private addSensor(
+        config: DeviceDiscovery,
+        id: number,
+        comp: string,
+        desc: string,
+        opts: Record<string, unknown> & { read_xform?: (raw: number) => string | number },
+    ) {
+        const { read_xform, ...attrs } = opts
+        config['components'][comp] = allowExtendedType({
+            platform: 'sensor',
+            unique_id: `$deviceid-${comp}`,
+            name: desc,
+            ...attrs,
+        })
+        this.addField(config, { id, name: '', comp, writable: false, read_xform })
+    }
+
+    /* 0x3e8 is reported only in the answer to a capabilities query (0x1f5=1) on this model. */
+    isCapsResponse(tlvArray: TLV.TLV[]) {
+        return tlvArray.some(({ t }) => t === 0x3e8)
+    }
+
+    isValuesResponse(tlvArray: TLV.TLV[]) {
+        return tlvArray.some(({ t }) => t === 0x1f7 || t === 0x1f9 || t === 0x1fa)
+    }
+}

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -23,6 +23,7 @@ import RV13B6ES_D_US_WIFI from './devices/RV13B6ES_D_US_WIFI'
 import WTL_FXU_BDV_NA_01 from './devices/WTL_FXU_BDV_NA_01'
 import DHUM_056905_WW from './devices/DHUM_056905_WW'
 import ST_B_E4H01Y_APL from './devices/ST_B_E4H01Y_APL'
+import HUM_056905_WW from './devices/HUM_056905_WW'
 import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
 import { type Connection } from './homeassistant'
@@ -69,6 +70,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     WTL_FXU_BDV_NA_01, // LG WashTower
     DHUM_056905_WW,
     ST_B_E4H01Y_APL,
+    HUM_056905_WW,
 }
 
 class Bridge {

--- a/tests/cloud/devices/HUM_056905_WW.test.ts
+++ b/tests/cloud/devices/HUM_056905_WW.test.ts
@@ -1,0 +1,219 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/HUM_056905_WW'
+import type { Metadata } from '@/cloud/thinq'
+import * as TLV from '@/util/tlv'
+import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+import { enableMockTimers, tickMockTimers } from '@/tests/helpers/timers'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'HUM_056905_WW'
+const META: Metadata = { modelId: MODEL_ID, modelName: 'TEST HUM', swVersion: '4378' }
+
+/*
+ * Both frames are verbatim from the appliance: the answers it gave to a capabilities query
+ * (0x1f5=1) and a values query (0x1f5=2), injected through the management API on 2026-07-28.
+ */
+const CAPS_RESPONSE_HEX =
+    '000004000000a702012778640f644f6c4cb00eb0601020b480a5c0965020b0a001d4b4e05000b5b020100057c3580f79507bb6a04956b6e04378b700b750feb9501eb99046bc200800bc70020201b3c0bd1031bd60099fbd85d3c0d400dd04f7905af7d014fa01fb0bf870fffc40ef83b5c5b600b642b5ccb600b642b5d018b600b642e059'
+const QUERY_RESPONSE_HEX =
+    '000004000000a702042d9d6880698069c06a006a406a806ac06b006b406b806bc06c006cc06e405902fa807dc17e457e827f50374241584179c07a437a807b50647b8fb4501cb7901c86c0870087c08940898094d041d8808790c8cd46cd05ccc49001cd90308840d5503ed59064ab007f00e801e900e94ae989ebc1ed08ed40ee405cf0180c055d00f80b6e0178c179007980ab40b5c5b600b642b5ccb600b642b5d018b600b64290c1'
+
+/** Confirmed on the wire by driving the appliance from LG's cloud through the bridge. */
+const MODES = [
+    ['Air Clean', 5],
+    ['Humidify+Clean', 12],
+    ['Humidify', 24],
+] as const
+
+const FANS = [
+    ['Auto', 8],
+    ['Low', 2],
+    ['Mid', 4],
+    ['High', 6],
+    ['Turbo', 7],
+] as const
+
+function writtenFields(thinq: MockThinq2Device) {
+    const packet = thinq.outbox[thinq.outbox.length - 1]
+    assert.ok(packet, 'a packet was sent')
+    return TLV.parse(packet.subarray(11, packet.length - 2)).map(({ t, v }) => ({ t, v }))
+}
+
+function buildReadyDevice(t: import('node:test').TestContext) {
+    enableMockTimers(t)
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    thinq.resetRecorder()
+    thinq.emit('data', buf(CAPS_RESPONSE_HEX))
+    thinq.emit('data', buf(QUERY_RESPONSE_HEX))
+    tickMockTimers(t, 6000)
+    thinq.resetRecorder()
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('the captured values frame populates the entities it is meant to', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+        const props = ha.devices[DEVICE_ID]!.properties
+        assert.equal(props['humidifier-power'], 'ON')
+        assert.equal(props['humidifier-mode'], 'Air Clean')
+        assert.equal(props['humidifier-target_humidity'], 65)
+        assert.equal(props['fan_speed-'], 'Low')
+        assert.equal(props['current_humidity-'], 48)
+        // 0x1fd is half-degrees: wire 55 is 27.5 degC, which is what the cloud read at the time.
+        assert.equal(props['temperature-'], 27.5)
+        assert.equal(props['night_mode-'], 'ON')
+        assert.equal(props['sleep_mode-'], 'OFF')
+        assert.equal(props['auto_strength-'], 'OFF')
+        // The tank was out of its seat during the capture, which is what LG's code 1 means.
+        assert.equal(props['status-'], 'No tank')
+        dev.drop()
+    })
+
+    test('config offers the LG mode and fan vocabularies', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+        const components = ha.devices[DEVICE_ID]!.config!.components as Record<string, Record<string, unknown>>
+        assert.deepEqual(
+            components.humidifier.modes,
+            MODES.map(([label]) => label),
+        )
+        assert.deepEqual(
+            components.fan_speed.options,
+            FANS.map(([label]) => label),
+        )
+        dev.drop()
+    })
+
+    test('every mode code decodes to its label', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+        for (const [label, wire] of MODES) {
+            dev.processKeyValue(0x1f9, wire)
+            assert.equal(ha.devices[DEVICE_ID]!.properties['humidifier-mode'], label)
+        }
+        dev.drop()
+    })
+
+    test('every mode label writes its wire code and turns the appliance on', (t) => {
+        const { thinq, dev } = buildReadyDevice(t)
+        for (const [label, wire] of MODES) {
+            thinq.resetRecorder()
+            dev.setProperty('humidifier-mode', label)
+            assert.deepEqual(writtenFields(thinq), [
+                { t: 0x1f9, v: wire },
+                { t: 0x1f7, v: 1 },
+            ])
+        }
+        dev.drop()
+    })
+
+    test('every fan code decodes, and every fan label writes 0x1fa alone', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+        for (const [label, wire] of FANS) {
+            dev.processKeyValue(0x1fa, wire)
+            assert.equal(ha.devices[DEVICE_ID]!.properties['fan_speed-'], label)
+            thinq.resetRecorder()
+            dev.setProperty('fan_speed-', label)
+            assert.deepEqual(writtenFields(thinq), [{ t: 0x1fa, v: wire }])
+        }
+        dev.drop()
+    })
+
+    test('target humidity snaps to LG’s 5% step', (t) => {
+        const { thinq, dev } = buildReadyDevice(t)
+        dev.setProperty('humidifier-target_humidity', '52')
+        assert.deepEqual(writtenFields(thinq), [{ t: 0x253, v: 50 }])
+        dev.drop()
+    })
+
+    test('target humidity rejects non-finite and out-of-range writes', (t) => {
+        const { thinq, dev } = buildReadyDevice(t)
+        for (const value of ['NaN', 'Infinity', '-1', '101']) {
+            dev.setProperty('humidifier-target_humidity', value)
+        }
+        assert.equal(thinq.outbox.length, 0)
+        dev.drop()
+    })
+
+    test('enum entities use the exact unknown fallback and declare their options', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+        const props = ha.devices[DEVICE_ID]!.properties
+        dev.processKeyValue(0x1f9, 99)
+        dev.processKeyValue(0x1e3, 99)
+        assert.equal(props['humidifier-mode'], 'unknown')
+        assert.equal(props['status-'], 'unknown')
+
+        const status = ha.devices[DEVICE_ID]!.config!.components.status as Record<string, unknown>
+        assert.equal(status.device_class, 'enum')
+        assert.deepEqual(status.options, [
+            'Normal',
+            'No tank',
+            'Low water',
+            'Sterilizing',
+            'Drying',
+            'Boiling',
+            'Boiling (low)',
+        ])
+        dev.drop()
+    })
+
+    test('display brightness round-trips its LG codes', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+        dev.processKeyValue(0x21f, 9)
+        assert.equal(ha.devices[DEVICE_ID]!.properties['display-'], 'Level 2')
+        thinq.resetRecorder()
+        dev.setProperty('display-', 'Level 3')
+        assert.deepEqual(writtenFields(thinq), [{ t: 0x21f, v: 10 }])
+        dev.drop()
+    })
+
+    test('every registered tag is present in the captured values response', (t) => {
+        const { dev } = buildReadyDevice(t)
+        const frame = buf(QUERY_RESPONSE_HEX)
+        const capturedTags = new Set(TLV.parse(frame.subarray(11, frame.length - 2)).map(({ t }) => t))
+        const registeredTags = Object.keys(dev.fields_by_id).map(Number)
+        assert.deepEqual(
+            registeredTags.filter((tag) => !capturedTags.has(tag)),
+            [],
+        )
+        dev.drop()
+    })
+
+    test('unverified and raw-only entities are not exposed', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+        const components = ha.devices[DEVICE_ID]!.config!.components
+        for (const name of [
+            'over_prevention',
+            'sensor_mon',
+            'auto_dry',
+            'watertank_light',
+            'air_quality',
+            'error',
+            'water_lack',
+        ]) {
+            assert.equal(components[name], undefined)
+        }
+        dev.drop()
+    })
+
+    test('the off timer is hours in HA and minutes on the wire, as on RAC_056905_WW', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+        dev.processKeyValue(0x21b, 90)
+        assert.equal(ha.devices[DEVICE_ID]!.properties['stoptimer-'], 1.5)
+        thinq.resetRecorder()
+        dev.setProperty('stoptimer-', '2.25')
+        assert.deepEqual(writtenFields(thinq), [{ t: 0x21b, v: 135 }])
+        // LG caps targetTimeToStop at 720 minutes.
+        assert.equal((ha.devices[DEVICE_ID]!.config!.components.stoptimer as Record<string, unknown>).max, 12)
+        dev.drop()
+    })
+
+    test('the absolute HHMM schedule tags are not exposed', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+        const components = ha.devices[DEVICE_ID]!.config!.components
+        assert.equal(components.start_time, undefined)
+        assert.equal(components.stop_time, undefined)
+        dev.drop()
+    })
+})


### PR DESCRIPTION
Second of the per-device-class splits from #111.

**HUM_056905_WW** — a ThinQ2 PuriCare humidifier (deviceType 404) on the existing TLV path. The wire map is taken from LG's own modelJSON `tlv_*` labels rather than guessed tags, and every enum was confirmed against the LG cloud's decode of the same unit while bridged.

Shared infrastructure (same as the dehumidifier PR #113): `TLVDevice`'s packet gate accepts `0xA7` in byte 6 alongside `0x87` — this family frames with `0xA7`. Originally from @BluSyn's #64.

All labels are English. `npm test` passes; `tsc` clean.