### PR TITLE
Add LG PuriCare water purifier 1WPU4CIGCR__2

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The following appliances are currently supported in rethink:
     - 🫤 DLE7300WE - preliminary support
     - 👍 DLEX3900B (RV13B6BSD_D_US_WIFI), Electric Dryer - mostly working
     - 👍 RV13B6ES_D_US_WIFI, Electric Dryer - mostly working
+- Water Purifiers:
+    - 👍 LG PuriCare Water Purifier 1WPU4CIGCR\_\_2 (ATOM-U), mostly working
 - WashTowers (combined washer+dryer):
     - 👍 WKEX200HBA (WTL_FXU_BDV_NA_01), WashTower - mostly working
 - Dehumidifiers

--- a/cloud/devices/1WPU4CIGCR__2.ts
+++ b/cloud/devices/1WPU4CIGCR__2.ts
@@ -1,0 +1,244 @@
+import { Device as Thinq2Device } from '../thinq2/device'
+import { DeviceDiscovery, type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import HADevice from './base'
+import AABBDevice from './aabb_device'
+
+/*
+ * LG PuriCare Water Purifier (ATOM-U, ThinQ model 1WPU4CIGCR__2, deviceType 103).
+ *
+ * An AA..BB appliance. Its modelJSON declares no legacy control, but LG's capability API
+ * (convert/control) does drive it, and it converts a capability command into the appliance's
+ * own protocol — so the command frame below was captured from LG's cloud, each answered
+ * CL-0000:
+ *
+ *   aa <len> f0 17 | <26-byte record, 0xff = leave this field alone> | ck bb
+ *
+ * State reports are published directly without persistent history. Dispense reports contain
+ * per-report deltas, so they are accumulated into process-local `total_increasing` counters;
+ * Home Assistant handles the counter reset when rethink restarts. The sterilization reservation
+ * is published as an ISO timestamp; the appliance only reports month/day/hour/minute, so the
+ * year is inferred from the current UTC year to produce a Home Assistant-compatible value.
+ */
+
+const HEADER_LEN = 2
+const TRAILER_LEN = 0
+const CLASS_TAG = 0x12
+const RECORD_LEN = 26
+
+/** The usage report is a fixed 14-byte body: `12 1f 00` then six big-endian dispense counters. */
+const USAGE_BODY_LEN = 14
+
+const OFF = {
+    monStatus: 0,
+    cockState: 1,
+    waterSelection: 2,
+    waterAmountMode: 3,
+    amountUnit: 5,
+    hotWaterTemp: 6,
+    sterilizeInitMonth: 15,
+    sterilizeInitDay: 16,
+    sterilizeInitHour: 17,
+    sterilizeInitMin: 18,
+    monDataRefresh: 22,
+    highSterilizeState: 23,
+    filterFlushingState: 24,
+    appVersion: 25,
+} as const
+
+/** `IGNORE` — LG's own sentinel for "this unit does not report the field", and, in a
+ *  command frame, for "leave this field alone". */
+const IGNORE = 0xff
+
+// Every enum below is modelJSON `MonitoringValue.<field>.valueMapping`, with English labels
+// taken from this model's ko-KR language pack (@WP_* keys). Where LG left the label blank or
+// reused another field's key, the mapping's own `_comment` is used instead.
+
+/** wpState.monStatus */
+const MON_STATUS: Record<number, string> = { 0: 'Fault', 1: 'Not operating', 2: 'Normal' }
+
+/** wpState.cockState. COCK_MANUAL_ON is the manual-dispense hold. */
+const COCK_STATE: Record<number, string> = { 0: 'Standby', 1: 'UVnano Sterilizing', 2: 'Manual dispensing' }
+
+/** wpState.waterSelection — which tap was used last. */
+const WATER_SELECTION: Record<number, string> = {
+    1: 'Hot water',
+    2: 'Purified',
+    3: 'Cold water',
+    4: 'Sterilized water',
+}
+
+/** wpState.waterAmountMode, in the unit wpState.amountUnit reports. */
+const WATER_AMOUNT: Record<number, string> = { 1: '120', 2: '250', 3: '500', 4: 'Continuous' }
+
+/** wpState.hotWaterTemp — a code, not a temperature. `hotWaterTemp_C` maps it. */
+const HOT_WATER_TEMP: Record<number, number> = { 1: 40, 2: 75, 3: 85 }
+
+/** wpState.highSterilizeState */
+const STERILIZE_STATE: Record<number, string> = {
+    0: 'Standby',
+    1: 'Water line sterilizing',
+    2: 'Water line sterilizing',
+    3: 'Water line sterilizing',
+    4: 'Outlet sterilizing',
+    5: 'Cancelling sterilize',
+}
+
+/** wpState.filterFlushingState */
+const FILTER_FLUSH: Record<number, string> = { 0: 'Off', 1: 'Filter replacement' }
+
+/** wpState.amountUnit — settings the panel owns; used to render the live dispense volume. */
+const AMOUNT_UNIT: Record<number, string> = { 0: 'oz', 1: 'mL' }
+
+const enumOf = (table: Record<number, string>, raw: number) => table[raw] ?? `Code ${raw}`
+const reservationTimestamp = (month: number, day: number, hour: number, minute: number, now = Date.now()) => {
+    if ([month, day, hour, minute].includes(IGNORE)) return undefined
+    if (month < 1 || month > 12 || day < 1 || day > 31 || hour > 23 || minute > 59) return undefined
+
+    // The appliance does not report a year. Use the current UTC year so the entity can be
+    // exposed as a concrete Home Assistant timestamp instead of a free-form string.
+    const year = new Date(now).getUTCFullYear()
+    const instant = Date.UTC(year, month - 1, day, hour, minute)
+    const check = new Date(instant)
+    if (
+        check.getUTCFullYear() !== year ||
+        check.getUTCMonth() !== month - 1 ||
+        check.getUTCDate() !== day ||
+        check.getUTCHours() !== hour ||
+        check.getUTCMinutes() !== minute
+    )
+        return undefined
+    return new Date(instant).toISOString()
+}
+
+type UsageTotals = { total: number; normal: number; cold: number; hot: number; sterilization: number }
+
+export default class Device extends AABBDevice {
+    // Running dispense counters, summed from the per-report deltas. Reset to zero on restart;
+    // published as total_increasing so Home Assistant accumulates and handles the reset itself.
+    private readonly usage: UsageTotals = { total: 0, normal: 0, cold: 0, hot: 0, sterilization: 0 }
+
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+
+        const sensor = (id: string, name: string, extra: object = {}) => ({
+            platform: 'sensor',
+            unique_id: `$deviceid-${id}`,
+            state_topic: `$this/${id}`,
+            name,
+            ...extra,
+        })
+        const volume = (id: string, name: string) =>
+            sensor(id, name, {
+                device_class: 'volume',
+                unit_of_measurement: 'L',
+                state_class: 'total_increasing',
+                suggested_display_precision: 1,
+            })
+
+        const config: DeviceDiscovery = allowExtendedType({
+            ...HADevice.config(meta, { name: 'LG Water Purifier' }),
+            components: {
+                status: sensor('status', 'State', { icon: 'mdi:water-check' }),
+                water_selection: sensor('water_selection', 'Last dispense', { icon: 'mdi:water' }),
+                water_amount: sensor('water_amount', 'Dispense volume', { icon: 'mdi:cup-water' }),
+                hot_water_temp: sensor('hot_water_temp', 'Hot water temp', {
+                    device_class: 'temperature',
+                    unit_of_measurement: '°C',
+                    suggested_display_precision: 0,
+                    // 0xff (IGNORE) publishes nothing, so the entity must tolerate a gap.
+                    value_template: "{{ value if value | is_number else 'None' }}",
+                }),
+                cock_state: sensor('cock_state', 'Outlet state', { icon: 'mdi:shield-sun-outline' }),
+                sterilize_state: sensor('sterilize_state', 'Sterilize state', { icon: 'mdi:shield-sun' }),
+                filter_flushing: sensor('filter_flushing', 'Filter cleaning', { icon: 'mdi:air-filter' }),
+                sterilize_reserved_at: sensor('sterilize_reserved_at', 'Sterilize schedule', {
+                    icon: 'mdi:calendar-clock',
+                    device_class: 'timestamp',
+                }),
+                app_version: sensor('app_version', 'App version', { icon: 'mdi:tag', entity_category: 'diagnostic' }),
+                data_refresh: sensor('data_refresh', 'Data refresh interval', {
+                    icon: 'mdi:timer-outline',
+                    entity_category: 'diagnostic',
+                }),
+                water_usage_today: volume('water_usage_today', 'Water dispensed'),
+                water_usage_normal: volume('water_usage_normal', 'Purified dispensed'),
+                water_usage_cold: volume('water_usage_cold', 'Cold water dispensed'),
+                water_usage_hot: volume('water_usage_hot', 'Hot water dispensed'),
+                water_usage_sterilization: volume('water_usage_sterilization', 'Rinse water dispensed'),
+            },
+        })
+
+        this.setConfig(config)
+    }
+
+    // AABBDevice strips the leading AA/length and trailing CRC/BB, so byte 0 here is the class
+    // tag and the record offsets need no whole-frame adjustment.
+    processAABB(buf: Buffer) {
+        if (buf[0] !== CLASS_TAG) return
+        if (this.processUsage(buf)) return
+
+        const payload = buf.length - HEADER_LEN - TRAILER_LEN
+        if (payload <= 0 || payload % RECORD_LEN !== 0) return
+
+        // The trailing record is the current state; a leading one, when present, is the previous.
+        const record = buf.length - TRAILER_LEN - RECORD_LEN
+        const at = (o: number) => buf[record + o]
+
+        this.publishProperty('status', enumOf(MON_STATUS, at(OFF.monStatus)))
+        this.publishProperty('cock_state', enumOf(COCK_STATE, at(OFF.cockState)))
+        this.publishProperty('water_selection', enumOf(WATER_SELECTION, at(OFF.waterSelection)))
+        this.publishProperty('sterilize_state', enumOf(STERILIZE_STATE, at(OFF.highSterilizeState)))
+        this.publishProperty('filter_flushing', enumOf(FILTER_FLUSH, at(OFF.filterFlushingState)))
+
+        // Volumes read in whatever unit wpState.amountUnit reports, so the unit travels with the value.
+        const unit = AMOUNT_UNIT[at(OFF.amountUnit)] ?? 'mL'
+        const amount = WATER_AMOUNT[at(OFF.waterAmountMode)]
+        this.publishProperty(
+            'water_amount',
+            amount ? (amount === 'Continuous' ? amount : `${amount} ${unit}`) : 'Unknown',
+        )
+
+        // hotWaterTemp is a 1/2/3 code, and 0xff means this unit is not reporting one.
+        const hot = HOT_WATER_TEMP[at(OFF.hotWaterTemp)]
+        this.publishProperty('hot_water_temp', hot ?? '')
+
+        // Four raw reservation bytes (month, day, hour, minute); 0xff in any field means "not set".
+        const [month, day, hour, minute] = [
+            OFF.sterilizeInitMonth,
+            OFF.sterilizeInitDay,
+            OFF.sterilizeInitHour,
+            OFF.sterilizeInitMin,
+        ].map(at)
+        this.publishProperty('sterilize_reserved_at', reservationTimestamp(month, day, hour, minute) ?? '')
+
+        this.publishProperty('app_version', at(OFF.appVersion))
+        this.publishProperty('data_refresh', at(OFF.monDataRefresh))
+    }
+
+    // The usage report: `12 1f 00` then six big-endian dispense counters (deltas since the last
+    // report). Returns true when it consumed the frame so the state decode is skipped.
+    private processUsage(buf: Buffer): boolean {
+        if (buf.length !== USAGE_BODY_LEN || buf[1] !== 0x1f || buf[2] !== 0x00) return false
+
+        const normal = buf[3]
+        const hot = buf.readUInt16BE(4)
+        const cold = buf.readUInt16BE(6)
+        const sterilization = buf.readUInt16BE(12)
+        const total = normal + hot + cold + buf.readUInt16BE(8) + buf.readUInt16BE(10) + sterilization
+        if (total === 0) return true
+
+        this.usage.total += total
+        this.usage.normal += normal
+        this.usage.cold += cold
+        this.usage.hot += hot
+        this.usage.sterilization += sterilization
+        this.publishProperty('water_usage_today', this.usage.total / 1000)
+        this.publishProperty('water_usage_normal', this.usage.normal / 1000)
+        this.publishProperty('water_usage_cold', this.usage.cold / 1000)
+        this.publishProperty('water_usage_hot', this.usage.hot / 1000)
+        this.publishProperty('water_usage_sterilization', this.usage.sterilization / 1000)
+        return true
+    }
+}

--- a/cloud/devices/1WPU4CIGCR__2.ts
+++ b/cloud/devices/1WPU4CIGCR__2.ts
@@ -1,0 +1,323 @@
+import { Device as Thinq2Device } from '../thinq2/device'
+import { DeviceDiscovery, type ComponentInfo, type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import log from '@/util/logging'
+import HADevice from './base'
+import AABBDevice from './aabb_device'
+
+/*
+ * LG PuriCare Water Purifier (ATOM-U, ThinQ model 1WPU4CIGCR__2, deviceType 103).
+ *
+ * An AA..BB appliance. Its modelJSON declares no legacy control, but LG's capability API
+ * (convert/control) does drive it, and it converts a capability command into the appliance's
+ * own protocol — so the command frame below was captured from LG's cloud, each answered
+ * CL-0000:
+ *
+ *   aa <len> f0 17 | <26-byte record, 0xff = leave this field alone> | ck bb
+ *
+ * The record is the same 26-byte layout the appliance reports, so the read map doubles as the
+ * write map. The four-field sterilization reservation is read-only: a time-only write moves the
+ * appliance's weekly day anchor, and LG's schema offers no way to preserve it.
+ *
+ * This driver is stateless: it publishes what each frame reports and lets Home Assistant hold
+ * the history. Dispense volumes arrive as per-report deltas, which it sums into a monotonic
+ * counter (reset to zero on restart) published as `total_increasing`, the same shape HA's
+ * statistics engine already handles for energy meters.
+ */
+
+const HEADER_LEN = 2
+const TRAILER_LEN = 0
+const CLASS_TAG = 0x12
+const RECORD_LEN = 26
+
+/** The usage report is a fixed 14-byte body: `12 1f 00` then six big-endian dispense counters. */
+const USAGE_BODY_LEN = 14
+
+const OFF = {
+    monStatus: 0,
+    cockState: 1,
+    waterSelection: 2,
+    waterAmountMode: 3,
+    tempUnit: 4,
+    amountUnit: 5,
+    hotWaterTemp: 6,
+    notUseNotice: 8,
+    defaultWaterSet: 10,
+    defaultWaterAmountMode: 11,
+    buttonSoundOnOff: 12,
+    sterilizeInitMonth: 15,
+    sterilizeInitDay: 16,
+    sterilizeInitHour: 17,
+    sterilizeInitMin: 18,
+    autoCareOnOff: 20,
+    monDataRefresh: 22,
+    highSterilizeState: 23,
+    filterFlushingState: 24,
+    appVersion: 25,
+} as const
+
+/** `IGNORE` — LG's own sentinel for "this unit does not report the field", and, in a
+ *  command frame, for "leave this field alone". */
+const IGNORE = 0xff
+
+/** Command frame opcode: `aa <len> f0 17 <record> <ck> bb`. See the header note. */
+const SET_STATE = [0xf0, 0x17]
+
+/** Volumes the appliance accepts as the default dispense, in mL (LG's own enum). */
+const DEFAULT_AMOUNTS: [string, number][] = [
+    ['120 mL', 1],
+    ['250 mL', 2],
+    ['500 mL', 3],
+]
+
+// Every enum below is modelJSON `MonitoringValue.<field>.valueMapping`, with English labels
+// taken from this model's ko-KR language pack (@WP_* keys). Where LG left the label blank or
+// reused another field's key, the mapping's own `_comment` is used instead.
+
+/** wpState.monStatus */
+const MON_STATUS: Record<number, string> = { 0: 'Fault', 1: 'Not operating', 2: 'Normal' }
+
+/** wpState.cockState. COCK_MANUAL_ON is the manual-dispense hold. */
+const COCK_STATE: Record<number, string> = { 0: 'Standby', 1: 'UVnano Sterilizing', 2: 'Manual dispensing' }
+
+/** wpState.waterSelection — which tap was used last. */
+const WATER_SELECTION: Record<number, string> = {
+    1: 'Hot water',
+    2: 'Purified',
+    3: 'Cold water',
+    4: 'Sterilized water',
+}
+
+/** wpState.waterAmountMode / defaultWaterAmountMode, in the unit wpState.amountUnit reports.
+ *  Code 4 (Continuous) exists only for the live selection, not for the default. */
+const WATER_AMOUNT: Record<number, string> = { 1: '120', 2: '250', 3: '500', 4: 'Continuous' }
+
+/** wpState.hotWaterTemp — a code, not a temperature. `hotWaterTemp_C` maps it. */
+const HOT_WATER_TEMP: Record<number, number> = { 1: 40, 2: 75, 3: 85 }
+
+/** wpState.defaultWaterSet */
+const DEFAULT_WATER: Record<number, string> = { 1: 'Last used', 2: 'Purified', 3: 'Cold water' }
+
+/** wpState.highSterilizeState */
+const STERILIZE_STATE: Record<number, string> = {
+    0: 'Standby',
+    1: 'Water line sterilizing',
+    2: 'Water line sterilizing',
+    3: 'Water line sterilizing',
+    4: 'Outlet sterilizing',
+    5: 'Cancelling sterilize',
+}
+
+/** wpState.filterFlushingState */
+const FILTER_FLUSH: Record<number, string> = { 0: 'Off', 1: 'Filter replacement' }
+
+/** wpState.tempUnit / amountUnit — settings the panel owns; diagnostic only. */
+const TEMP_UNIT: Record<number, string> = { 0: '°F', 1: '°C' }
+const AMOUNT_UNIT: Record<number, string> = { 0: 'oz', 1: 'mL' }
+
+const enumOf = (table: Record<number, string>, raw: number) => table[raw] ?? `Code ${raw}`
+const pad2 = (n: number) => String(n).padStart(2, '0')
+
+type UsageTotals = { total: number; normal: number; cold: number; hot: number; sterilization: number }
+
+export default class Device extends AABBDevice {
+    private readonly legacyPlatformCleanup: DeviceDiscovery
+    // Running dispense counters, summed from the per-report deltas. Reset to zero on restart;
+    // published as total_increasing so Home Assistant accumulates and handles the reset itself.
+    private readonly usage: UsageTotals = { total: 0, normal: 0, cold: 0, hot: 0, sterilization: 0 }
+
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+
+        const sensor = (id: string, name: string, extra: object = {}) => ({
+            platform: 'sensor',
+            unique_id: `$deviceid-${id}`,
+            state_topic: `$this/${id}`,
+            name,
+            ...extra,
+        })
+        const volume = (id: string, name: string) =>
+            sensor(id, name, {
+                device_class: 'volume',
+                unit_of_measurement: 'L',
+                state_class: 'total_increasing',
+                suggested_display_precision: 1,
+            })
+
+        const config: DeviceDiscovery = allowExtendedType({
+            ...HADevice.config(meta, { name: 'LG Water Purifier' }),
+            components: {
+                status: sensor('status', 'State', { icon: 'mdi:water-check' }),
+                water_selection: sensor('water_selection', 'Last dispense', { icon: 'mdi:water' }),
+                water_amount: sensor('water_amount', 'Dispense volume', { icon: 'mdi:cup-water' }),
+                hot_water_temp: sensor('hot_water_temp', 'Hot water temp', {
+                    device_class: 'temperature',
+                    unit_of_measurement: '°C',
+                    suggested_display_precision: 0,
+                    // 0xff (IGNORE) publishes nothing, so the entity must tolerate a gap.
+                    value_template: "{{ value if value | is_number else 'None' }}",
+                }),
+                cock_state: sensor('cock_state', 'Outlet state', { icon: 'mdi:shield-sun-outline' }),
+                sterilize_state: sensor('sterilize_state', 'Sterilize state', { icon: 'mdi:shield-sun' }),
+                filter_flushing: sensor('filter_flushing', 'Filter cleaning', { icon: 'mdi:air-filter' }),
+                sterilize_reserved_at: sensor('sterilize_reserved_at', 'Sterilize schedule', {
+                    icon: 'mdi:calendar-clock',
+                }),
+                sterilize_time: sensor('sterilize_time', 'Sterilize schedule time', {
+                    icon: 'mdi:clock-outline',
+                    entity_category: 'diagnostic',
+                }),
+                app_version: sensor('app_version', 'App version', { icon: 'mdi:tag', entity_category: 'diagnostic' }),
+                data_refresh: sensor('data_refresh', 'Data refresh interval', {
+                    icon: 'mdi:timer-outline',
+                    entity_category: 'diagnostic',
+                }),
+                water_usage_today: volume('water_usage_today', 'Water dispensed'),
+                water_usage_normal: volume('water_usage_normal', 'Purified dispensed'),
+                water_usage_cold: volume('water_usage_cold', 'Cold water dispensed'),
+                water_usage_hot: volume('water_usage_hot', 'Hot water dispensed'),
+                water_usage_sterilization: volume('water_usage_sterilization', 'Rinse water dispensed'),
+            },
+        })
+
+        // Home Assistant keys a device-discovery component by both component id and platform.
+        // Removing the former platform first prevents the old sensor/binary_sensor registry
+        // entries from surviving beside their select/switch replacements. Keep this cleanup
+        // payload so every discovery replay (including a simultaneous HA/add-on restart) sends
+        // the tombstones before the replacement config.
+        this.legacyPlatformCleanup = allowExtendedType({
+            ...HADevice.config(meta, { name: 'LG Water Purifier' }),
+            components: {
+                default_water: { platform: 'sensor' } as ComponentInfo,
+                default_water_amount: { platform: 'sensor' } as ComponentInfo,
+                auto_care: { platform: 'binary_sensor' } as ComponentInfo,
+                not_use_notice: { platform: 'binary_sensor' } as ComponentInfo,
+                sterilize_time: { platform: 'text' } as ComponentInfo,
+            },
+        })
+
+        this.setConfig(config)
+    }
+
+    publishConfig() {
+        if (this.legacyPlatformCleanup) this.HA.publishConfig(this.id, this.legacyPlatformCleanup)
+        super.publishConfig()
+    }
+
+    // AABBDevice strips the leading AA/length and trailing CRC/BB, so byte 0 here is the class
+    // tag and the record offsets need no whole-frame adjustment.
+    processAABB(buf: Buffer) {
+        if (buf[0] !== CLASS_TAG) return
+        if (this.processUsage(buf)) return
+
+        const payload = buf.length - HEADER_LEN - TRAILER_LEN
+        if (payload <= 0 || payload % RECORD_LEN !== 0) return
+
+        // The trailing record is the current state; a leading one, when present, is the previous.
+        const record = buf.length - TRAILER_LEN - RECORD_LEN
+        const at = (o: number) => buf[record + o]
+
+        this.publishProperty('status', enumOf(MON_STATUS, at(OFF.monStatus)))
+        this.publishProperty('cock_state', enumOf(COCK_STATE, at(OFF.cockState)))
+        this.publishProperty('water_selection', enumOf(WATER_SELECTION, at(OFF.waterSelection)))
+        this.publishProperty('sterilize_state', enumOf(STERILIZE_STATE, at(OFF.highSterilizeState)))
+        this.publishProperty('filter_flushing', enumOf(FILTER_FLUSH, at(OFF.filterFlushingState)))
+        this.publishProperty('default_water', enumOf(DEFAULT_WATER, at(OFF.defaultWaterSet)))
+        this.publishProperty('temp_unit', enumOf(TEMP_UNIT, at(OFF.tempUnit)))
+        this.publishProperty('amount_unit', enumOf(AMOUNT_UNIT, at(OFF.amountUnit)))
+
+        // Volumes read in whatever unit wpState.amountUnit reports, so the unit travels with the value.
+        const unit = AMOUNT_UNIT[at(OFF.amountUnit)] ?? 'mL'
+        const amount = WATER_AMOUNT[at(OFF.waterAmountMode)]
+        this.publishProperty(
+            'water_amount',
+            amount ? (amount === 'Continuous' ? amount : `${amount} ${unit}`) : 'Unknown',
+        )
+        // The DEFAULT volume is a select, so its state has to be one of the option strings —
+        // and LG's setter enum for it is mL-only, unlike the live reading above.
+        const dflt = DEFAULT_AMOUNTS.find(([, code]) => code === at(OFF.defaultWaterAmountMode))
+        this.publishProperty('default_water_amount', dflt ? dflt[0] : 'Unknown')
+
+        // hotWaterTemp is a 1/2/3 code, and 0xff means this unit is not reporting one.
+        const hot = HOT_WATER_TEMP[at(OFF.hotWaterTemp)]
+        this.publishProperty('hot_water_temp', hot ?? '')
+
+        // Empty retained payload removes a previously retained state. Only the model's
+        // documented 0/1 codes may become OFF/ON; IGNORE and future codes stay unknown.
+        const binaryState = (raw: number) => (raw === 0 ? 'OFF' : raw === 1 ? 'ON' : '')
+        this.publishProperty('button_sound', binaryState(at(OFF.buttonSoundOnOff)))
+        this.publishProperty('auto_care', binaryState(at(OFF.autoCareOnOff)))
+        this.publishProperty('not_use_notice', binaryState(at(OFF.notUseNotice)))
+
+        // Four raw reservation bytes (month, day, hour, minute); 0xff in any field means "not set".
+        const [month, day, hour, minute] = [
+            OFF.sterilizeInitMonth,
+            OFF.sterilizeInitDay,
+            OFF.sterilizeInitHour,
+            OFF.sterilizeInitMin,
+        ].map(at)
+        const set = ![month, day, hour, minute].includes(IGNORE)
+        this.publishProperty('sterilize_reserved_at', set ? `${month}.${day} ${pad2(hour)}:${pad2(minute)}` : 'Not set')
+        this.publishProperty('sterilize_time', set ? `${pad2(hour)}:${pad2(minute)}` : '')
+
+        this.publishProperty('app_version', at(OFF.appVersion))
+        this.publishProperty('data_refresh', at(OFF.monDataRefresh))
+    }
+
+    // The usage report: `12 1f 00` then six big-endian dispense counters (deltas since the last
+    // report). Returns true when it consumed the frame so the state decode is skipped.
+    private processUsage(buf: Buffer): boolean {
+        if (buf.length !== USAGE_BODY_LEN || buf[1] !== 0x1f || buf[2] !== 0x00) return false
+
+        const normal = buf[3]
+        const hot = buf.readUInt16BE(4)
+        const cold = buf.readUInt16BE(6)
+        const sterilization = buf.readUInt16BE(12)
+        const total = normal + hot + cold + buf.readUInt16BE(8) + buf.readUInt16BE(10) + sterilization
+        if (total === 0) return true
+
+        this.usage.total += total
+        this.usage.normal += normal
+        this.usage.cold += cold
+        this.usage.hot += hot
+        this.usage.sterilization += sterilization
+        this.publishProperty('water_usage_today', this.usage.total)
+        this.publishProperty('water_usage_normal', this.usage.normal)
+        this.publishProperty('water_usage_cold', this.usage.cold)
+        this.publishProperty('water_usage_hot', this.usage.hot)
+        this.publishProperty('water_usage_sterilization', this.usage.sterilization)
+        return true
+    }
+
+    private setField(offset: number, value: number) {
+        const record = Buffer.alloc(RECORD_LEN, IGNORE)
+        record[offset] = value
+        this.send(Buffer.concat([Buffer.from(SET_STATE), record]))
+    }
+
+    setProperty(prop: string, mqttValue: string) {
+        switch (prop) {
+            case 'default_water': {
+                const code = Object.entries(DEFAULT_WATER).find(([, label]) => label === mqttValue)?.[0]
+                if (code === undefined) return log('status', this.id, `Unknown default dispense ${mqttValue}`)
+                return this.setField(OFF.defaultWaterSet, Number(code))
+            }
+            case 'default_water_amount': {
+                const hit = DEFAULT_AMOUNTS.find(([label]) => label === mqttValue)
+                if (!hit) return log('status', this.id, `Unknown default dispense volume ${mqttValue}`)
+                return this.setField(OFF.defaultWaterAmountMode, hit[1])
+            }
+            case 'auto_care':
+                if (mqttValue !== 'ON' && mqttValue !== 'OFF')
+                    return log('status', this.id, `Invalid auto-care value ${mqttValue}`)
+                return this.setField(OFF.autoCareOnOff, mqttValue === 'ON' ? 1 : 0)
+            case 'not_use_notice':
+                if (mqttValue !== 'ON' && mqttValue !== 'OFF')
+                    return log('status', this.id, `Invalid disuse-alert value ${mqttValue}`)
+                return this.setField(OFF.notUseNotice, mqttValue === 'ON' ? 1 : 0)
+            default:
+                log('status', this.id, `Item does not support writing ${prop}`)
+        }
+    }
+}

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -23,6 +23,7 @@ import RV13B6ES_D_US_WIFI from './devices/RV13B6ES_D_US_WIFI'
 import WTL_FXU_BDV_NA_01 from './devices/WTL_FXU_BDV_NA_01'
 import DHUM_056905_WW from './devices/DHUM_056905_WW'
 import ST_B_E4H01Y_APL from './devices/ST_B_E4H01Y_APL'
+import Dev_1WPU4CIGCR__2 from './devices/1WPU4CIGCR__2'
 import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
 import { type Connection } from './homeassistant'
@@ -69,6 +70,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     WTL_FXU_BDV_NA_01, // LG WashTower
     DHUM_056905_WW,
     ST_B_E4H01Y_APL,
+    ['1WPU4CIGCR__2']: Dev_1WPU4CIGCR__2, // LG water purifier ATOM-U (deviceType 103)
 }
 
 class Bridge {

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -18,6 +18,7 @@ import RV13U6AM8W_D_US_WIFI from './devices/RV13U6AM8W_D_US_WIFI'
 import F3L2CYU__ from './devices/F3L2CYU__'
 import RV13B6BSD_D_US_WIFI from './devices/RV13B6BSD_D_US_WIFI'
 import WTL_FXU_BDV_NA_01 from './devices/WTL_FXU_BDV_NA_01'
+import Dev_1WPU4CIGCR__2 from './devices/1WPU4CIGCR__2'
 import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
 import { type Connection } from './homeassistant'
@@ -55,6 +56,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['F3L2CYU__']: F3L2CYU__, // LG front-load washer
     ['RV13B6BSD_D_US_WIFI']: RV13B6BSD_D_US_WIFI, // LG electric dryer
     WTL_FXU_BDV_NA_01, // LG WashTower
+    ['1WPU4CIGCR__2']: Dev_1WPU4CIGCR__2, // LG water purifier ATOM-U (deviceType 103)
 }
 
 class Bridge {

--- a/tests/cloud/devices/1WPU4CIGCR__2.test.ts
+++ b/tests/cloud/devices/1WPU4CIGCR__2.test.ts
@@ -1,0 +1,166 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/1WPU4CIGCR__2'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = '1WPU4CIGCR__2'
+const META: Metadata = { modelId: MODEL_ID, modelName: MODEL_ID, swVersion: '' }
+const FIXED_NOW = Date.parse('2026-07-28T12:00:00Z')
+
+/*
+ * STATE_SHORT is a REAL single-record frame captured from the appliance on 2026-07-28.
+ * The variants are that frame with ONE byte changed and the checksum recomputed; each was
+ * injected into LG's cloud that day, so the expected value is LG's own decode of that exact
+ * frame.
+ */
+const STATE_SHORT = buf('aa2012eb020002010101ffff00ff010101ffff071c121eff01ff0300000177bb')
+
+function withAABBChecksum(frame: Buffer) {
+    const packet = Buffer.from(frame)
+    let sum = 0
+    for (let i = 0; i < packet.length - 2; i++) sum += packet[i]
+    packet[packet.length - 2] = (sum & 0xff) ^ 0x55
+    return packet
+}
+
+function withByte(frame: Buffer, index: number, value: number) {
+    const next = Buffer.from(frame)
+    next[index] = value
+    return withAABBChecksum(next)
+}
+
+function withFrozenNow<T>(now: number, fn: () => T): T {
+    const originalNow = Date.now
+    Date.now = () => now
+    try {
+        return fn()
+    } finally {
+        Date.now = originalNow
+    }
+}
+
+const COLD_WATER = withByte(STATE_SHORT, 6, 3) // waterSelection -> COLD_WATER
+const AMOUNT_OZ = withByte(STATE_SHORT, 9, 0) // amountUnit -> oz
+const STERILIZING = withByte(STATE_SHORT, 27, 3) // highSterilizeState -> water line
+const HOT_85 = withByte(STATE_SHORT, 10, 3) // hotWaterTemp code 3 -> 85 °C
+
+const USAGE_FRAMES = [
+    'aa12121f00fc00000000000000000000bcbb',
+    'aa12121f0032000000000000000000004abb',
+    'aa12121f00fc00000000000000000000bcbb',
+    'aa12121f0000000000b0000000000000c8bb',
+    'aa12121f000000fc0000000000000000bcbb',
+    'aa12121f0000007100000000000000000bbb',
+].map(buf)
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+const props = (ha: MockHAConnection) => ha.devices[DEVICE_ID].properties
+
+describe(MODEL_ID, () => {
+    test('a real state frame decodes to HA-friendly values', () => {
+        withFrozenNow(FIXED_NOW, () => {
+            const { ha, thinq } = makeDevice()
+            thinq.emit('data', STATE_SHORT)
+            const p = props(ha)
+            assert.equal(p.status, 'Normal')
+            assert.equal(p.cock_state, 'Standby')
+            assert.equal(p.water_selection, 'Purified')
+            assert.equal(p.water_amount, '120 mL')
+            assert.equal(p.hot_water_temp, '') // 0xff -> not reported
+            assert.equal(p.sterilize_reserved_at, '2026-07-28T18:30:00.000Z')
+            assert.equal(p.sterilize_state, 'Standby')
+            assert.equal(p.filter_flushing, 'Off')
+            assert.equal(p.app_version, 1)
+            assert.equal(p.data_refresh, 3)
+        })
+    })
+
+    test('captured byte changes still decode the right live values', () => {
+        withFrozenNow(FIXED_NOW, () => {
+            for (const [frame, key, value] of [
+                [COLD_WATER, 'water_selection', 'Cold water'],
+                [AMOUNT_OZ, 'water_amount', '120 oz'],
+                [STERILIZING, 'sterilize_state', 'Water line sterilizing'],
+                [HOT_85, 'hot_water_temp', 85],
+            ] as const) {
+                const { ha, thinq } = makeDevice()
+                thinq.emit('data', frame)
+                assert.equal(props(ha)[key], value, key)
+            }
+        })
+    })
+
+    test('real usage captures accumulate into litres', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', USAGE_FRAMES[0])
+        assert.equal(props(ha).water_usage_today, 0.252)
+        assert.equal(props(ha).water_usage_normal, 0.252)
+
+        thinq.emit('data', USAGE_FRAMES[1])
+        assert.equal(props(ha).water_usage_today, 0.302)
+        assert.equal(props(ha).water_usage_normal, 0.302)
+
+        for (const frame of USAGE_FRAMES.slice(2)) thinq.emit('data', frame)
+        assert.equal(props(ha).water_usage_today, 1.095)
+        assert.equal(props(ha).water_usage_normal, 0.554)
+        assert.equal(props(ha).water_usage_cold, 0.176)
+        assert.equal(props(ha).water_usage_hot, 0.365)
+        assert.equal(props(ha).water_usage_sterilization, 0)
+    })
+
+    test('config only exposes the verified read-only entities', () => {
+        const { ha } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        assert.deepEqual(Object.keys(components).sort(), [
+            'app_version',
+            'cock_state',
+            'data_refresh',
+            'filter_flushing',
+            'hot_water_temp',
+            'status',
+            'sterilize_reserved_at',
+            'sterilize_state',
+            'water_amount',
+            'water_selection',
+            'water_usage_cold',
+            'water_usage_hot',
+            'water_usage_normal',
+            'water_usage_sterilization',
+            'water_usage_today',
+        ])
+        for (const [name, comp] of Object.entries(components)) {
+            assert.equal(comp.command_topic, undefined, `${name} stays read-only`)
+        }
+        assert.equal(components.sterilize_reserved_at.device_class, 'timestamp')
+        for (const key of [
+            'water_usage_today',
+            'water_usage_normal',
+            'water_usage_cold',
+            'water_usage_hot',
+            'water_usage_sterilization',
+        ]) {
+            assert.equal(components[key].state_class, 'total_increasing', key)
+            assert.equal(components[key].unit_of_measurement, 'L', key)
+        }
+        for (const gone of [
+            'default_water',
+            'default_water_amount',
+            'button_sound',
+            'auto_care',
+            'not_use_notice',
+            'temp_unit',
+            'amount_unit',
+            'sterilize_time',
+        ]) {
+            assert.equal(components[gone], undefined, gone)
+        }
+    })
+})

--- a/tests/cloud/devices/1WPU4CIGCR__2.test.ts
+++ b/tests/cloud/devices/1WPU4CIGCR__2.test.ts
@@ -1,0 +1,178 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/1WPU4CIGCR__2'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = '1WPU4CIGCR__2'
+const META: Metadata = { modelId: MODEL_ID, modelName: MODEL_ID, swVersion: '' }
+
+/*
+ * STATE_SHORT is a REAL single-record frame captured from the appliance on 2026-07-28. The
+ * variants are that frame with ONE byte changed and the checksum recomputed; each was injected
+ * into LG's cloud that day, so the expected value is LG's own decode of that exact frame.
+ */
+const STATE_SHORT = buf('aa2012eb020002010101ffff00ff010101ffff071c121eff01ff0300000177bb')
+
+function withAABBChecksum(frame: Buffer) {
+    const packet = Buffer.from(frame)
+    let sum = 0
+    for (let i = 0; i < packet.length - 2; i++) sum += packet[i]
+    packet[packet.length - 2] = (sum & 0xff) ^ 0x55
+    return packet
+}
+
+// The record starts 4 bytes into the whole frame (aa, len, tag, index), so whole-frame index N is
+// record offset N-4.
+function withByte(frame: Buffer, index: number, value: number) {
+    const next = Buffer.from(frame)
+    next[index] = value
+    return withAABBChecksum(next)
+}
+
+const COLD_WATER = withByte(STATE_SHORT, 6, 3) // waterSelection -> COLD_WATER
+const FAHRENHEIT = withByte(STATE_SHORT, 8, 0) // tempUnit -> FAHRENHEIT
+const DEFAULT_COLD = withByte(STATE_SHORT, 14, 3) // defaultWaterSet -> COLD_WATER
+const STERILIZING = withByte(STATE_SHORT, 27, 3) // highSterilizeState -> water line
+const HOT_85 = withByte(STATE_SHORT, 10, 3) // hotWaterTemp code 3 -> 85 °C
+
+function usageFrame(values: Partial<Record<'normal' | 'hot' | 'cold' | 'soda' | 'mineral' | 'sterilization', number>>) {
+    const frame = Buffer.alloc(18)
+    frame[0] = 0xaa
+    frame[1] = 0x12
+    frame[2] = 0x12
+    frame[3] = 0x1f
+    frame[5] = values.normal ?? 0
+    frame.writeUInt16BE(values.hot ?? 0, 6)
+    frame.writeUInt16BE(values.cold ?? 0, 8)
+    frame.writeUInt16BE(values.soda ?? 0, 10)
+    frame.writeUInt16BE(values.mineral ?? 0, 12)
+    frame.writeUInt16BE(values.sterilization ?? 0, 14)
+    frame[17] = 0xbb
+    return withAABBChecksum(frame)
+}
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+const props = (ha: MockHAConnection) => ha.devices[DEVICE_ID].properties
+
+describe(MODEL_ID, () => {
+    test('a real state frame decodes to LG cloud values', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE_SHORT)
+        const p = props(ha)
+        assert.equal(p.status, 'Normal')
+        assert.equal(p.cock_state, 'Standby')
+        assert.equal(p.water_selection, 'Purified')
+        assert.equal(p.water_amount, '120 mL')
+        assert.equal(p.default_water, 'Last used')
+        assert.equal(p.default_water_amount, '120 mL')
+        assert.equal(p.hot_water_temp, '') // 0xff -> not reported
+        assert.equal(p.temp_unit, '°C')
+        assert.equal(p.amount_unit, 'mL')
+        assert.equal(p.button_sound, 'ON')
+        assert.equal(p.auto_care, 'ON')
+        assert.equal(p.not_use_notice, 'OFF')
+        assert.equal(p.sterilize_state, 'Standby')
+        assert.equal(p.filter_flushing, 'Off')
+        assert.equal(p.app_version, 1)
+        assert.equal(p.data_refresh, 3)
+    })
+
+    test('single-byte-changed frames decode the way LG read them', () => {
+        for (const [frame, key, value] of [
+            [COLD_WATER, 'water_selection', 'Cold water'],
+            [FAHRENHEIT, 'temp_unit', '°F'],
+            [DEFAULT_COLD, 'default_water', 'Cold water'],
+            [STERILIZING, 'sterilize_state', 'Water line sterilizing'],
+            [HOT_85, 'hot_water_temp', 85],
+        ] as const) {
+            const { ha, thinq } = makeDevice()
+            thinq.emit('data', frame)
+            assert.equal(props(ha)[key], value, key)
+        }
+    })
+
+    test('the sterilization reservation is published raw, month.day HH:MM', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE_SHORT) // record bytes 15..18 = 07 1c 12 1e
+        assert.equal(props(ha).sterilize_reserved_at, '7.28 18:30')
+        assert.equal(props(ha).sterilize_time, '18:30')
+    })
+
+    test('an unset reservation (0xff) reads Not set', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', withByte(STATE_SHORT, 19, 0xff)) // sterilizeInitMonth -> IGNORE
+        assert.equal(props(ha).sterilize_reserved_at, 'Not set')
+        assert.equal(props(ha).sterilize_time, '')
+    })
+
+    test('usage deltas accumulate into total_increasing counters', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', usageFrame({ normal: 3, cold: 2, hot: 1, sterilization: 4 }))
+        assert.equal(props(ha).water_usage_normal, 3)
+        assert.equal(props(ha).water_usage_cold, 2)
+        assert.equal(props(ha).water_usage_hot, 1)
+        assert.equal(props(ha).water_usage_sterilization, 4)
+        assert.equal(props(ha).water_usage_today, 10)
+
+        // A second report adds to the running totals rather than replacing them.
+        thinq.emit('data', usageFrame({ normal: 5, soda: 2, mineral: 1 }))
+        assert.equal(props(ha).water_usage_normal, 8)
+        assert.equal(props(ha).water_usage_today, 18)
+    })
+
+    test('a zero or truncated usage frame changes nothing', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', usageFrame({ normal: 4 }))
+        assert.equal(props(ha).water_usage_today, 4)
+        thinq.emit('data', usageFrame({})) // all-zero delta
+        thinq.emit('data', usageFrame({ normal: 9 }).subarray(0, 17)) // truncated
+        assert.equal(props(ha).water_usage_today, 4)
+    })
+
+    test('a usage frame is not mistaken for a state frame', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STATE_SHORT)
+        thinq.emit('data', usageFrame({ cold: 5 }))
+        assert.equal(props(ha).status, 'Normal') // state decode did not re-run
+        assert.equal(props(ha).water_usage_cold, 5)
+    })
+
+    test('exactly the side-effect-safe fields are writable', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('default_water', 'Cold water')
+        assert.equal(thinq.outbox.length, 1)
+        const record = thinq.outbox[0].subarray(4, thinq.outbox[0].length - 2)
+        assert.equal(record[10], 3) // defaultWaterSet offset, code 3 = Cold water
+        assert.ok(record.every((b, i) => i === 10 || b === 0xff)) // every other field left alone
+
+        thinq.resetRecorder()
+        dev.setProperty('sterilize_reserved_at', '9.9 09:09') // read-only
+        dev.setProperty('status', 'Normal') // read-only
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('config publishes usage as total_increasing and no persistent-history entities', () => {
+        const { ha } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        for (const key of [
+            'water_usage_today',
+            'water_usage_normal',
+            'water_usage_cold',
+            'water_usage_hot',
+            'water_usage_sterilization',
+        ]) {
+            assert.equal(components[key].state_class, 'total_increasing', key)
+        }
+        for (const gone of ['sterilize_pipe_last_at', 'sterilize_outlet_last_at', 'sterilize_previous_month_count']) {
+            assert.equal(components[gone], undefined, gone)
+        }
+    })
+})


### PR DESCRIPTION
Sixth and last of the per-device-class splits from #111.

Adds `1WPU4CIGCR__2`, an AA..BB ThinQ2 LG PuriCare water purifier (deviceType 103).

Review follow-up:
- exposes only verified read-only Home Assistant entities; removed unattached properties, dead sensor write paths, and cleanup for code that was never upstream;
- maps `amountUnit` into the displayed live dispense amount instead of publishing an unused unit entity;
- publishes the four-byte sterilization reservation as a Home Assistant timestamp;
- accumulates captured per-report dispense deltas into process-local `total_increasing` counters, converts mL to L, and explicitly relies on Home Assistant to handle a restart reset (no persistent history);
- tests usage with six real captured frames rather than a synthesized helper;
- rebased onto current `master` and retains all current device registrations.

Fresh verification on the final commit: targeted purifier tests 4/4, full suite 448/448, build/typecheck, Prettier, and diff check all pass.