### PR TITLE
Dashboard UI Improvements.

### DIFF
--- a/bridge/index.ts
+++ b/bridge/index.ts
@@ -93,12 +93,22 @@ class BridgedDevice {
 type BridgeEvents = {
     loggedIn: () => void
     loggedOut: () => void
+    namesChanged: () => void
     started: (id: string) => void
     stopped: (id: string) => void
 }
 
 export class Bridge extends TypedEmitter<BridgeEvents> {
     bridgedDevices = new Map<string, BridgedDevice>()
+
+    /*
+     * What the owner calls each appliance, from the ThinQ account - the same names the app shows.
+     *
+     * rethink knows a device by its id and its model, which is enough to talk to it and useless for
+     * telling four identical ceiling cassettes apart. The account already holds the answer; it was
+     * only ever read while registering a device (see registrationPlan), so it never reached the panel.
+     */
+    deviceNames = new Map<string, string>()
 
     constructor(
         readonly state: BridgeState,
@@ -108,6 +118,34 @@ export class Bridge extends TypedEmitter<BridgeEvents> {
         this.manager.on('newDevice', this.#start.bind(this))
         this.manager.on('dropDevice', this.#stop.bind(this))
         Object.values(this.manager.allDevices).forEach(this.#start.bind(this))
+        void this.refreshNames()
+    }
+
+    name(id: string) {
+        return this.deviceNames.get(id)
+    }
+
+    /*
+     * Best-effort: the panel is perfectly usable without the names, so a cloud that will not answer
+     * costs a log line and nothing else. Logging out takes the same path - no credentials, no names.
+     */
+    async refreshNames() {
+        const creds = this.state.getCredentials()
+        if (!creds) {
+            this.deviceNames = new Map()
+            this.emit('namesChanged')
+            return
+        }
+
+        try {
+            const client = new ThinqClient(creds.env)
+            await client.auth(creds.refreshToken)
+            const devices = await client.listDevices()
+            this.deviceNames = new Map(devices.filter((dev) => dev.alias).map((dev) => [dev.deviceId, dev.alias]))
+            this.emit('namesChanged')
+        } catch (err) {
+            console.warn('Could not read the device names from the ThinQ account:', err)
+        }
     }
 
     #start(dev: AnyDevice) {
@@ -151,6 +189,7 @@ export class Bridge extends TypedEmitter<BridgeEvents> {
         const bridged = new BridgedDevice(clientDevice, dev)
         this.bridgedDevices.set(dev.id, bridged)
         this.emit('started', dev.id)
+        void this.refreshNames() // registering may have just given this appliance its name
         return true
     }
 
@@ -182,6 +221,7 @@ export class Bridge extends TypedEmitter<BridgeEvents> {
                 refreshToken: token.refreshToken,
             })
             this.emit('loggedIn')
+            await this.refreshNames()
             return true
         } catch (err) {
             return false
@@ -191,6 +231,7 @@ export class Bridge extends TypedEmitter<BridgeEvents> {
     logout() {
         this.state.setCredentials(undefined)
         // FIXME? drop all devices
+        void this.refreshNames() // with the credentials gone, this clears the names
         this.emit('loggedOut')
     }
 

--- a/html/index.html
+++ b/html/index.html
@@ -6,6 +6,17 @@
                 display: none;
             }
 
+            /*
+             * The names come from a linked ThinQ account, so an installation without one has nothing
+             * to put in this column on any row. A column of em dashes is width spent saying that, on
+             * the widest table on the page, so the column is not shown at all until something has a
+             * name. An appliance the account does not cover still shows the dash, next to the ones
+             * that do have names, because there the column means something.
+             */
+            #devices_table.no-names .dev-name {
+                display: none;
+            }
+
             .status_field {
                 display: inline-block;
                 width: 1.5em;
@@ -44,6 +55,7 @@
             <table class="highlight">
                 <thead>
                     <tr>
+                        <th class="dev-name">Name</th>
                         <th>ID</th>
                         <th>Model</th>
                         <th>Platform</th>

--- a/html/index.html
+++ b/html/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
     <head>
+        <meta charset="utf-8" />
         <style>
             .offline .hide-when-offline {
                 display: none;
@@ -26,6 +27,86 @@
                 width: 24px;
                 height: 24px;
             }
+
+            .dev-bridge {
+                width: 10em;
+            }
+
+            /*
+             * The device list is the widest thing on this page, and the widest thing in it is a
+             * 36-character UUID, so on a phone the whole page ends up scrolling sideways. Below the
+             * width where six columns stop fitting, each row becomes a card instead: the name, model
+             * and id stack in one column, with the bridge switch and the monitor button pinned to the
+             * right where a thumb can still reach them. Nothing is hidden - the id and the platform
+             * just move under the name and get out of the way.
+             */
+            @media (max-width: 720px) {
+                #devices_table thead {
+                    display: none;
+                }
+
+                #devices_table tbody tr {
+                    display: grid;
+                    grid-template-columns: minmax(0, 1fr) auto auto;
+                    grid-template-areas:
+                        'name     bridge monitor'
+                        'model    bridge monitor'
+                        'platform bridge monitor'
+                        'id       bridge monitor';
+                    gap: 0 0.5rem;
+                    align-items: center;
+                    padding: 0.5rem 0;
+                }
+
+                #devices_table tbody td {
+                    border: none;
+                    padding: 0;
+                    min-width: 0;
+                }
+
+                #devices_table .dev-name {
+                    grid-area: name;
+                    font-weight: 500;
+                }
+                #devices_table .dev-model {
+                    grid-area: model;
+                }
+                #devices_table .dev-platform {
+                    grid-area: platform;
+                }
+                #devices_table .dev-id {
+                    grid-area: id;
+                }
+                #devices_table .dev-bridge {
+                    grid-area: bridge;
+                    width: auto;
+                }
+                #devices_table .dev-monitor {
+                    grid-area: monitor;
+                }
+
+                #devices_table .dev-platform,
+                #devices_table .dev-id {
+                    font-size: 0.75rem;
+                    color: rgba(0, 0, 0, 0.54);
+                }
+
+                /* Cut off rather than wrapped: a UUID broken across three lines is no more readable
+                   than a truncated one, and it drags the row's height with it. Both cells carry the
+                   full text as a title, and the monitor page shows the id in full anyway. */
+                #devices_table .dev-name,
+                #devices_table .dev-id {
+                    white-space: nowrap;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                }
+
+                /* The default button padding is wider than the icon needs, and here it is competing
+                   with the device's own name for the width of a phone. */
+                #devices_table .dev-monitor .btn {
+                    padding: 0 0.75rem;
+                }
+            }
         </style>
         <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
         <link
@@ -38,9 +119,12 @@
     <body class="offline">
         <nav class="light-blue lighten-1" role="navigation">
             <div class="nav-wrapper container">
+                <!-- Materialize centres the brand on a narrow screen, so a title wider than the
+                     viewport is itself a reason the page scrolls sideways. Drop the two words that
+                     carry no information once you are looking at the thing. -->
                 <a id="logo-container" href="#" class="brand-logo">
                     <span class="material-icons">psychology_alt</span>
-                    Rethink management panel
+                    Rethink <span class="hide-on-med-and-down">management panel</span>
                 </a>
             </div>
         </nav>
@@ -52,7 +136,7 @@
 
         <div class="container hide-when-offline">
             <h4 class="header orange-text">Connected devices</h4>
-            <table class="highlight">
+            <table id="devices_table" class="highlight">
                 <thead>
                     <tr>
                         <th class="dev-name">Name</th>

--- a/html/monitor.html
+++ b/html/monitor.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
     <head>
+        <meta charset="utf-8" />
         <style>
             .status_label {
                 width: 10em;
@@ -68,6 +69,39 @@
             .reduced_margins .input-field {
                 margin: 4px;
             }
+
+            /*
+             * Auto-scroll used to be floated inside the "Messages" heading, which made the heading a
+             * layout container: once the row ran out of width the float dropped below it and took half
+             * the switch with it, leaving its name on one line and its lever on the next. It is a row
+             * of its own now, and each switch in it is one inline-flex unit that cannot be split - the
+             * row wraps between switches instead of through one.
+             */
+            .monitor-controls {
+                display: flex;
+                flex-wrap: wrap;
+                align-items: center;
+                gap: 4px 24px;
+                margin-bottom: 8px;
+            }
+
+            .monitor-controls .toggle {
+                display: inline-flex;
+                align-items: center;
+                gap: 8px;
+                white-space: nowrap;
+                border-radius: 4px;
+                padding: 2px 8px;
+            }
+
+            .monitor-controls .toggle > label {
+                cursor: pointer;
+            }
+
+            /* The lever alone says on or off; the Off/On words either side doubled its width. */
+            .monitor-controls .switch label .lever {
+                margin: 0;
+            }
         </style>
         <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
         <link
@@ -82,7 +116,7 @@
             <div class="nav-wrapper container">
                 <a id="logo-container" href="/" class="brand-logo">
                     <span class="material-icons">psychology_alt</span>
-                    Rethink management panel
+                    Rethink <span class="hide-on-med-and-down">management panel</span>
                 </a>
             </div>
         </nav>
@@ -94,17 +128,15 @@
         </div>
 
         <div class="reduced_margins container flex_y flex_grow" style="overflow: hidden">
-            <h4 class="header orange-text">
-                Messages
-                <div style="float: right">
+            <h4 class="header orange-text">Messages</h4>
+            <div class="monitor-controls">
+                <span class="toggle">
                     <label for="autoscroll">Auto-scroll</label>
                     <span class="switch">
-                        <label
-                            >Off <input id="autoscroll" type="checkbox" checked /> <span class="lever"></span>On</label
-                        >
+                        <label><input id="autoscroll" type="checkbox" checked /> <span class="lever"></span></label>
                     </span>
-                </div>
-            </h4>
+                </span>
+            </div>
             <div class="flex_grow" id="messages"></div>
             <div class="flex_x">
                 <div class="input-field flex_grow">

--- a/html/monitor.js
+++ b/html/monitor.js
@@ -15,16 +15,27 @@ function deviceSocketUrl() {
     return url
 }
 
+// As on the panel: first retry near-immediately, back off only if that fails too.
+let retryDelay = 250
+
 function connect() {
     clearTimeout(reconnectTimer)
+    if (ws) {
+        ws.onclose = ws.onopen = ws.onmessage = null
+        try {
+            ws.close()
+        } catch {}
+    }
     ws = new WebSocket(deviceSocketUrl())
 
     ws.onclose = () => {
-        reconnectTimer = setTimeout(connect, 5000)
+        reconnectTimer = setTimeout(connect, retryDelay)
+        retryDelay = 5000
         get('device_status').innerText = 'Waiting for rethink connection...'
     }
 
     ws.onopen = () => {
+        retryDelay = 250
         get('device_status').innerText = 'offline'
     }
 
@@ -74,6 +85,12 @@ function connect() {
         }
     }
 }
+
+// Same as the panel, and for the same reason its readyState check had to go: the restored socket can
+// still read as OPEN here and only report its close afterwards.
+window.addEventListener('pageshow', (ev) => {
+    if (ev.persisted) connect()
+})
 
 function pushMessage(direction, payload, injected) {
     const timestamp = document.createElement('span')

--- a/html/panel.js
+++ b/html/panel.js
@@ -59,14 +59,19 @@ class DeviceEntry {
         // The owner's own name for the appliance, which only the bridge can know. Without it four
         // identical ceiling cassettes are four rows of the same model and a different UUID.
         td = document.createElement('td')
+        td.className = 'dev-name'
         td.innerText = this.remoteState.name || '—'
+        td.title = this.remoteState.name || '' // the cell is cut off on a narrow screen
         children.push(td)
 
         td = document.createElement('td')
+        td.className = 'dev-id'
         td.innerText = this.id
+        td.title = this.id
         children.push(td)
 
         td = document.createElement('td')
+        td.className = 'dev-model'
         let model = this.remoteState.model
         if (!this.remoteState.mapped) {
             model += ` <i class="material-icons tooltipped tiny" data-position="bottom" data-tooltip="This device is not supported by rethink. It will not be mapped to HomeAssistant">warning</i>`
@@ -75,12 +80,14 @@ class DeviceEntry {
         children.push(td)
 
         td = document.createElement('td')
+        td.className = 'dev-platform'
         td.innerText = this.remoteState.platform
         children.push(td)
 
+        // The width lives in the stylesheet now: on a narrow screen this cell moves out of the
+        // column layout entirely, and a fixed width there would push the row wide again.
         td = document.createElement('td')
-        td.style = 'width: 10em'
-
+        td.className = 'dev-bridge'
         td.innerHTML = `
             <div class="switch">
                 <label>Off <input type="checkbox"> <span class="lever"></span>On</label>
@@ -147,6 +154,7 @@ class DeviceEntry {
         }
 
         td = document.createElement('td')
+        td.className = 'dev-monitor'
         td.innerHTML = `<a class="btn waves-effect waves-light" href="monitor?id=${this.id}"><i class="material-icons">troubleshoot</i></a>`
         children.push(td)
 

--- a/html/panel.js
+++ b/html/panel.js
@@ -171,18 +171,33 @@ class DeviceEntry {
     }
 }
 
+// The first reconnect is near-immediate and only then does it back off. A socket that closes because
+// the page went into the back/forward cache, or because rethink restarted under it, otherwise leaves
+// the panel blank - everything is behind .hide-when-offline - for the whole retry interval.
+let retryDelay = 250
+
 function connect() {
     clearTimeout(reconnectTimer)
+    if (ws) {
+        // detach first: a socket replaced mid-flight still fires its close, which would queue a second
+        // reconnect on top of this one
+        ws.onclose = ws.onopen = ws.onmessage = null
+        try {
+            ws.close()
+        } catch {}
+    }
     ws = new WebSocket(baseUrl + 'ws')
 
     ws.onclose = () => {
         get('status_rethink').innerHTML = STATUS_ERROR
         get('status_mqtt').innerHTML = STATUS_UNKNOWN
         document.getElementsByTagName('body')[0].classList.add('offline')
-        reconnectTimer = setTimeout(connect, 5000)
+        reconnectTimer = setTimeout(connect, retryDelay)
+        retryDelay = 5000
     }
 
     ws.onopen = () => {
+        retryDelay = 250
         get('status_rethink').innerHTML = STATUS_OK
         document.getElementsByTagName('body')[0].classList.remove('offline')
     }
@@ -258,6 +273,17 @@ get('btn_thinq_logout_continue').onclick = async () => {
     await fetchWrapper(`thinq_logout`, {}, { method: 'POST' })
     M.Modal.getInstance(get('thinq_logout')).close()
 }
+
+/*
+ * A page restored from the browser's back/forward cache comes back with a socket the browser has
+ * killed on the way in, and the close handler hides everything behind .hide-when-offline - so
+ * pressing Back from the monitor lands on a panel with no device list. Reconnect unconditionally:
+ * the socket can still read as OPEN at this point and only report its close a moment later, so
+ * checking readyState here is exactly the mistake that made the first attempt at this a no-op.
+ */
+window.addEventListener('pageshow', (ev) => {
+    if (ev.persisted) connect() // a full load runs connect() on its own
+})
 
 function get(id) {
     return document.getElementById(id)

--- a/html/panel.js
+++ b/html/panel.js
@@ -56,6 +56,12 @@ class DeviceEntry {
         const children = []
 
         let td
+        // The owner's own name for the appliance, which only the bridge can know. Without it four
+        // identical ceiling cassettes are four rows of the same model and a different UUID.
+        td = document.createElement('td')
+        td.innerText = this.remoteState.name || '—'
+        children.push(td)
+
         td = document.createElement('td')
         td.innerText = this.id
         children.push(td)
@@ -222,6 +228,12 @@ function connect() {
                     if (!devices[id]) devices[id] = new DeviceEntry(id, j, get('devices_body'))
                     else devices[id].update(j)
                 }
+
+                // Only the bridge knows the names, and only when a ThinQ account is linked. Decided
+                // over the whole list rather than per row: the column either says something about
+                // these appliances or it says nothing about any of them.
+                const named = Object.values(devices).some((dev) => dev.remoteState.name)
+                get('devices_table').classList.toggle('no-names', !named)
             }
 
             if (typeof json.bridge === 'object') {

--- a/management/index.ts
+++ b/management/index.ts
@@ -95,6 +95,8 @@ export function app(ha: HA_bridge, manager: DeviceManager, bridge: Bridge | unde
             const dev = manager.allDevices[id]
             const meta = dev.meta
             allDevices[id] = {
+                // What the owner calls it, when the bridge has been able to ask the account
+                name: bridge?.name(id),
                 model: meta.modelId,
                 deviceType: meta.deviceType,
                 platform: dev.platform,
@@ -180,11 +182,13 @@ export function app(ha: HA_bridge, manager: DeviceManager, bridge: Bridge | unde
         bridge.on('loggedOut', refreshBridgeStatus)
         bridge.on('started', refreshDevices)
         bridge.on('stopped', refreshDevices)
+        bridge.on('namesChanged', refreshDevices)
         disposers.push(() => {
             bridge.removeListener('loggedIn', refreshBridgeStatus)
             bridge.removeListener('loggedOut', refreshBridgeStatus)
             bridge.removeListener('started', refreshDevices)
             bridge.removeListener('stopped', refreshDevices)
+            bridge.removeListener('namesChanged', refreshDevices)
         })
     }
 

--- a/tests/bridge/device-names.test.ts
+++ b/tests/bridge/device-names.test.ts
@@ -1,0 +1,42 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { Bridge } from '@/bridge/index'
+import { DeviceManager } from '@/cloud/devmgr'
+import type { BridgeState, Credentials } from '@/bridge/state'
+
+// Enough of the stored bridge state to answer "are we logged in?", which is the only question
+// refreshNames() asks before deciding whether there is an account to read names from.
+function state(credentials?: Credentials): BridgeState {
+    let creds = credentials
+    return {
+        getCredentials: () => creds,
+        setCredentials: (value) => {
+            creds = value
+        },
+        getDeviceState: () => undefined,
+        setDeviceState: () => {},
+    }
+}
+
+describe('ThinQ device names', () => {
+    test('there are none until an account has been read', () => {
+        const bridge = new Bridge(state(), new DeviceManager())
+        assert.equal(bridge.name('any-device'), undefined)
+    })
+
+    test('logging out clears them, and says so', async () => {
+        // Built logged out so the constructor's own refresh does not go looking for a cloud; the names
+        // are then put in place as a successful read would have left them.
+        const bridge = new Bridge(state(), new DeviceManager())
+        bridge.deviceNames = new Map([['cassette', 'Bedroom AC']])
+
+        let announced = 0
+        bridge.on('namesChanged', () => announced++)
+
+        bridge.logout()
+        await Promise.resolve() // logout does not wait for the refresh it kicks off
+
+        assert.equal(bridge.name('cassette'), undefined)
+        assert.equal(announced, 1)
+    })
+})


### PR DESCRIPTION
**Show the ThinQ name for each appliance.** The panel listed a UUID and a model id;
The bridge already reads the account's aliases for registration — this keeps the list and
hands it to the panel, refreshed on login, register and logout. Costs nothing to an
installation without an account: no row has a name, so the column is not drawn.

**Reconnect a page restored from the back/forward cache.** Back from the monitor landed
on an empty panel for five seconds: the browser closes the socket when it caches the
page, so the close handler ran on the way back in.

**Fit the device list on a phone.** Six columns, one a 36-character UUID, scrolled
sideways. Below the breakpoint each row becomes a card, with the bridge switch and
monitor button pinned right. Nothing is dropped — name and id ellipsize and carry their
full text as `title`. Auto-scroll also moves out of the "Messages" heading, which was
acting as a float container and splitting the switch across a wrap.