### PR TITLE
Add LG Styler ST_B_E4H01Y_APL

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The following appliances are currently supported in rethink:
     - 👍 MD19GQGE0, Smart Dehumidifier - mostly working
 - Range Hoods:
     - 👍 HCED3015D (STUDIO_HOOD), Generic identifier and probably works with multiple models. Working.
+- Stylers:
+    - 👍 S5BBP (ST_B_E4H01Y_APL), Styler - mostly working
 
 The supported appliances can be used "out of the box" with HomeAssistant or another compatible MQTT consumer.  
 Appliances not listed above can still be used with the bridge mode, but they will not be translated to MQTT. Contributions are welcome!

--- a/cloud/devices/ST_B_E4H01Y_APL.ts
+++ b/cloud/devices/ST_B_E4H01Y_APL.ts
@@ -1,0 +1,736 @@
+import { Device as Thinq2Device } from '../thinq2/device'
+import log from '@/util/logging'
+import { DeviceDiscovery, type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import HADevice from './base'
+import AABBDevice from './aabb_device'
+
+/*
+ * LG Styler (S5BBP), ThinQ model ST_B_E4H01Y_APL, deviceType 203.
+ *
+ * The byte layout was recovered by injecting single-byte-changed state frames through the
+ * management API and reading LG cloud's decode back, so each offset rests on a direct
+ * observation. Three of the bytes are bitfields, split bit by bit.
+ *
+ * READ. `aa ff 31 0a 00 | <len16 LE> | <seq16> | 00 01 | 00 <tag> | <record bytes, BE16> |
+ * …40-byte records… | <crc16 XMODEM> bb`. Offsets into the whole frame, single-record form:
+ *
+ *   17 state              18 remainTimeHour     19 remainTimeMinute
+ *   20 initialTimeHour    21 initialTimeMinute  22 course
+ *   23 error              24 preState
+ *   29 reserveTimeHour    30 reserveTimeMinute
+ *   31 flags  0x01 childLock  0x02 nightDry  0x04 initialBit  0x08 remoteStart
+ *   34..35 energyMonitoring, big-endian 16-bit — not published, the unit is undeclared
+ *   37 smartCourse
+ *   40 currentDownloadCourseCount   41..44 currentDownloadCourse1..4
+ *   45 buzzer
+ *   46 flags  0x01 applyRemoteMaintain  0x02 applyBuzzer  0x04 remoteMaintain
+ *   47 endMelody          48 internalLightingTime — not published, no declared value list
+ *   49 flags  0x01 isLastCourse  0x02 smartCareFineDust  0x04 smartCareHumidity
+ *             0x08 smartCareNightCare  0x10 smartPairing  0x20 currentTimeDisplay
+ *   50..53 nightCareStartTime / nightCareEndTime, hour then minute
+ *   54 TCLCount
+ *
+ * That covers all 38 `styler.*` keys LG publishes for this unit. Byte 31 bit 0x20 and byte 49
+ * bits 0x40/0x80 move no field and are left alone.
+ *
+ * The record count varies, so it is counted rather than assumed: at rest the appliance sends
+ * one 40-byte record, and while it is doing anything it sends two — previous, then current —
+ * as the water purifier in this repo does. Header 15 bytes, trailer 3, and what is between
+ * must be a whole number of records, cross-checked against the record-bytes field at 13..14.
+ * That also rejects the frames which carry no state: the 112/113-byte downloadable-course name
+ * lists, the 35-byte `aa ff 31 0a 00 23 00 …` (every byte probed with 0xff, nothing moved) and
+ * the `aa 07 31 c3 02` heartbeat.
+ *
+ * WRITE. Settings go out as
+ *
+ *   aa <len> f0 24 <controlDataType> <valueLength> [<controlDataType_sub>] <value…> <ck> bb
+ *
+ *   01 POWERON/POWEROFF          len 1   off 0, on 1
+ *   04 PAUSE                     len 1   0
+ *   10 REMOTE_MAINTAIN           len 1   off 0, on 1
+ *   13 UPCENTER, then a sub id and the value:
+ *      01 ENDMELODY              len 1   melody index, 0..11
+ *      03 UPBUZZER               len 1   buzzer level, 0..4
+ *      04 SC_FINEDUST            len 1   off 0, on 1
+ *      05 SC_HUMIDITY            len 1   off 0, on 1
+ *      06 SC_NIGHTCARE           len 1   off 0, on 1
+ *      07 SC_NIGHTCARE_START     len 2   hour, minute
+ *      08 SC_NIGHTCARE_END       len 2   hour, minute
+ *      09 CTRL_IS_LAST_COURSE    len 1   off 0, on 1
+ *
+ * and course control as
+ *
+ *   start  aa 34 f0 26 | <46-byte course block> | ck bb
+ *   resume aa 33 f0 26 | <course id> <44 zero bytes> | ck bb
+ *
+ * `controlDataType`, `controlDataValueLength` and `controlDataType_sub` are modelJSON's own
+ * `ControlWifi` vocabulary, and every value is the code the read map already uses for that
+ * field. The frames came from LG's own cloud (`dataops/v1/s2p/backend/convert/control`), which
+ * wants `{"setOnOff":{"value":"on"}}` rather than the aircon's `{"onOff":"on"}`, and answers
+ * CL-0005 while the appliance is in no state to take the command. REMOTE_MAINTAIN is the one
+ * exception: LG's converter only ever emits its OFF frame, so the ON frame was built from the
+ * same shape, sent to the appliance directly, acknowledged, and read back on byte 46 bit 0x04.
+ *
+ * The course block is `<id> 01 00 04 00 00 00 00 00` followed by modelJSON's
+ * `Course[id].function` defaults in declaration order, with `TimeDry` folded into bit 0x80 of
+ * the `PreSteam1_Time` byte. Standard (id 1) and Quick (id 3) were captured off LG's converter
+ * and the suite checks the frames this driver builds for them byte for byte.
+ *
+ * `cycles setCurrentCycle` does not convert for this model, so course select is a local choice
+ * this driver remembers and Start course is what sends it — the order LG's own app uses too.
+ */
+const HEADER_LEN = 13
+const TRAILER_LEN = 1
+const RECORD_LEN = 40
+/** buf[13..14], big-endian: how many record bytes the frame says it carries. */
+const RECORD_BYTES_OFF = 11
+const STATE_TAG = 0x31
+
+/** Offsets WITHIN a record. Add the record start to get the absolute frame offset; the
+ *  header comment states them against the 58-byte frame, whose single record starts at 15. */
+const OFF = {
+    state: 2,
+    remainTimeHour: 3,
+    remainTimeMinute: 4,
+    initialTimeHour: 5,
+    initialTimeMinute: 6,
+    course: 7,
+    error: 8,
+    preState: 9,
+    reserveTimeHour: 14,
+    reserveTimeMinute: 15,
+    flagsA: 16,
+    smartCourse: 22,
+    downloadCourseCount: 25,
+    downloadCourse1: 26,
+    buzzer: 30,
+    flagsB: 31,
+    endMelody: 32,
+    flagsC: 34,
+    nightCareStartHour: 35,
+    nightCareStartMinute: 36,
+    nightCareEndHour: 37,
+    nightCareEndMinute: 38,
+    tclCount: 39,
+} as const
+
+/** byte 31 */
+const F_CHILD_LOCK = 0x01
+const F_NIGHT_DRY = 0x02
+const F_REMOTE_START = 0x08
+/** byte 46 */
+const F_REMOTE_MAINTAIN = 0x04
+/** byte 49 */
+const F_IS_LAST_COURSE = 0x01
+const F_SC_FINEDUST = 0x02
+const F_SC_HUMIDITY = 0x04
+const F_SC_NIGHTCARE = 0x08
+
+/** Command frame opcode: `aa <len> f0 24 …`. See the WRITE DIRECTION note. */
+const SET_STATE = [0xf0, 0x24]
+
+/** modelJSON `ControlWifi` controlDataType ids, as the captured frames carry them. */
+const CTRL_POWER = 0x01
+const CTRL_PAUSE = 0x04
+const CTRL_REMOTE_MAINTAIN = 0x10
+const CTRL_UPCENTER = 0x13
+
+/** Course start and resume travel under their own opcode, carrying a course block. */
+const RUN_COURSE = [0xf0, 0x26]
+/** `<id> 01 00 04 00 00 00 00 00` — identical in both captured start frames. */
+const COURSE_HEAD = [0x01, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00]
+/** Resume carries the course id and nothing else, one byte shorter than a start block. */
+const RESUME_BLOCK_LEN = 45
+
+/*
+ * The parameter half of a start block: this model's `Course[id].function` defaults, in LG's
+ * declaration order, with TimeDry folded into bit 0x80 of the first byte. Ids are LG's course
+ * ids, the same ones the state frame reports.
+ *
+ * Ids 1 and 3 are the two captured off LG's converter; the suite checks the whole frame this
+ * driver builds for them against those captures, byte for byte.
+ */
+const COURSE_PARAMS: Record<number, string> = {
+    1: '02645a00000005005a05b45a01b4001ab40000000000000000000000000000000000000000', // Styling Standard
+    3: '82645a00000003005a00000001b4000eb40000000000000000000000000000000000000000', // Styling Quick
+    5: '02645a00000007005a05c85a01c80031b40000000000000000000000000000000000000000', // Styling Intensive
+    6: '82000000000004000000000001000014780000000000000000000000000000000000000000', // Wool/Knit
+    7: '82645a00000004005a04b45a01b40017780000000000000000000000000000000000000000', // Suit/Coat
+    11: '0200002d000006000008000003000023780000000000000000000000000000000000000000', // Sterilize Standard
+    15: '0000000000000000000000000000005a780000000000000000000000000000000000000000', // Auto Dry
+    17: '8000000000000000000000000000001e780000000000000000000000000000000000000000', // Timed Dry 30
+    18: '8000000000000000000000000000003c780000000000000000000000000000000000000000', // Timed Dry 60
+    19: '8000000000000000000000000000005a780000000000000000000000000000000000000000', // Timed Dry 90
+    // Identical to Timed Dry 60 on purpose: LG's modelJSON gives course 20 a Drying1_Time
+    // default of 60, the same as course 18. The duration the appliance actually runs comes
+    // from the course id, not from this block.
+    20: '8000000000000000000000000000003c780000000000000000000000000000000000000000', // Timed Dry 120
+    23: '80000000000000000000000000000078000000000000000000000000000000000000000000', // Room Dehumidify 120
+    24: '800000000000000000000000000000f0000000000000000000000000000000000000000000', // Room Dehumidify 240
+    28: '82005a00000005005a05b45a01b4002eb40000000000000000000000000000000000000000', // Padding Care
+    30: '82000000000000000000000005c80000000000000000000003005a02c85a01c80028c80000', // Fine dust
+    31: '8200002d000007000008000003000043000000000000000000000000000000000000000000', // Virus
+    32: '8200002d000006000008000003000028000000000000000000000000000000000000000000', // Jeans Care
+    33: '8000000000000000000000000000001e780000000000000000000000000000000000000000', // Fur/Leather Care
+    36: '8200002d00000600000800000300002b780000000000000000000000000000000000000000', // Suit/Uniform Sterilize
+    37: '8200002d00000600000800000300002b780000000000000000000000000000000000000000', // Silk
+    38: '8200002d00000600000800000300002b780000000000000000000000000000000000000000', // Cashmere
+}
+
+/** ...and the controlDataType_sub ids that follow UPCENTER. */
+const UP = {
+    endMelody: 0x01,
+    buzzer: 0x03,
+    smartCareFineDust: 0x04,
+    smartCareHumidity: 0x05,
+    smartCareNightCare: 0x06,
+    nightCareStart: 0x07,
+    nightCareEnd: 0x08,
+    isLastCourse: 0x09,
+} as const
+
+/** `styler.state` code 0. The appliance sends no decodable state frame while it is off, so
+ *  this is also the value the power switch reports back from. */
+const STATE_POWEROFF = 0
+
+/** Both night-care times: LG's own schema accepts whole and half hours only
+ *  (`^(0[0-9]|1[0-9]|2[0-3]):(00|30)$`), and the appliance is the one enforcing it. */
+const HALF_HOUR = /^([01]\d|2[0-3]):(00|30)$/
+
+/*
+ * The enum tables below are LG's own, in LG's own order.
+ *
+ * `styler.state` / `styler.preState` / `styler.error` are modelJSON `Value.<field>.option`,
+ * which lists names but no codes; the code is the position in that list. Three points were
+ * observed on the wire and all three agree — byte 17 = 1 read back INITIAL (index 1),
+ * byte 24 = 2 read back RUNNING (index 2), byte 23 = 1 read back ERROR_TE1 (index 1) — so
+ * the remaining entries follow the same declaration order.
+ *
+ * `styler.course` and `styler.smartCourse` are NOT positional: the byte is LG's course id
+ * straight out of the `Course` / `SmartCourse` tables. Confirmed twice — byte 22 = 1 read
+ * back STANDARD (id 1), and the untouched byte 41 = 0x4e = 78 read back FUR_LEATHER (id 78).
+ *
+ * Labels are English translations of this model's own ko-KR packs — the product pack for
+ * states and melodies, the per-model pack (`langPackModelUri`) for course names. Where two
+ * courses share a name ("Standard" for both styling and sanitising) the modelJSON `_comment`'s
+ * category prefix disambiguates them.
+ */
+
+/*
+ * `styler.state`, which is NOT positional — the running codes jump to 50 and up. Every entry
+ * below was measured by injecting that code and reading LG's own name back; 10..49 and 60
+ * answer NOT_DEFINE_VALUE, so the gap is LG's.
+ *
+ * LG deliberately collapses phases: PREHEAT, STEAM and STAY all print Refreshing, and
+ * COOLING / DRYING / ENDCOOLING all print Drying — the app shows the same.
+ */
+const STATE: Record<number, string> = {
+    0: 'Power off', // POWEROFF
+    1: 'Standby', // INITIAL
+    2: 'Styling', // RUNNING
+    3: 'Pause', // PAUSE
+    4: 'Course complete', // COMPLETE
+    5: 'Check appliance', // ERROR
+    6: 'Smart diagnosing', // DIAGNOSIS
+    7: 'Storing', // NIGHTDRY
+    8: 'Reserved', // RESERVED
+    9: 'Power-save running', // SLEEP
+    50: 'Steam preparing', // PRESTEAM
+    51: 'Refreshing', // PREHEAT
+    52: 'Refreshing', // STEAM
+    53: 'Refreshing', // STAY
+    54: 'Drying', // COOLING
+    55: 'Drying', // DRYING
+    56: 'Drying', // ENDCOOLING
+    57: 'Sterilizing', // STERILIZE
+    58: 'Course complete', // RUNNINGEND
+    59: 'Course complete', // END_REMOTE_MAINTAIN_ON
+}
+
+/*
+ * `styler.error`, also not positional — LG's own Error table skips values. Every entry below was
+ * measured by injecting the code and reading LG's name back; 12..17, 19..22, 24 and 27..30
+ * answer NOT_DEFINE_VALUE. Where LG has an owner-facing label (Water refill / drain) that is
+ * used rather than the service code.
+ *
+ * These matter beyond display: the appliance refuses to start a course while an error stands,
+ * which is why Check needed is published as its own problem sensor.
+ */
+const ERROR: Record<number, string> = {
+    0: 'Normal', // ERROR_NO
+    1: 'TE1',
+    2: 'TE2',
+    3: 'TE3',
+    4: 'TE4',
+    5: 'TE5',
+    6: 'E1',
+    7: 'E2',
+    8: 'Water refill', // ERROR_E3 — LG's own _comment is "E3_Water refill LED"
+    9: 'E4',
+    10: 'LE2',
+    11: 'AE',
+    18: 'LE',
+    23: 'Normal', // ERROR_NONE
+    25: 'Water drain', // ERROR_DRAINE
+    26: 'Door open', // ERROR_DE_OPEN
+    31: 'Check door closed', // ERROR_DE_CLOSE
+    32: 'E6',
+    33: 'PS',
+    34: 'No filter', // ERROR_IF
+}
+
+/** The two codes that mean "nothing wrong". Everything else stops a course from starting. */
+const ERROR_CLEAR = new Set([0, 23])
+
+/** modelJSON `Course`, id -> name (per-model language pack, translated). */
+const COURSE: Record<number, string> = {
+    0: 'None',
+    1: 'Styling Standard',
+    3: 'Styling Quick',
+    5: 'Styling Intensive',
+    6: 'Wool/Knit',
+    7: 'Suit/Coat',
+    11: 'Sterilize Standard',
+    15: 'Auto Dry',
+    17: 'Timed Dry 30',
+    18: 'Timed Dry 60',
+    19: 'Timed Dry 90',
+    20: 'Timed Dry 120',
+    23: 'Room Dehumidify 120',
+    24: 'Room Dehumidify 240',
+    28: 'Padding Care',
+    30: 'Fine dust',
+    31: 'Virus',
+    32: 'Jeans Care',
+    33: 'Fur/Leather Care',
+    36: 'Suit/Uniform Sterilize',
+    37: 'Silk',
+    38: 'Cashmere',
+}
+
+/** modelJSON `SmartCourse`, id -> name. Id 1 is LG's panel-pairing pseudo-course. */
+const SMART_COURSE: Record<number, string> = {
+    0: 'None',
+    1: 'Panel course',
+    61: 'Suit/Uniform Sterilize',
+    62: 'Scarf Care',
+    66: 'Pants Care',
+    67: 'Quiet Care',
+    68: 'Coat warm',
+    69: 'Static removal',
+    71: 'Old-clothes Care',
+    73: 'Blanket warm',
+    75: 'Dress-shirt Dry',
+    76: 'Snow/Rain Dry',
+    78: 'Fur/Leather Care',
+    93: 'Jeans Care',
+    94: 'Baby-clothes Sterilize',
+    95: 'Doll Sterilize',
+    96: 'Wool/Knit Dry',
+    97: 'Rainy-season Laundry Dry',
+    98: 'Uniform Care',
+    99: 'Padding Care',
+    100: 'Thin Padding Dry',
+    101: 'Thick Padding Dry',
+    112: 'Yoga/Pilates Care',
+    113: 'Yoga/Pilates Dry',
+    114: 'Swimwear Dry',
+    115: 'Functional',
+    119: 'Bedding Sterilize',
+}
+
+/** `styler.buzzer`: the byte is n in BUZZER_n (byte 45 = 4 read BUZZER_4, = 1 read BUZZER_1). */
+const BUZZER: Record<number, string> = { 0: 'Mute', 1: 'Small', 2: 'Normal', 3: 'Large', 4: 'Very large' }
+
+/** `styler.endMelody`: the byte is n in END_MELODY_n (byte 47 = 1 read END_MELODY_1). */
+const END_MELODY: Record<number, string> = {
+    0: 'Default sound',
+    1: 'Vivaldi Winter',
+    2: 'Bach Minuet',
+    3: 'Home Sweet Home',
+    4: 'Breeze',
+    5: 'Old MacDonald',
+    6: 'Verdi Brindisi',
+    7: 'Bubble',
+    8: 'Beethoven Symphony No.5 5',
+    9: 'Arirang',
+    10: 'Pachelbel Canon',
+    11: 'Beethoven Choral',
+    12: 'Jingle Bells (intro)',
+    13: 'Jingle Bells (chorus)',
+    14: 'We Wish You a Merry Christmas',
+    15: 'Silent Night',
+    16: 'O Christmas Tree',
+}
+
+/** The melodies LG's own capability schema offers for this unit — codes 0..11, in this order,
+ *  and a command frame was captured for every one. Codes 12..16 in the table above are read
+ *  labels only; LG does not list them for this model, so the select does not offer them. */
+const END_MELODY_OPTIONS = Array.from({ length: 12 }, (_, i) => END_MELODY[i])
+
+/** The courses this unit can be told to run — every id with a block above, under the name the
+ *  read table gives it, so Course select and the Course sensor speak the same words. */
+const COURSE_IDS = Object.keys(COURSE_PARAMS).map(Number)
+const COURSE_OPTIONS = COURSE_IDS.map((id) => COURSE[id])
+
+const enumOf = (table: Record<number, string>, raw: number) => table[raw] ?? `Code ${raw}`
+const hhmm = (h: number, m: number) => `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
+
+export default class Device extends AABBDevice {
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+
+        const sensor = (id: string, name: string, extra: object = {}) => ({
+            platform: 'sensor',
+            unique_id: `$deviceid-${id}`,
+            state_topic: `$this/${id}`,
+            name,
+            ...extra,
+        })
+        const flag = (id: string, name: string, extra: object = {}) => ({
+            platform: 'binary_sensor',
+            unique_id: `$deviceid-${id}`,
+            state_topic: `$this/${id}`,
+            name,
+            payload_on: 'ON',
+            payload_off: 'OFF',
+            ...extra,
+        })
+        const minutes = (id: string, name: string, extra: object = {}) =>
+            sensor(id, name, {
+                device_class: 'duration',
+                unit_of_measurement: 'min',
+                state_class: 'measurement',
+                ...extra,
+            })
+        /** A flag the appliance takes a command for. */
+        const toggle = (id: string, name: string, extra: object = {}) => ({
+            platform: 'switch',
+            unique_id: `$deviceid-${id}`,
+            state_topic: `$this/${id}`,
+            command_topic: `$this/${id}/set`,
+            name,
+            payload_on: 'ON',
+            payload_off: 'OFF',
+            ...extra,
+        })
+        /** A setting the appliance takes a command for, offered as LG's own labels. */
+        const choice = (id: string, name: string, options: string[], extra: object = {}) => ({
+            platform: 'select',
+            unique_id: `$deviceid-${id}`,
+            state_topic: `$this/${id}`,
+            command_topic: `$this/${id}/set`,
+            name,
+            options,
+            ...extra,
+        })
+        /** A one-shot command with no state of its own. */
+        const press = (id: string, name: string, icon: string) => ({
+            platform: 'button',
+            unique_id: `$deviceid-${id}`,
+            command_topic: `$this/${id}/set`,
+            payload_press: '',
+            name,
+            icon,
+        })
+        /** One half of the night-care window. LG's own setter takes HH:MM on the half hour. */
+        const halfHourClock = (id: string, name: string, extra: object = {}) => ({
+            platform: 'text',
+            unique_id: `$deviceid-${id}`,
+            state_topic: `$this/${id}`,
+            command_topic: `$this/${id}/set`,
+            name,
+            icon: 'mdi:clock-time-four-outline',
+            pattern: HALF_HOUR.source,
+            min: 5,
+            max: 5,
+            entity_category: 'config',
+            ...extra,
+        })
+
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: 'LG Styler' }),
+                components: {
+                    power: toggle('power', 'Power', { icon: 'mdi:power' }),
+                    status: sensor('status', 'Status', { icon: 'mdi:hanger' }),
+                    course: sensor('course', 'Course', { icon: 'mdi:playlist-check' }),
+                    // Choosing a course does not start it — LG's own app works the same way,
+                    // and its setCurrentCycle does not convert for this model.
+                    course_select: choice('course_select', 'Course select', COURSE_OPTIONS, {
+                        icon: 'mdi:playlist-edit',
+                    }),
+                    start_course: press('start_course', 'Start course', 'mdi:play-circle-outline'),
+                    pause_course: press('pause_course', 'Pause', 'mdi:pause-circle-outline'),
+                    resume_course: press('resume_course', 'Resume', 'mdi:play-pause'),
+                    smart_course: sensor('smart_course', 'Smart course', { icon: 'mdi:playlist-star' }),
+                    remaining_time: minutes('remaining_time', 'Remaining time', { icon: 'mdi:timer-sand' }),
+                    initial_time: minutes('initial_time', 'Initial time', { icon: 'mdi:timer-outline' }),
+                    // LG declares Reserve_Time_H as a 3..19 hour range, so this is a delay before
+                    // the course starts, not a wall-clock time; 0 means no reservation.
+                    reserve_time: minutes('reserve_time', 'Reserve time', { icon: 'mdi:calendar-clock' }),
+                    error: sensor('error', 'Error', { icon: 'mdi:alert-circle-outline' }),
+                    // The appliance will not start a course while an error stands — Water refill is
+                    // the everyday one — so it gets a problem sensor of its own rather than
+                    // hiding inside a text reading nobody has an automation on.
+                    problem: flag('problem', 'Check needed', {
+                        device_class: 'problem',
+                        icon: 'mdi:alert',
+                    }),
+                    child_lock: flag('child_lock', 'Button lock', { icon: 'mdi:lock' }),
+                    night_dry: flag('night_dry', 'Store', { icon: 'mdi:weather-night' }),
+                    remote_start: flag('remote_start', 'Remote-control ready', { icon: 'mdi:cellphone-check' }),
+                    remote_maintain: toggle('remote_maintain', 'Remote control allowed', {
+                        icon: 'mdi:cellphone-wireless',
+                    }),
+                    buzzer: choice('buzzer', 'Alert sound', Object.values(BUZZER), {
+                        icon: 'mdi:volume-high',
+                        entity_category: 'config',
+                    }),
+                    end_melody: choice('end_melody', 'End melody', END_MELODY_OPTIONS, {
+                        icon: 'mdi:music',
+                        entity_category: 'config',
+                    }),
+                    keep_last_course: toggle('keep_last_course', 'Keep last course', {
+                        icon: 'mdi:repeat',
+                        entity_category: 'config',
+                    }),
+                    smart_care_finedust: toggle('smart_care_finedust', 'SmartCare Fine-dust', {
+                        icon: 'mdi:weather-dust',
+                        entity_category: 'config',
+                    }),
+                    smart_care_humidity: toggle('smart_care_humidity', 'SmartCare Humidity', {
+                        icon: 'mdi:water-percent',
+                        entity_category: 'config',
+                    }),
+                    smart_care_nightcare: toggle('smart_care_nightcare', 'SmartCare Night', {
+                        icon: 'mdi:sleep',
+                        entity_category: 'config',
+                    }),
+                    night_care_start: halfHourClock('night_care_start', 'Night-care start time'),
+                    night_care_end: halfHourClock('night_care_end', 'Night-care end time'),
+                    download_course: sensor('download_course', 'Downloaded course', {
+                        icon: 'mdi:download',
+                        entity_category: 'diagnostic',
+                    }),
+                    tcl_count: sensor('tcl_count', 'Sterilize-tank clean alert count', {
+                        icon: 'mdi:counter',
+                        entity_category: 'diagnostic',
+                        // Resets when the maintenance course runs, so total_increasing would
+                        // wrongly accumulate across the reset — no state_class.
+                    }),
+                    previous_status: sensor('previous_status', 'Previous state', {
+                        icon: 'mdi:history',
+                        entity_category: 'diagnostic',
+                    }),
+                },
+            }),
+        )
+    }
+
+    // AABBDevice strips the leading AA/FF and trailing CRC/BB, so offsets here are two less than
+    // the whole-frame positions the probes recorded.
+    processAABB(buf: Buffer) {
+        if (buf[0] !== STATE_TAG) return
+        if (buf.length < HEADER_LEN + RECORD_LEN + TRAILER_LEN) return
+        const payload = buf.length - HEADER_LEN - TRAILER_LEN
+        if (payload % RECORD_LEN !== 0) return
+        // The frame states how many record bytes it carries; disagreeing with the length means
+        // this is a different message that happens to divide evenly.
+        if (buf.readUInt16BE(RECORD_BYTES_OFF) !== payload) return
+
+        // The trailing record is the current state; a leading one, when present, is the previous.
+        const record = buf.length - TRAILER_LEN - RECORD_LEN
+        const at = (o: number) => buf[record + o]
+        const flagsA = at(OFF.flagsA)
+        const flagsB = at(OFF.flagsB)
+        const flagsC = at(OFF.flagsC)
+        const on = (byte: number, bit: number) => ((byte & bit) !== 0 ? 'ON' : 'OFF')
+
+        this.poweredOn = at(OFF.state) !== STATE_POWEROFF
+        this.nightCareEnabled = (flagsC & F_SC_NIGHTCARE) !== 0
+        this.hasProblem = !ERROR_CLEAR.has(at(OFF.error))
+        this.publishProperty('status', enumOf(STATE, at(OFF.state)))
+        this.publishProperty('power', this.poweredOn ? 'ON' : 'OFF')
+        this.publishProperty('previous_status', enumOf(STATE, at(OFF.preState)))
+        this.publishProperty('error', enumOf(ERROR, at(OFF.error)))
+        this.publishProperty('problem', this.hasProblem ? 'ON' : 'OFF')
+        this.publishProperty('course', enumOf(COURSE, at(OFF.course)))
+        this.publishProperty('smart_course', enumOf(SMART_COURSE, at(OFF.smartCourse)))
+
+        // Track whatever the appliance is actually set to, so Course select opens on the right one.
+        // Idle it reports NONE, which is not an option — that leaves the last choice standing.
+        const running = COURSE_PARAMS[at(OFF.course)] !== undefined ? at(OFF.course) : undefined
+        if (running !== undefined) {
+            this.selectedCourse = running
+            this.publishProperty('course_select', COURSE[running])
+        }
+
+        // LG reports the times split into hours and minutes; HA wants one duration.
+        this.publishProperty('remaining_time', at(OFF.remainTimeHour) * 60 + at(OFF.remainTimeMinute))
+        this.publishProperty('initial_time', at(OFF.initialTimeHour) * 60 + at(OFF.initialTimeMinute))
+
+        this.publishProperty('reserve_time', at(OFF.reserveTimeHour) * 60 + at(OFF.reserveTimeMinute))
+
+        this.publishProperty('child_lock', on(flagsA, F_CHILD_LOCK))
+        this.publishProperty('night_dry', on(flagsA, F_NIGHT_DRY))
+        this.publishProperty('remote_start', on(flagsA, F_REMOTE_START))
+        this.publishProperty('remote_maintain', on(flagsB, F_REMOTE_MAINTAIN))
+
+        // Both are selects, and a select's state has to be one of its options — publishing
+        // `Code N` for something outside the list would make Home Assistant reject the state and
+        // log it, so an unlisted code leaves the previous value standing.
+        this.publishOption('buzzer', BUZZER[at(OFF.buzzer)])
+        this.publishOption('end_melody', END_MELODY_OPTIONS[at(OFF.endMelody)])
+
+        this.publishProperty('keep_last_course', on(flagsC, F_IS_LAST_COURSE))
+        this.publishProperty('smart_care_finedust', on(flagsC, F_SC_FINEDUST))
+        this.publishProperty('smart_care_humidity', on(flagsC, F_SC_HUMIDITY))
+        this.publishProperty('smart_care_nightcare', on(flagsC, F_SC_NIGHTCARE))
+
+        this.publishProperty('night_care_start', hhmm(at(OFF.nightCareStartHour), at(OFF.nightCareStartMinute)))
+        this.publishProperty('night_care_end', hhmm(at(OFF.nightCareEndHour), at(OFF.nightCareEndMinute)))
+
+        // Only slot 1 is meaningful on this unit: Config.maxDownloadCourseNum is 1, and the
+        // count byte 40 reads 1. Slots 2..4 hold leftovers and are not published.
+        this.publishProperty('download_course', enumOf(SMART_COURSE, at(OFF.downloadCourse1)))
+
+        this.publishProperty('tcl_count', at(OFF.tclCount))
+    }
+
+    /** What Start course will run. Kept here because LG's setCurrentCycle does not convert, so the
+     *  appliance has no notion of a selected-but-not-started course to read back. */
+    private selectedCourse = COURSE_IDS[0]
+    /** Last state the appliance itself reported. `undefined` means no state frame has arrived. */
+    private poweredOn: boolean | undefined
+    private nightCareEnabled: boolean | undefined
+    private hasProblem: boolean | undefined
+
+    private publishOption(prop: string, label: string | undefined) {
+        if (label !== undefined) this.publishProperty(prop, label)
+    }
+
+    /** `aa 34 f0 26 | <id> 01 00 04 00 00 00 00 00 | <course parameters> | ck bb`. */
+    private runCourse(id: number) {
+        const params = COURSE_PARAMS[id]
+        if (params === undefined) return log('status', this.id, `Course cannot start ${id}`)
+        this.send(
+            Buffer.concat([Buffer.from(RUN_COURSE), Buffer.from([id, ...COURSE_HEAD]), Buffer.from(params, 'hex')]),
+        )
+    }
+
+    /** Resume carries the course id and nothing else. */
+    private resumeCourse(id: number) {
+        const block = Buffer.alloc(RESUME_BLOCK_LEN)
+        block[0] = id
+        this.send(Buffer.concat([Buffer.from(RUN_COURSE), block]))
+    }
+
+    /**
+     * Build and send a command frame: `aa <len> f0 24 <type> <len> <value…> <ck> bb`.
+     *
+     * The base class's `send` supplies the AA/length prefix and the checksum, so what goes in is
+     * `f0 24` plus the body — which reproduces the captured frames byte for byte.
+     */
+    private setControl(type: number, ...values: number[]) {
+        this.send(Buffer.from([...SET_STATE, type, values.length, ...values]))
+    }
+
+    /** The UPCENTER settings put their own sub id between the length and the value, and the
+     *  length still counts only the value bytes — 1 for a flag, 2 for a clock time. */
+    private setUpCenter(sub: number, ...values: number[]) {
+        this.send(Buffer.from([...SET_STATE, CTRL_UPCENTER, values.length, sub, ...values]))
+    }
+
+    /*
+     * Publish what was just asked for, without waiting for the appliance to say it.
+     *
+     * This appliance reports when it feels like it. A settings change comes back in a second or
+     * two, but a course start can take a minute or more: while it runs it mostly sends frames
+     * that carry no state at all, so the 98-byte state frame that would confirm the course is
+     * simply not due yet. Waiting for it makes every control feel broken and invites a second
+     * press. The next real frame overwrites whatever is published here, so the appliance still
+     * has the last word. Known refusals are not echoed: this model rejects every setting while
+     * powered off, and rejects night-care times while night care is disabled.
+     */
+    private echo(prop: string, value: string | number) {
+        if (this.poweredOn !== true) return
+        if (prop === 'course' && this.hasProblem !== false) return
+        if (this.nightCareEnabled === false && (prop === 'night_care_start' || prop === 'night_care_end')) {
+            return
+        }
+        this.publishProperty(prop, value)
+    }
+
+    setProperty(prop: string, mqttValue: string) {
+        const onOff = () => (mqttValue === 'ON' ? 1 : 0)
+        switch (prop) {
+            case 'power':
+                this.setControl(CTRL_POWER, onOff())
+                // Every other setting here is confirmed by the state frame the appliance sends
+                // back. Power is the exception: switched off, it stops sending a frame this
+                // driver can read at all, so the switch would never see OFF. It is published
+                // here and corrected by the next real frame.
+                if (mqttValue !== 'ON') this.poweredOn = false
+                return this.publishProperty('power', mqttValue === 'ON' ? 'ON' : 'OFF')
+            case 'remote_maintain':
+                this.setControl(CTRL_REMOTE_MAINTAIN, onOff())
+                return this.echo(prop, mqttValue)
+            case 'keep_last_course':
+                this.setUpCenter(UP.isLastCourse, onOff())
+                return this.echo(prop, mqttValue)
+            case 'course_select': {
+                const id = COURSE_IDS.find((c) => COURSE[c] === mqttValue)
+                if (id === undefined) return log('status', this.id, `Unknown course ${mqttValue}`)
+                this.selectedCourse = id
+                // Nothing goes to the appliance until Start course — this is a choice, not a command.
+                return this.publishProperty('course_select', mqttValue)
+            }
+            case 'start_course':
+                this.runCourse(this.selectedCourse)
+                // The course itself, so the dashboard shows what was asked for straight away.
+                return this.echo('course', COURSE[this.selectedCourse])
+            case 'pause_course':
+                return this.setControl(CTRL_PAUSE, 0)
+            case 'resume_course':
+                return this.resumeCourse(this.selectedCourse)
+            case 'smart_care_finedust':
+                this.setUpCenter(UP.smartCareFineDust, onOff())
+                return this.echo(prop, mqttValue)
+            case 'smart_care_humidity':
+                this.setUpCenter(UP.smartCareHumidity, onOff())
+                return this.echo(prop, mqttValue)
+            case 'smart_care_nightcare':
+                this.setUpCenter(UP.smartCareNightCare, onOff())
+                return this.echo(prop, mqttValue)
+            case 'buzzer': {
+                const code = Object.entries(BUZZER).find(([, label]) => label === mqttValue)?.[0]
+                if (code === undefined) return log('status', this.id, `Unknown alert sound ${mqttValue}`)
+                this.setUpCenter(UP.buzzer, Number(code))
+                return this.echo(prop, mqttValue)
+            }
+            case 'end_melody': {
+                const code = END_MELODY_OPTIONS.indexOf(mqttValue)
+                if (code < 0) return log('status', this.id, `Unknown end melody ${mqttValue}`)
+                this.setUpCenter(UP.endMelody, code)
+                return this.echo(prop, mqttValue)
+            }
+            case 'night_care_start':
+            case 'night_care_end': {
+                // The text entity carries the pattern, but a driver that trusts it would write a
+                // stray byte into the schedule on any other producer. The appliance only takes
+                // whole and half hours, which is LG's own constraint, not ours.
+                const m = HALF_HOUR.exec(mqttValue.trim())
+                if (!m) return log('status', this.id, `Night-care time format error ${mqttValue}`)
+                const sub = prop === 'night_care_start' ? UP.nightCareStart : UP.nightCareEnd
+                // Hour and minute travel in one frame, exactly as LG's own setter sent them.
+                this.setUpCenter(sub, Number(m[1]), Number(m[2]))
+                return this.echo(prop, mqttValue.trim())
+            }
+            default:
+                log('status', this.id, `Item does not support writing ${prop}`)
+        }
+    }
+}

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -22,6 +22,7 @@ import RV13B6BSD_D_US_WIFI from './devices/RV13B6BSD_D_US_WIFI'
 import RV13B6ES_D_US_WIFI from './devices/RV13B6ES_D_US_WIFI'
 import WTL_FXU_BDV_NA_01 from './devices/WTL_FXU_BDV_NA_01'
 import DHUM_056905_WW from './devices/DHUM_056905_WW'
+import ST_B_E4H01Y_APL from './devices/ST_B_E4H01Y_APL'
 import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
 import { type Connection } from './homeassistant'
@@ -67,6 +68,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     // Wrinkle Care sits in a different bitfield, so it needs its own handler rather than an alias
     WTL_FXU_BDV_NA_01, // LG WashTower
     DHUM_056905_WW,
+    ST_B_E4H01Y_APL,
 }
 
 class Bridge {

--- a/tests/cloud/devices/ST_B_E4H01Y_APL.test.ts
+++ b/tests/cloud/devices/ST_B_E4H01Y_APL.test.ts
@@ -1,0 +1,642 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/ST_B_E4H01Y_APL'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'ST_B_E4H01Y_APL'
+const META: Metadata = { modelId: MODEL_ID, modelName: MODEL_ID, swVersion: '2.11.255' }
+
+/*
+ * Fixtures.
+ *
+ * STATE and STATE2 are REAL frames captured from the appliance on 2026-07-28 (same content,
+ * different sequence number). The rest are STATE with ONE byte changed and the CRC16 recomputed;
+ * every one of them was injected into LG's cloud that day, so what each test expects is LG's own
+ * decode of that exact frame.
+ */
+
+// Real, appliance idle. LG read this as state POWEROFF, preState INITIAL, course NONE,
+// error ERROR_NO, childLock OFF, buzzer BUZZER_4, applyBuzzer ON, applyRemoteMaintain ON,
+// remoteMaintain OFF, endMelody END_MELODY_0, currentDownloadCourse1 FUR_LEATHER (78),
+// currentDownloadCourseCount 1, TCLCount 37, energyMonitoring 0.
+const STATE = buf(
+    'aaff310a003a0053ea000100eb002800000000010001000001000000000000200000000000000000014e420000040300000000000000257205bb',
+)
+const STATE2 = buf(
+    'aaff310a003a005504000100eb002800000000010001000001000000000000200000000000000000014e420000040300000000000000251351bb',
+)
+
+const READY = buf(
+    'aaff310a003a0053ea000100eb002800000100010001000001000000000000200000000000000000014e42000004030000000000000025969ebb',
+) // byte[17]=1 -> state INITIAL
+const COURSE_STANDARD = buf(
+    'aaff310a003a0053ea000100eb002800000000010001010001000000000000200000000000000000014e42000004030000000000000025ffd9bb',
+) // byte[22]=1 -> course STANDARD (id 1)
+const ERROR_TE1 = buf(
+    'aaff310a003a0053ea000100eb002800000000010001000101000000000000200000000000000000014e420000040300000000000000252b43bb',
+) // byte[23]=1 -> error ERROR_TE1
+const PRESTATE_RUNNING = buf(
+    'aaff310a003a0053ea000100eb002800000000010001000002000000000000200000000000000000014e42000004030000000000000025f05fbb',
+) // byte[24]=2 -> preState RUNNING
+const FLAGS_A_ALL = buf(
+    'aaff310a003a0053ea000100eb0028000000000100010000010000000000000f0000000000000000014e42000004030000000000000025df93bb',
+) // byte[31]=0x0f -> childLock + nightDry + initialBit + remoteStart all ON
+const REMOTE_MAINTAIN = buf(
+    'aaff310a003a0053ea000100eb002800000000010001000001000000000000200000000000000000014e42000004040000000000000025c3aebb',
+) // byte[46]=0x04 -> remoteMaintain ON (and both apply* bits cleared)
+const FLAGS_C_ALL = buf(
+    'aaff310a003a0053ea000100eb002800000000010001000001000000000000200000000000000000014e420000040300003f0000000025988abb',
+) // byte[49]=0x3f -> isLastCourse + 3x smartCare + smartPairing + currentTimeDisplay all ON
+const BUZZER_LOW = buf(
+    'aaff310a003a0053ea000100eb002800000000010001000001000000000000200000000000000000014e42000001030000000000000025b075bb',
+) // byte[45]=1 -> buzzer BUZZER_1
+const MELODY_1 = buf(
+    'aaff310a003a0053ea000100eb002800000000010001000001000000000000200000000000000000014e4200000403010000000000002535d6bb',
+) // byte[47]=1 -> endMelody END_MELODY_1
+const SMART_COURSE_1 = buf(
+    'aaff310a003a0053ea000100eb002800000000010001000001000000000000200000000000010000014e420000040300000000000000258234bb',
+) // byte[37]=1 -> smartCourse PAIRING_PANEL_COURSE (id 1)
+const TCL_1 = buf(
+    'aaff310a003a0053ea000100eb002800000000010001000001000000000000200000000000000000014e4200000403000000000000000116e3bb',
+) // byte[54]=1 -> TCLCount 1
+
+// REAL 98-byte two-record frames, captured 2026-07-28 the moment the appliance was switched on and
+// a course selected. LG read these as state INITIAL, course STANDARD, remoteStart ON — while a
+// decoder keyed on "58 bytes" was still publishing Power off off the last idle frame. Record B (the
+// trailing one) is the current state.
+const RUNNING_READY = buf(
+    'aaff310a0062005cd0000100ec005000000000010001000001000000000000200000000000000000014e4200000403000000000000002500000100010001000000000000000000200000000000000000014e42000004030000000000000025ee3ebb',
+) // record B: state 1 (Standby)
+const RUNNING_COURSE = buf(
+    'aaff310a0062005ce5000100ec0050000001011e011e0f0000000000000000280000000000000000014e4200000403000000000000002500000100230023010000000000000000280000000000000000014e42000004030000000000000025042abb',
+) // record B: state 1, course 1 (Styling Standard), 35 min, flagsA 0x28 -> remoteStart ON
+// The downloadable-course name list — 112 bytes, which is NOT a whole number of 40-byte records.
+const COURSE_LIST = buf(
+    'aaff310a0070005ccc00010a86005e0d053230332d3101073230332d312d3101073230332d312d3201073230332d312d3301073230332d312d34010453542d34010453542d35010453542d36010453542d37010453542d38010453542d39010553542d3130000553542d313201ed79bb',
+)
+
+// The 35-byte frame shares the header but is NOT state: probing bytes 9..31 of it with 0xff moved
+// no field in LG's snapshot at all.
+const NOT_STATE_35 = buf('aaff310a00230053ed000101030011100b0306100000008a00000000000000059317bb')
+// Heartbeat.
+const HEARTBEAT = buf('aa0731c302f2bb')
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    /*
+     * Writable exactly where a frame the appliance accepts was established: captured off LG's
+     * own capability API (CL-0000), or — for remote_maintain's ON side, which LG's converter
+     * never emits — built from the same frame shape, acknowledged by the appliance and read
+     * back on the next state frame. Everything else stays read-only.
+     */
+    const WRITABLE = new Set([
+        'power',
+        'buzzer',
+        'end_melody',
+        'keep_last_course',
+        'smart_care_finedust',
+        'smart_care_humidity',
+        'smart_care_nightcare',
+        'night_care_start',
+        'night_care_end',
+        'remote_maintain',
+        'course_select',
+        'start_course',
+        'pause_course',
+        'resume_course',
+    ])
+
+    test('exactly the fields with a captured command frame are writable', () => {
+        const { ha } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        for (const [name, comp] of Object.entries(components)) {
+            if (WRITABLE.has(name)) {
+                assert.equal(comp.command_topic, `$this/${name}/set`, `${name} is writable`)
+            } else if (comp.platform === 'button') {
+                assert.fail(`${name} is a button with no command topic`)
+            } else {
+                assert.equal(comp.command_topic, undefined, `${name} stays read-only`)
+                assert.ok(
+                    comp.platform === 'sensor' || comp.platform === 'binary_sensor',
+                    `${name} is a sensor platform, got ${comp.platform}`,
+                )
+            }
+        }
+    })
+
+    /*
+     * The frames below are REAL. LG's capability API was asked to make each change
+     * (`convert/control`; every one answered CL-0000, and the appliance ACKed each with
+     * `aa 08 31 00 24 00 …`) and these are the cloud→appliance frames rethink relayed as a
+     * result, on 2026-07-28. So the assertion is that this driver emits byte for byte what LG
+     * emits — not that it agrees with its own idea of the format.
+     *
+     * Every option of every enum is here, because a select that offers an option nobody ever
+     * drove is shipping a guess for that option.
+     */
+    test('each write reproduces the frame LG itself sent for that command', () => {
+        for (const [prop, value, want] of [
+            // POWERON / POWEROFF (controlDataType 0x01)
+            ['power', 'ON', 'aa09f0240101019fbb'],
+            ['power', 'OFF', 'aa09f0240101009cbb'],
+            // UPCENTER 0x13, sub 0x01 ENDMELODY — the value is the melody's index
+            ['end_melody', 'Default sound', 'aa0af0241301010088bb'],
+            ['end_melody', 'Vivaldi Winter', 'aa0af024130101018bbb'],
+            ['end_melody', 'Bach Minuet', 'aa0af024130101028abb'],
+            ['end_melody', 'Home Sweet Home', 'aa0af02413010103b5bb'],
+            ['end_melody', 'Breeze', 'aa0af02413010104b4bb'],
+            ['end_melody', 'Old MacDonald', 'aa0af02413010105b7bb'],
+            ['end_melody', 'Verdi Brindisi', 'aa0af02413010106b6bb'],
+            ['end_melody', 'Bubble', 'aa0af02413010107b1bb'],
+            ['end_melody', 'Beethoven Symphony No.5 5', 'aa0af02413010108b0bb'],
+            ['end_melody', 'Arirang', 'aa0af02413010109b3bb'],
+            ['end_melody', 'Pachelbel Canon', 'aa0af0241301010ab2bb'],
+            ['end_melody', 'Beethoven Choral', 'aa0af0241301010bbdbb'],
+            // sub 0x03 UPBUZZER
+            ['buzzer', 'Mute', 'aa0af024130103008abb'],
+            ['buzzer', 'Small', 'aa0af02413010301b5bb'],
+            ['buzzer', 'Normal', 'aa0af02413010302b4bb'],
+            ['buzzer', 'Large', 'aa0af02413010303b7bb'],
+            ['buzzer', 'Very large', 'aa0af02413010304b6bb'],
+            // subs 0x04 / 0x05 / 0x06 — the three smart-care flags
+            ['smart_care_finedust', 'ON', 'aa0af02413010401b4bb'],
+            ['smart_care_finedust', 'OFF', 'aa0af02413010400b5bb'],
+            ['smart_care_humidity', 'ON', 'aa0af02413010501b7bb'],
+            ['smart_care_humidity', 'OFF', 'aa0af02413010500b4bb'],
+            ['smart_care_nightcare', 'ON', 'aa0af02413010601b6bb'],
+            ['smart_care_nightcare', 'OFF', 'aa0af02413010600b7bb'],
+            // sub 0x09 CTRL_IS_LAST_COURSE
+            ['keep_last_course', 'ON', 'aa0af02413010901b3bb'],
+            ['keep_last_course', 'OFF', 'aa0af02413010900b0bb'],
+        ] as [string, string, string][]) {
+            const { thinq, dev } = makeDevice()
+            thinq.resetRecorder()
+            dev.setProperty(prop, value)
+            assert.equal(thinq.outbox.length, 1, `${prop}=${value} sent one frame`)
+            assert.equal(thinq.outbox[0].toString('hex'), want, `${prop}=${value}`)
+        }
+    })
+
+    /*
+     * Remote control allowed has no LG-emitted ON frame: setRemoteControlType answers CL-0000 for every
+     * argument and always emits the OFF frame. The ON frame below was built and sent to the
+     * appliance directly on 2026-07-28; it ACKed (`aa 08 31 00 24 00`) and the next state frame
+     * came back with the bit set, which is the appliance confirming it and not a guess.
+     */
+    test('Remote control allowed writes the frame the appliance acknowledged', () => {
+        for (const [value, want] of [
+            ['ON', 'aa09f0241001018cbb'],
+            ['OFF', 'aa09f0241001008dbb'],
+        ] as [string, string][]) {
+            const { thinq, dev } = makeDevice()
+            thinq.resetRecorder()
+            dev.setProperty('remote_maintain', value)
+            assert.equal(thinq.outbox[0].toString('hex'), want, `remote_maintain=${value}`)
+        }
+    })
+
+    /*
+     * REAL start frames: LG's converter was asked to run Standard and Quick
+     * (`operationState startCycle {"cycle":{"id":"1"}}` / `"3"`, both CL-0000) and these are the
+     * frames rethink relayed, on 2026-07-28. The appliance ran the course each time.
+     *
+     * Only two of the twenty-one courses were driven, and the rest of the table is the same rule
+     * applied to the same modelJSON declaration — so these two are what proves the rule, and
+     * they have to match to the byte, checksum included.
+     */
+    test('Start course reproduces the frame LG itself sent, for both captured courses', () => {
+        for (const [course, want] of [
+            [
+                'Styling Standard',
+                'aa34f02601010004000000000002645a00000005005a05b45a01b4001ab40000000000000000000000000000000000000000fabb',
+            ],
+            [
+                'Styling Quick',
+                'aa34f02603010004000000000082645a00000003005a00000001b4000eb4000000000000000000000000000000000000000045bb',
+            ],
+        ] as [string, string][]) {
+            const { thinq, dev } = makeDevice()
+            dev.setProperty('course_select', course)
+            thinq.resetRecorder()
+            dev.setProperty('start_course', '')
+            assert.equal(thinq.outbox.length, 1, `${course} sent one frame`)
+            assert.equal(thinq.outbox[0].toString('hex'), want, course)
+        }
+    })
+
+    test('Pause and Resume reproduce their captured frames', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('course_select', 'Styling Standard')
+        thinq.resetRecorder()
+        dev.setProperty('pause_course', '')
+        // PAUSE, LG's controlDataType 0x04, value 0 — exactly modelJSON's pauseCourse dataForm
+        assert.equal(thinq.outbox[0].toString('hex'), 'aa09f02404010099bb')
+        thinq.resetRecorder()
+        dev.setProperty('resume_course', '')
+        assert.equal(
+            thinq.outbox[0].toString('hex'),
+            'aa33f026010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a1bb',
+        )
+    })
+
+    test('a write shows up straight away instead of waiting for the appliance', () => {
+        // The appliance reports on its own schedule — a course start can go a minute without a
+        // state frame — so a control that waits for confirmation reads as broken and gets
+        // pressed twice. What is published here is overwritten by the next real frame.
+        const { ha, thinq, dev } = makeDevice()
+        const enabled = Buffer.from(READY)
+        enabled[49] |= 0x08 // smartCareNightCare ON
+        thinq.emit('data', enabled)
+        dev.setProperty('buzzer', 'Small')
+        dev.setProperty('smart_care_humidity', 'ON')
+        dev.setProperty('night_care_start', '22:30')
+        dev.setProperty('course_select', 'Styling Standard')
+        dev.setProperty('start_course', '')
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.buzzer, 'Small')
+        assert.equal(p.smart_care_humidity, 'ON')
+        assert.equal(p.night_care_start, '22:30')
+        assert.equal(p.course, 'Styling Standard')
+        // ...and the appliance still has the last word.
+        thinq.emit('data', enabled)
+        assert.equal(p.buzzer, 'Very large')
+        assert.equal(p.course, 'None')
+    })
+
+    test('a setting rejected while powered off is not optimistically published', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', STATE)
+        thinq.resetRecorder()
+
+        dev.setProperty('buzzer', 'Small')
+        dev.setProperty('smart_care_humidity', 'ON')
+        dev.setProperty('course_select', 'Styling Standard')
+        dev.setProperty('start_course', '')
+
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(thinq.outbox.length, 3, 'commands are still sent so the appliance has the final say')
+        assert.equal(p.buzzer, 'Very large')
+        assert.equal(p.smart_care_humidity, 'OFF')
+        assert.equal(p.course, 'None')
+        assert.equal(p.course_select, 'Styling Standard', 'the local-only course choice still updates')
+    })
+
+    test('night-care times rejected while night care is disabled are not optimistically published', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', READY)
+        thinq.resetRecorder()
+
+        dev.setProperty('night_care_start', '22:30')
+        dev.setProperty('night_care_end', '06:00')
+
+        assert.equal(thinq.outbox.length, 2, 'valid command frames are still sent')
+        assert.equal(ha.devices[DEVICE_ID].properties.night_care_start, '00:00')
+        assert.equal(ha.devices[DEVICE_ID].properties.night_care_end, '00:00')
+    })
+
+    test('no setting is optimistically published before the first authoritative state', () => {
+        const { ha, thinq, dev } = makeDevice()
+        dev.setProperty('buzzer', 'Small')
+        dev.setProperty('course_select', 'Styling Standard')
+        dev.setProperty('start_course', '')
+
+        assert.equal(thinq.outbox.length, 2, 'valid frames still reach the appliance')
+        assert.equal(ha.devices[DEVICE_ID].properties.buzzer, undefined)
+        assert.equal(ha.devices[DEVICE_ID].properties.course, undefined)
+        assert.equal(ha.devices[DEVICE_ID].properties.course_select, 'Styling Standard')
+    })
+
+    test('a course rejected by a standing error is not optimistically published', () => {
+        const { ha, thinq, dev } = makeDevice()
+        const poweredError = Buffer.from(ERROR_TE1)
+        poweredError[17] = 1 // state INITIAL: powered on while error TE1 is standing
+        thinq.emit('data', poweredError)
+        thinq.resetRecorder()
+
+        dev.setProperty('course_select', 'Styling Standard')
+        dev.setProperty('start_course', '')
+
+        assert.equal(thinq.outbox.length, 1, 'the appliance still receives the valid course frame')
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.problem, 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'None')
+    })
+
+    test('Course select chooses without commanding the appliance', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('course_select', 'Sterilize Standard')
+        assert.equal(thinq.outbox.length, 0, 'selecting sends nothing')
+        assert.equal(ha.devices[DEVICE_ID].properties.course_select, 'Sterilize Standard')
+        // ...and Start course then runs the one that was chosen.
+        dev.setProperty('start_course', '')
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(thinq.outbox[0][4], 11, 'course id 11 leads the block')
+    })
+
+    test('a course the appliance is running takes over the selection', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', COURSE_STANDARD)
+        assert.equal(ha.devices[DEVICE_ID].properties.course_select, 'Styling Standard')
+        // Idle it reports NONE, which is no course at all — the last choice has to stand.
+        thinq.emit('data', STATE)
+        assert.equal(ha.devices[DEVICE_ID].properties.course_select, 'Styling Standard')
+    })
+
+    test('an unknown course is refused rather than started', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('course_select', 'InvalidCourse')
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('the night-care window writes hour and minute in one frame', () => {
+        for (const [prop, value, want] of [
+            // subs 0x07 / 0x08, valueLength 2 — exactly as LG's own setStartTime/setEndTime sent them
+            ['night_care_start', '23:30', 'aa0bf024130207171e4fbb'],
+            ['night_care_start', '00:00', 'aa0bf0241302070000b0bb'],
+            ['night_care_end', '06:00', 'aa0bf0241302080600b9bb'],
+            ['night_care_end', '00:00', 'aa0bf0241302080000b3bb'],
+        ] as [string, string, string][]) {
+            const { thinq, dev } = makeDevice()
+            thinq.resetRecorder()
+            dev.setProperty(prop, value)
+            assert.equal(thinq.outbox[0].toString('hex'), want, `${prop}=${value}`)
+        }
+    })
+
+    test('a time the appliance would refuse is not written', () => {
+        // LG's own schema is `^(0[0-9]|1[0-9]|2[0-3]):(00|30)$` — whole and half hours only.
+        for (const bad of ['23:45', '24:00', '9:30', 'abc', '', '07:1']) {
+            const { thinq, dev } = makeDevice()
+            thinq.resetRecorder()
+            dev.setProperty('night_care_start', bad)
+            assert.equal(thinq.outbox.length, 0, `refused ${JSON.stringify(bad)}`)
+        }
+    })
+
+    test('an unknown option is refused rather than guessed', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('buzzer', 'InvalidVolume')
+        dev.setProperty('end_melody', 'Jingle Bells (intro)') // a read label, but not one LG offers here
+        dev.setProperty('course', 'Styling Standard') // read-only
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('the power switch reports OFF as soon as it is switched off', () => {
+        // Powered off, this appliance stops sending any frame this driver can decode, so a switch
+        // that waited for confirmation would never leave ON.
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', READY)
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
+        dev.setProperty('power', 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'OFF')
+        // ...and a real frame still has the last word.
+        thinq.emit('data', READY)
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
+    })
+
+    test('every user-facing name and enum option is English', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE)
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, { name?: string | null }>
+        for (const [key, comp] of Object.entries(components)) {
+            if (comp.name == null) continue
+            assert.match(comp.name, /[A-Za-z]/, `${key} name is English: ${comp.name}`)
+        }
+        const p = ha.devices[DEVICE_ID].properties
+        for (const key of ['status', 'previous_status', 'course', 'smart_course', 'buzzer', 'end_melody', 'error']) {
+            assert.match(String(p[key]), /[A-Za-z]/, `${key} value is English: ${p[key]}`)
+        }
+    })
+
+    test('real captured frame decodes to what LG read from the same frame', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE)
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.status, 'Power off')
+        assert.equal(p.previous_status, 'Standby')
+        assert.equal(p.course, 'None')
+        assert.equal(p.smart_course, 'None')
+        assert.equal(p.error, 'Normal')
+        assert.equal(p.remaining_time, 1)
+        assert.equal(p.initial_time, 1)
+        assert.equal(p.reserve_time, 0)
+        assert.equal(p.child_lock, 'OFF')
+        assert.equal(p.night_dry, 'OFF')
+        assert.equal(p.remote_start, 'OFF')
+        assert.equal(p.remote_maintain, 'OFF')
+        assert.equal(p.buzzer, 'Very large')
+        assert.equal(p.end_melody, 'Default sound')
+        assert.equal(p.smart_care_finedust, 'OFF')
+        assert.equal(p.smart_care_humidity, 'OFF')
+        assert.equal(p.smart_care_nightcare, 'OFF')
+        assert.equal(p.keep_last_course, 'OFF')
+        assert.equal(p.night_care_start, '00:00')
+        assert.equal(p.night_care_end, '00:00')
+        assert.equal(p.power, 'OFF')
+        assert.equal(p.tcl_count, 37)
+        // Slot 1 holds course id 78, which LG names FUR_LEATHER.
+        assert.equal(p.download_course, 'Fur/Leather Care')
+    })
+
+    test('a second real frame with a different sequence number decodes identically', () => {
+        const { ha: a, thinq: ta } = makeDevice()
+        ta.emit('data', STATE)
+        const { ha: b, thinq: tb } = makeDevice()
+        tb.emit('data', STATE2)
+        assert.deepEqual(b.devices[DEVICE_ID].properties, a.devices[DEVICE_ID].properties)
+    })
+
+    test('each probed offset moves exactly the field LG said it moves', () => {
+        for (const [frame, key, want] of [
+            [READY, 'status', 'Standby'],
+            [COURSE_STANDARD, 'course', 'Styling Standard'],
+            [ERROR_TE1, 'error', 'TE1'],
+            [PRESTATE_RUNNING, 'previous_status', 'Styling'],
+            [BUZZER_LOW, 'buzzer', 'Small'],
+            [MELODY_1, 'end_melody', 'Vivaldi Winter'],
+            [SMART_COURSE_1, 'smart_course', 'Panel course'],
+            [TCL_1, 'tcl_count', 1],
+            [REMOTE_MAINTAIN, 'remote_maintain', 'ON'],
+        ] as [Buffer, string, string | number][]) {
+            const { ha, thinq } = makeDevice()
+            thinq.emit('data', STATE)
+            thinq.emit('data', frame)
+            assert.equal(ha.devices[DEVICE_ID].properties[key], want, `${key} after single-byte probe`)
+        }
+    })
+
+    /*
+     * The state codes are not the declaration order. Each pair below was measured by injecting
+     * that code and reading LG's own name back; 10..49 answered NOT_DEFINE_VALUE.
+     */
+    test('the running-state codes decode, not just the idle ones', () => {
+        for (const [code, want] of [
+            [0, 'Power off'],
+            [3, 'Pause'],
+            [9, 'Power-save running'],
+            [50, 'Steam preparing'], // PRESTEAM
+            [52, 'Refreshing'], // STEAM
+            [55, 'Drying'], // DRYING
+            [57, 'Sterilizing'], // STERILIZE
+            [58, 'Course complete'], // RUNNINGEND
+        ] as [number, string][]) {
+            const { ha, thinq } = makeDevice()
+            const frame = Buffer.from(STATE)
+            frame[17] = code
+            thinq.emit('data', frame)
+            assert.equal(ha.devices[DEVICE_ID].properties.status, want, `state ${code}`)
+        }
+    })
+
+    test('a code LG itself does not define is shown as a code, not as a wrong name', () => {
+        const { ha, thinq } = makeDevice()
+        const frame = Buffer.from(STATE)
+        frame[17] = 20 // NOT_DEFINE_VALUE on this model
+        thinq.emit('data', frame)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Code 20')
+    })
+
+    /*
+     * Same lesson as the state codes: LG's Error table skips values, so a positional reading
+     * drifts from E2 onward. Each pair was measured by injection on 2026-07-28.
+     */
+    test('the error codes decode, and Water refill is not off by one', () => {
+        for (const [code, want, problem] of [
+            [0, 'Normal', 'OFF'],
+            [8, 'Water refill', 'ON'], // ERROR_E3 — the one that stops a course every day
+            [11, 'AE', 'ON'],
+            [18, 'LE', 'ON'],
+            [23, 'Normal', 'OFF'], // ERROR_NONE, LG's second way of saying nothing is wrong
+            [25, 'Water drain', 'ON'],
+            [26, 'Door open', 'ON'],
+            [34, 'No filter', 'ON'],
+            [12, 'Code 12', 'ON'], // NOT_DEFINE_VALUE on this model
+        ] as [number, string, string][]) {
+            const { ha, thinq } = makeDevice()
+            const frame = Buffer.from(STATE)
+            frame[23] = code
+            thinq.emit('data', frame)
+            const p = ha.devices[DEVICE_ID].properties
+            assert.equal(p.error, want, `error ${code}`)
+            assert.equal(p.problem, problem, `problem for error ${code}`)
+        }
+    })
+
+    test('byte 31 is a bitfield, not an enum', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', FLAGS_A_ALL)
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.child_lock, 'ON')
+        assert.equal(p.night_dry, 'ON')
+        assert.equal(p.remote_start, 'ON')
+        // Bit 0x04 (initialBit) is LG's internal first-boot marker and gets no entity; bit 0x20,
+        // set in every captured frame, moved no field and is deliberately not decoded.
+    })
+
+    test('byte 49 is a bitfield carrying six independent flags', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', FLAGS_C_ALL)
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.smart_care_finedust, 'ON')
+        assert.equal(p.smart_care_humidity, 'ON')
+        assert.equal(p.smart_care_nightcare, 'ON')
+        assert.equal(p.keep_last_course, 'ON')
+    })
+
+    test('the night-care window reads back as two clock times', () => {
+        const { ha, thinq } = makeDevice()
+        const scheduled = Buffer.from(STATE)
+        scheduled[50] = 23 // nightCareStartTime_Hour
+        scheduled[51] = 30 // nightCareStartTime_Minute
+        scheduled[52] = 6 // nightCareEndTime_Hour
+        scheduled[53] = 0 // nightCareEndTime_Minute
+        thinq.emit('data', scheduled)
+        assert.equal(ha.devices[DEVICE_ID].properties.night_care_start, '23:30')
+        assert.equal(ha.devices[DEVICE_ID].properties.night_care_end, '06:00')
+    })
+
+    test('the 35-byte frame and the heartbeat carry no state', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE)
+        const before = { ...ha.devices[DEVICE_ID].properties }
+        thinq.emit('data', NOT_STATE_35)
+        thinq.emit('data', HEARTBEAT)
+        assert.deepEqual(ha.devices[DEVICE_ID].properties, before)
+    })
+
+    test('hours and minutes are folded into one duration', () => {
+        const { ha, thinq } = makeDevice()
+        const running = Buffer.from(STATE)
+        running[18] = 1 // remainTimeHour
+        running[19] = 25 // remainTimeMinute
+        running[20] = 2 // initialTimeHour
+        running[21] = 0 // initialTimeMinute
+        thinq.emit('data', running)
+        assert.equal(ha.devices[DEVICE_ID].properties.remaining_time, 85)
+        assert.equal(ha.devices[DEVICE_ID].properties.initial_time, 120)
+    })
+
+    test('a two-record frame is decoded, and it is the LAST record that counts', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE) // idle: 58 bytes, one record
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Power off')
+        thinq.emit('data', RUNNING_READY)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Standby', 'the 98-byte frame must decode')
+        thinq.emit('data', RUNNING_COURSE)
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.status, 'Standby')
+        assert.equal(p.course, 'Styling Standard')
+        assert.equal(p.remaining_time, 35)
+        assert.equal(p.initial_time, 35)
+        // flagsA 0x28 = the always-set 0x20 bit | 0x08 remoteStart
+        assert.equal(p.remote_start, 'ON')
+        assert.equal(p.child_lock, 'OFF')
+    })
+
+    test('the course-name list frame is not mistaken for state', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE)
+        const before = { ...ha.devices[DEVICE_ID].properties }
+        thinq.emit('data', COURSE_LIST)
+        assert.deepEqual(ha.devices[DEVICE_ID].properties, before)
+    })
+
+    test('a set reservation reads as a delay in minutes', () => {
+        const { ha, thinq } = makeDevice()
+        const reserved = Buffer.from(STATE)
+        reserved[29] = 7
+        reserved[30] = 5
+        thinq.emit('data', reserved)
+        assert.equal(ha.devices[DEVICE_ID].properties.reserve_time, 425)
+    })
+})
+
+/*
+ * Two failure modes that are invisible from the add-on side: Home Assistant accepts the
+ * discovery payload, writes the entity into its registry, and then never creates it. Both cost
+ * real entities on the first live rebuild of these drivers.
+ */
+describe(`${MODEL_ID} discovery contract`, () => {
+    test("no read-only component claims entity_category 'config'", () => {
+        const { ha } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as Record<
+            string,
+            { platform?: string; entity_category?: string }
+        >
+        for (const [name, comp] of Object.entries(components)) {
+            if (comp.platform !== 'sensor' && comp.platform !== 'binary_sensor') continue
+            assert.notEqual(comp.entity_category, 'config', `${name} must not be entity_category 'config'`)
+        }
+    })
+})


### PR DESCRIPTION
Third of the per-device-class splits from #111.

**ST_B_E4H01Y_APL** — an AA..BB ThinQ2 Styler / garment-care unit (deviceType 203). The byte layout was recovered by injecting single-byte-changed state frames through the management API and reading the LG cloud's own decode back, one offset per observation (three of the bytes are bitfields, split bit by bit).

Addressing your review notes from #111:
- **processAABB** — reads now go through the base class's `processAABB` instead of a custom `processData`; the frame arrives with its leading AA/FF and trailing CRC/BB stripped, so the record offsets are simply two less than the whole-frame positions.
- **logging utility** — the stray `console.warn` calls now use `log(...)`.
- **header comment** — trimmed to what's needed to read the code.

All labels are English. `npm test` passes; `tsc` clean.