### PR TITLE
Add support for F_V7_Y___W.B__QEUK/FV1409S4W

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The following appliances are currently supported in rethink:
     - 👍 F2J7HG1W, Washing Machine - mostly working,
     - 🫤 F4WV508S2E, Front-Loading Washing Machine - preliminary support
     - 🫤 F4WV709P1E, Front-Loading Washing Machine - preliminary support
+    - 👍 FV1409S4W, Front-Loading Washing Machine - mostly working
     - 🫤 TW4V9RW9W - preliminary support
     - 👍 F4X7511TWS (VCDWL2QEUK), Front-Load Washing Machine - mostly working
     - 🫤 WT7300CW - preliminary support

--- a/cloud/devices/F_V7_Y___W.B__QEUK.ts
+++ b/cloud/devices/F_V7_Y___W.B__QEUK.ts
@@ -1,0 +1,225 @@
+import HADevice from './base.js';
+import { allowExtendedType } from '../../util/casting.js';
+import AABBDevice from './aabb_device.js';
+import { ERRORS, STATES, COURSES, TEMPERATURES, SPINS } from './washer_common.js';
+export default class Device extends AABBDevice {
+    constructor(HA, thinq, meta) {
+        super(HA, thinq);
+        this.setConfig(allowExtendedType({
+            ...HADevice.config(meta, { name: 'LG Washer' }),
+            components: {
+                power: {
+                    platform: 'switch',
+                    unique_id: '$deviceid-power',
+                    state_topic: '$this/power',
+                    command_topic: '$this/power/set',
+                    name: '',
+                    icon: 'mdi:washing-machine',
+                },
+                start: {
+                    platform: 'button',
+                    unique_id: '$deviceid-start',
+                    command_topic: '$this/start/set',
+                    payload_press: '',
+                    name: 'Start',
+                    icon: 'mdi:play-circle-outline',
+                },
+                pause: {
+                    platform: 'button',
+                    unique_id: '$deviceid-pause',
+                    command_topic: '$this/pause/set',
+                    payload_press: '',
+                    name: 'Pause',
+                    icon: 'mdi:pause-circle-outline',
+                },
+                status: {
+                    platform: 'sensor',
+                    unique_id: '$deviceid-status',
+                    state_topic: '$this/status',
+                    name: 'Status',
+                    icon: 'mdi:state-machine',
+                    device_class: 'enum',
+                    options: STATES.filter((a) => a !== undefined),
+                },
+                error: {
+                    platform: 'binary_sensor',
+                    unique_id: '$deviceid-error',
+                    state_topic: '$this/error',
+                    name: 'Error',
+                    icon: 'mdi:check-circle',
+                    device_class: 'problem',
+                    entity_category: 'diagnostic',
+                },
+                error_message: {
+                    platform: 'sensor',
+                    unique_id: '$deviceid-error-message',
+                    state_topic: '$this/error_message',
+                    name: 'Error message',
+                    icon: 'mdi:alert-circle-outline',
+                    device_class: 'enum',
+                    entity_category: 'diagnostic',
+                    options: ERRORS.filter((a) => a !== undefined),
+                },
+                course: {
+                    platform: 'sensor',
+                    unique_id: '$deviceid-course',
+                    state_topic: '$this/course',
+                    name: 'Course',
+                    icon: 'mdi:pin-outline',
+                },
+                temp: {
+                    platform: 'sensor',
+                    unique_id: '$deviceid-temp',
+                    state_topic: '$this/temp',
+                    name: 'Temperature',
+                    device_class: 'temperature',
+                    unit_of_measurement: '..C',
+                    suggested_display_precision: 0,
+                    value_template: "{{ value if value | is_number else 'None' }}",
+                },
+                spin: {
+                    platform: 'sensor',
+                    unique_id: '$deviceid-spin',
+                    state_topic: '$this/spin',
+                    name: 'Spin',
+                    icon: 'mdi:autorenew',
+                    unit_of_measurement: 'RPM',
+                    value_template: "{{ value if value | is_number else 'None' }}",
+                },
+                cycles: {
+                    platform: 'sensor',
+                    unique_id: '$deviceid-cycles',
+                    state_topic: '$this/cycles',
+                    name: 'Cycle count',
+                    icon: 'mdi:counter',
+                },
+                remote_start: {
+                    platform: 'binary_sensor',
+                    unique_id: '$deviceid-remote_start',
+                    state_topic: '$this/remote_start',
+                    name: 'Remote start',
+                    icon: 'mdi:play-circle-outline',
+                },
+                door_lock: {
+                    platform: 'binary_sensor',
+                    unique_id: '$deviceid-door_lock',
+                    state_topic: '$this/door_lock',
+                    name: 'Door lock',
+                    device_class: 'lock',
+                },
+                child_lock: {
+                    platform: 'binary_sensor',
+                    unique_id: '$deviceid-child_lock',
+                    state_topic: '$this/child_lock',
+                    name: 'Child lock',
+                    device_class: 'lock',
+                },
+                initial_time: {
+                    platform: 'sensor',
+                    unique_id: '$deviceid-initial_time',
+                    state_topic: '$this/initial_time',
+                    device_class: 'duration',
+                    unit_of_measurement: 'min',
+                    name: 'Initial time',
+                },
+                remaining_time: {
+                    platform: 'sensor',
+                    unique_id: '$deviceid-remaining_time',
+                    state_topic: '$this/remaining_time',
+                    device_class: 'duration',
+                    unit_of_measurement: 'min',
+                    name: 'Remaining time',
+                },
+                reserve_time: {
+                    platform: 'sensor',
+                    unique_id: '$deviceid-reserve_time',
+                    state_topic: '$this/reserve_time',
+                    device_class: 'duration',
+                    unit_of_measurement: 'h',
+                    name: 'Reserve time',
+                    icon: 'mdi:timer-sand',
+                },
+                extra_rinse: {
+                    platform: 'binary_sensor',
+                    unique_id: '$deviceid-extra_rinse',
+                    state_topic: '$this/extra_rinse',
+                    name: 'Extra rinse',
+                    icon: 'mdi:water-plus',
+                },
+                prewash: {
+                    platform: 'binary_sensor',
+                    unique_id: '$deviceid-prewash',
+                    state_topic: '$this/prewash',
+                    name: 'Pre-wash',
+                    icon: 'mdi:water-sync',
+                },
+                intensive_wash: {
+                    platform: 'binary_sensor',
+                    unique_id: '$deviceid-intensive_wash',
+                    state_topic: '$this/intensive_wash',
+                    name: 'Intensive wash',
+                    icon: 'mdi:washing-machine-alert',
+                },
+                steam: {
+                    platform: 'binary_sensor',
+                    unique_id: '$deviceid-steam',
+                    state_topic: '$this/steam',
+                    name: 'Steam',
+                    icon: 'mdi:kettle-steam',
+                },
+            },
+        }));
+    }
+    start() {
+        this.send(Buffer.from('F0ED1121010000001800', 'hex'));
+    }
+    processAABB(buf) {
+        if (buf.length === 80 && buf[0] == 0x20) {
+            const status = buf[43];
+            const time_remain = buf[44] * 60 + buf[45];
+            const time_initial = buf[46] * 60 + buf[47];
+            const course = buf[48];
+            const error = buf[49];
+            const wash_intensity = buf[50];
+            const spin = buf[51];
+            const temp = buf[52];
+            const extra_rinse = buf[53];
+            const time_reserve_hour = buf[55];
+            const options = buf[57];
+            const lock_status = buf[58];
+            const cycles = buf[64];
+            this.publishProperty('power', status > 0 ? 'ON' : 'OFF');
+            this.publishProperty('error_message', ERRORS[error] ?? 'unknown'); // publish message before set error state
+            this.publishProperty('error', error ? 'ON' : 'OFF');
+            this.publishProperty('status', STATES[status] ?? 'unknown');
+            this.publishProperty('course', COURSES[course] ?? 'unknown');
+            this.publishProperty('spin', SPINS[spin] ?? 'unknown');
+            this.publishProperty('temp', TEMPERATURES[temp] ?? 'unknown');
+            this.publishProperty('cycles', cycles);
+            this.publishProperty('remote_start', lock_status & 2 ? 'ON' : 'OFF');
+            this.publishProperty('door_lock', !(lock_status & 0x40) ? 'ON' : 'OFF'); // inverted logic, off=locked
+            this.publishProperty('child_lock', !(lock_status & 0x80) ? 'ON' : 'OFF'); // inverted logic, off=locked
+            this.publishProperty('initial_time', time_initial);
+            this.publishProperty('remaining_time', time_remain);
+            this.publishProperty('reserve_time', time_reserve_hour);
+            this.publishProperty('extra_rinse', extra_rinse >= 2 ? 'ON' : 'OFF'); // 0/1=off, 2+=one or more extra rinses (Rinse+)
+            this.publishProperty('prewash', options & 0x40 ? 'ON' : 'OFF');
+            this.publishProperty('steam', options & 0x80 ? 'ON' : 'OFF');
+            this.publishProperty('intensive_wash', wash_intensity >= 4 ? 'ON' : 'OFF'); // 3=normal, 4=intensive
+        }
+    }
+    setProperty(prop, mqttValue) {
+        if (prop === 'power') {
+            if (mqttValue === 'ON') {
+                this.send(Buffer.from('F02A0100', 'hex'));
+            }
+            else if (mqttValue === 'OFF') {
+                this.send(Buffer.from('F024010100', 'hex'));
+            }
+        }
+        if (prop === 'pause')
+            this.send(Buffer.from('F024040100', 'hex'));
+        if (prop === 'start')
+            this.send(Buffer.from(mqttValue || 'F024050100', 'hex'));
+    }
+}

--- a/cloud/devices/F_V7_Y___W.B__QEUK.ts
+++ b/cloud/devices/F_V7_Y___W.B__QEUK.ts
@@ -1,225 +1,233 @@
-import HADevice from './base.js';
-import { allowExtendedType } from '../../util/casting.js';
-import AABBDevice from './aabb_device.js';
-import { ERRORS, STATES, COURSES, TEMPERATURES, SPINS } from './washer_common.js';
+import HADevice from './base'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import AABBDevice from './aabb_device'
+import { ERRORS, STATES, COURSES, TEMPERATURES, SPINS } from './washer_common'
+
 export default class Device extends AABBDevice {
-    constructor(HA, thinq, meta) {
-        super(HA, thinq);
-        this.setConfig(allowExtendedType({
-            ...HADevice.config(meta, { name: 'LG Washer' }),
-            components: {
-                power: {
-                    platform: 'switch',
-                    unique_id: '$deviceid-power',
-                    state_topic: '$this/power',
-                    command_topic: '$this/power/set',
-                    name: '',
-                    icon: 'mdi:washing-machine',
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: 'LG Washer' }),
+                components: {
+                    power: {
+                        platform: 'switch',
+                        unique_id: '$deviceid-power',
+                        state_topic: '$this/power',
+                        command_topic: '$this/power/set',
+                        name: '',
+                        icon: 'mdi:washing-machine',
+                    },
+                    start: {
+                        platform: 'button',
+                        unique_id: '$deviceid-start',
+                        command_topic: '$this/start/set',
+                        payload_press: '',
+                        name: 'Start',
+                        icon: 'mdi:play-circle-outline',
+                    },
+                    pause: {
+                        platform: 'button',
+                        unique_id: '$deviceid-pause',
+                        command_topic: '$this/pause/set',
+                        payload_press: '',
+                        name: 'Pause',
+                        icon: 'mdi:pause-circle-outline',
+                    },
+                    status: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-status',
+                        state_topic: '$this/status',
+                        name: 'Status',
+                        icon: 'mdi:state-machine',
+                        device_class: 'enum',
+                        options: STATES.filter((a) => a !== undefined),
+                    },
+                    error: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-error',
+                        state_topic: '$this/error',
+                        name: 'Error',
+                        icon: 'mdi:check-circle',
+                        device_class: 'problem',
+                        entity_category: 'diagnostic',
+                    },
+                    error_message: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-error-message',
+                        state_topic: '$this/error_message',
+                        name: 'Error message',
+                        icon: 'mdi:alert-circle-outline',
+                        device_class: 'enum',
+                        entity_category: 'diagnostic',
+                        options: ERRORS.filter((a) => a !== undefined),
+                    },
+                    course: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-course',
+                        state_topic: '$this/course',
+                        name: 'Course',
+                        icon: 'mdi:pin-outline',
+                    },
+                    temp: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-temp',
+                        state_topic: '$this/temp',
+                        name: 'Temperature',
+                        device_class: 'temperature',
+                        unit_of_measurement: '°C',
+                        suggested_display_precision: 0,
+                        value_template: "{{ value if value | is_number else 'None' }}",
+                    },
+                    spin: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-spin',
+                        state_topic: '$this/spin',
+                        name: 'Spin',
+                        icon: 'mdi:autorenew',
+                        unit_of_measurement: 'RPM',
+                        value_template: "{{ value if value | is_number else 'None' }}",
+                    },
+                    cycles: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-cycles',
+                        state_topic: '$this/cycles',
+                        name: 'Cycle count',
+                        icon: 'mdi:counter',
+                    },
+                    remote_start: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-remote_start',
+                        state_topic: '$this/remote_start',
+                        name: 'Remote start',
+                        icon: 'mdi:play-circle-outline',
+                    },
+                    door_lock: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-door_lock',
+                        state_topic: '$this/door_lock',
+                        name: 'Door lock',
+                        device_class: 'lock',
+                    },
+                    child_lock: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-child_lock',
+                        state_topic: '$this/child_lock',
+                        name: 'Child lock',
+                        device_class: 'lock',
+                    },
+                    initial_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-initial_time',
+                        state_topic: '$this/initial_time',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        name: 'Initial time',
+                    },
+                    remaining_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-remaining_time',
+                        state_topic: '$this/remaining_time',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        name: 'Remaining time',
+                    },
+                    reserve_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-reserve_time',
+                        state_topic: '$this/reserve_time',
+                        device_class: 'duration',
+                        unit_of_measurement: 'h',
+                        name: 'Reserve time',
+                        icon: 'mdi:timer-sand',
+                    },
+                    extra_rinse: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-extra_rinse',
+                        state_topic: '$this/extra_rinse',
+                        name: 'Extra rinse',
+                        icon: 'mdi:water-plus',
+                    },
+                    prewash: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-prewash',
+                        state_topic: '$this/prewash',
+                        name: 'Pre-wash',
+                        icon: 'mdi:water-sync',
+                    },
+                    intensive_wash: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-intensive_wash',
+                        state_topic: '$this/intensive_wash',
+                        name: 'Intensive wash',
+                        icon: 'mdi:washing-machine-alert',
+                    },
+                    steam: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-steam',
+                        state_topic: '$this/steam',
+                        name: 'Steam',
+                        icon: 'mdi:kettle-steam',
+                    },
                 },
-                start: {
-                    platform: 'button',
-                    unique_id: '$deviceid-start',
-                    command_topic: '$this/start/set',
-                    payload_press: '',
-                    name: 'Start',
-                    icon: 'mdi:play-circle-outline',
-                },
-                pause: {
-                    platform: 'button',
-                    unique_id: '$deviceid-pause',
-                    command_topic: '$this/pause/set',
-                    payload_press: '',
-                    name: 'Pause',
-                    icon: 'mdi:pause-circle-outline',
-                },
-                status: {
-                    platform: 'sensor',
-                    unique_id: '$deviceid-status',
-                    state_topic: '$this/status',
-                    name: 'Status',
-                    icon: 'mdi:state-machine',
-                    device_class: 'enum',
-                    options: STATES.filter((a) => a !== undefined),
-                },
-                error: {
-                    platform: 'binary_sensor',
-                    unique_id: '$deviceid-error',
-                    state_topic: '$this/error',
-                    name: 'Error',
-                    icon: 'mdi:check-circle',
-                    device_class: 'problem',
-                    entity_category: 'diagnostic',
-                },
-                error_message: {
-                    platform: 'sensor',
-                    unique_id: '$deviceid-error-message',
-                    state_topic: '$this/error_message',
-                    name: 'Error message',
-                    icon: 'mdi:alert-circle-outline',
-                    device_class: 'enum',
-                    entity_category: 'diagnostic',
-                    options: ERRORS.filter((a) => a !== undefined),
-                },
-                course: {
-                    platform: 'sensor',
-                    unique_id: '$deviceid-course',
-                    state_topic: '$this/course',
-                    name: 'Course',
-                    icon: 'mdi:pin-outline',
-                },
-                temp: {
-                    platform: 'sensor',
-                    unique_id: '$deviceid-temp',
-                    state_topic: '$this/temp',
-                    name: 'Temperature',
-                    device_class: 'temperature',
-                    unit_of_measurement: '..C',
-                    suggested_display_precision: 0,
-                    value_template: "{{ value if value | is_number else 'None' }}",
-                },
-                spin: {
-                    platform: 'sensor',
-                    unique_id: '$deviceid-spin',
-                    state_topic: '$this/spin',
-                    name: 'Spin',
-                    icon: 'mdi:autorenew',
-                    unit_of_measurement: 'RPM',
-                    value_template: "{{ value if value | is_number else 'None' }}",
-                },
-                cycles: {
-                    platform: 'sensor',
-                    unique_id: '$deviceid-cycles',
-                    state_topic: '$this/cycles',
-                    name: 'Cycle count',
-                    icon: 'mdi:counter',
-                },
-                remote_start: {
-                    platform: 'binary_sensor',
-                    unique_id: '$deviceid-remote_start',
-                    state_topic: '$this/remote_start',
-                    name: 'Remote start',
-                    icon: 'mdi:play-circle-outline',
-                },
-                door_lock: {
-                    platform: 'binary_sensor',
-                    unique_id: '$deviceid-door_lock',
-                    state_topic: '$this/door_lock',
-                    name: 'Door lock',
-                    device_class: 'lock',
-                },
-                child_lock: {
-                    platform: 'binary_sensor',
-                    unique_id: '$deviceid-child_lock',
-                    state_topic: '$this/child_lock',
-                    name: 'Child lock',
-                    device_class: 'lock',
-                },
-                initial_time: {
-                    platform: 'sensor',
-                    unique_id: '$deviceid-initial_time',
-                    state_topic: '$this/initial_time',
-                    device_class: 'duration',
-                    unit_of_measurement: 'min',
-                    name: 'Initial time',
-                },
-                remaining_time: {
-                    platform: 'sensor',
-                    unique_id: '$deviceid-remaining_time',
-                    state_topic: '$this/remaining_time',
-                    device_class: 'duration',
-                    unit_of_measurement: 'min',
-                    name: 'Remaining time',
-                },
-                reserve_time: {
-                    platform: 'sensor',
-                    unique_id: '$deviceid-reserve_time',
-                    state_topic: '$this/reserve_time',
-                    device_class: 'duration',
-                    unit_of_measurement: 'h',
-                    name: 'Reserve time',
-                    icon: 'mdi:timer-sand',
-                },
-                extra_rinse: {
-                    platform: 'binary_sensor',
-                    unique_id: '$deviceid-extra_rinse',
-                    state_topic: '$this/extra_rinse',
-                    name: 'Extra rinse',
-                    icon: 'mdi:water-plus',
-                },
-                prewash: {
-                    platform: 'binary_sensor',
-                    unique_id: '$deviceid-prewash',
-                    state_topic: '$this/prewash',
-                    name: 'Pre-wash',
-                    icon: 'mdi:water-sync',
-                },
-                intensive_wash: {
-                    platform: 'binary_sensor',
-                    unique_id: '$deviceid-intensive_wash',
-                    state_topic: '$this/intensive_wash',
-                    name: 'Intensive wash',
-                    icon: 'mdi:washing-machine-alert',
-                },
-                steam: {
-                    platform: 'binary_sensor',
-                    unique_id: '$deviceid-steam',
-                    state_topic: '$this/steam',
-                    name: 'Steam',
-                    icon: 'mdi:kettle-steam',
-                },
-            },
-        }));
+            }),
+        )
     }
+
     start() {
-        this.send(Buffer.from('F0ED1121010000001800', 'hex'));
+        this.send(Buffer.from('F0ED1121010000001800', 'hex'))
     }
-    processAABB(buf) {
+
+    processAABB(buf: Buffer) {
         if (buf.length === 80 && buf[0] == 0x20) {
-            const status = buf[43];
-            const time_remain = buf[44] * 60 + buf[45];
-            const time_initial = buf[46] * 60 + buf[47];
-            const course = buf[48];
-            const error = buf[49];
-            const wash_intensity = buf[50];
-            const spin = buf[51];
-            const temp = buf[52];
-            const extra_rinse = buf[53];
-            const time_reserve_hour = buf[55];
-            const options = buf[57];
-            const lock_status = buf[58];
-            const cycles = buf[64];
-            this.publishProperty('power', status > 0 ? 'ON' : 'OFF');
-            this.publishProperty('error_message', ERRORS[error] ?? 'unknown'); // publish message before set error state
-            this.publishProperty('error', error ? 'ON' : 'OFF');
-            this.publishProperty('status', STATES[status] ?? 'unknown');
-            this.publishProperty('course', COURSES[course] ?? 'unknown');
-            this.publishProperty('spin', SPINS[spin] ?? 'unknown');
-            this.publishProperty('temp', TEMPERATURES[temp] ?? 'unknown');
-            this.publishProperty('cycles', cycles);
-            this.publishProperty('remote_start', lock_status & 2 ? 'ON' : 'OFF');
-            this.publishProperty('door_lock', !(lock_status & 0x40) ? 'ON' : 'OFF'); // inverted logic, off=locked
-            this.publishProperty('child_lock', !(lock_status & 0x80) ? 'ON' : 'OFF'); // inverted logic, off=locked
-            this.publishProperty('initial_time', time_initial);
-            this.publishProperty('remaining_time', time_remain);
-            this.publishProperty('reserve_time', time_reserve_hour);
-            this.publishProperty('extra_rinse', extra_rinse >= 2 ? 'ON' : 'OFF'); // 0/1=off, 2+=one or more extra rinses (Rinse+)
-            this.publishProperty('prewash', options & 0x40 ? 'ON' : 'OFF');
-            this.publishProperty('steam', options & 0x80 ? 'ON' : 'OFF');
-            this.publishProperty('intensive_wash', wash_intensity >= 4 ? 'ON' : 'OFF'); // 3=normal, 4=intensive
+            const status = buf[43]
+            const time_remain = buf[44] * 60 + buf[45]
+            const time_initial = buf[46] * 60 + buf[47]
+            const course = buf[48]
+            const error = buf[49]
+            const wash_intensity = buf[50]
+            const spin = buf[51]
+            const temp = buf[52]
+            const extra_rinse = buf[53]
+            const time_reserve_hour = buf[55]
+            const options = buf[57]
+            const lock_status = buf[58]
+            const cycles = buf[64]
+
+            this.publishProperty('power', status > 0 ? 'ON' : 'OFF')
+            this.publishProperty('error_message', ERRORS[error] ?? 'unknown') // publish message before set error state
+            this.publishProperty('error', error ? 'ON' : 'OFF')
+            this.publishProperty('status', STATES[status] ?? 'unknown')
+            this.publishProperty('course', COURSES[course] ?? 'unknown')
+            this.publishProperty('spin', SPINS[spin] ?? 'unknown')
+            this.publishProperty('temp', TEMPERATURES[temp] ?? 'unknown')
+            this.publishProperty('cycles', cycles)
+            this.publishProperty('remote_start', lock_status & 2 ? 'ON' : 'OFF')
+            this.publishProperty('door_lock', !(lock_status & 0x40) ? 'ON' : 'OFF') // inverted logic, off=locked
+            this.publishProperty('child_lock', !(lock_status & 0x80) ? 'ON' : 'OFF') // inverted logic, off=locked
+            this.publishProperty('initial_time', time_initial)
+            this.publishProperty('remaining_time', time_remain)
+            this.publishProperty('reserve_time', time_reserve_hour)
+            this.publishProperty('extra_rinse', extra_rinse >= 2 ? 'ON' : 'OFF') // 0/1=off, 2+=one or more extra rinses (Rinse+)
+            this.publishProperty('prewash', options & 0x40 ? 'ON' : 'OFF')
+            this.publishProperty('steam', options & 0x80 ? 'ON' : 'OFF')
+            this.publishProperty('intensive_wash', wash_intensity >= 4 ? 'ON' : 'OFF') // 3=normal, 4=intensive
         }
     }
-    setProperty(prop, mqttValue) {
+
+    setProperty(prop: string, mqttValue: string) {
         if (prop === 'power') {
             if (mqttValue === 'ON') {
-                this.send(Buffer.from('F02A0100', 'hex'));
-            }
-            else if (mqttValue === 'OFF') {
-                this.send(Buffer.from('F024010100', 'hex'));
+                this.send(Buffer.from('F02A0100', 'hex'))
+            } else if (mqttValue === 'OFF') {
+                this.send(Buffer.from('F024010100', 'hex'))
             }
         }
-        if (prop === 'pause')
-            this.send(Buffer.from('F024040100', 'hex'));
-        if (prop === 'start')
-            this.send(Buffer.from(mqttValue || 'F024050100', 'hex'));
+
+        if (prop === 'pause') this.send(Buffer.from('F024040100', 'hex'))
+        if (prop === 'start') this.send(Buffer.from(mqttValue || 'F024050100', 'hex'))
     }
 }

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -9,6 +9,7 @@ import Dev_2REB1GLVB1__2 from './devices/2REB1GLVB1__2'
 import Dev_2RES1VE600FWC from './devices/2RES1VE600FWC'
 import Y_V8_Y___W_B32QEUK from './devices/Y_V8_Y___W.B32QEUK'
 import F_V8_Y___W_B_2QEUK from './devices/F_V8_Y___W.B_2QEUK'
+import F_V7_Y___W_B__QEUK from './devices/F_V7_Y___W.B__QEUK'
 import Y_V8_F___W_B_2QEUK from './devices/Y_V8_F___W.B_2QEUK'
 import F_V__F___W_B_1QEUK from './devices/F_V__F___W.B_1QEUK'
 import F_VB_F___W_B_2QEUK from './devices/F_VB_F___W.B_2QEUK'
@@ -44,6 +45,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['2RES1VE600FWC']: Dev_2RES1VE600FWC,
     ['Y_V8_Y___W.B32QEUK']: Y_V8_Y___W_B32QEUK,
     ['F_V7_Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK, // NOTE: we reuse F_V8_Y___W_B_2QEUK as the models appear to be compatible
+    ['F_V7_Y___W.B__QEUK']: F_V7_Y___W_B__QEUK, // NOTE: based on F_V8_Y___W_B_2QEUK but with energy and turbowash removed
     ['F_V8_Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK,
     ['Y_V8_F___W.B_2QEUK']: Y_V8_F___W_B_2QEUK,
     ['F_V__Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK, // NOTE: we reuse F_V8_Y___W_B_2QEUK as the models appear to be compatible

--- a/tests/cloud/devices/F_V7_Y___W.B__QEUK.test.ts
+++ b/tests/cloud/devices/F_V7_Y___W.B__QEUK.test.ts
@@ -1,0 +1,134 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/F_V7_Y___W.B__QEUK'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'F_V7_Y___W.B__QEUK'
+const META: Metadata = { modelId: MODEL_ID, modelName: 'F_V7_Y___W.B__QEUK', swVersion: '0.0.0' }
+
+// All hex dumps below are captured status telegrams from issue #75 (F6WV710P2S.ABLQPDG).
+// The decoder parses the second record (starting at buf[42]); the option state lives at
+// buf[50] (wash intensity), buf[53] (extra rinse count) and the buf[57] options bitfield.
+
+// Cotton, 40°C, 1600 RPM — no extra options selected.
+const SAMPLE_COTTON_STD = buf(
+    'aa5420ec002501000000000000000000000000000000000000000001006400000000000000000000000000002501033a033a0100030b04010000000000010002000001006400000400000000000000000000e0bb',
+)
+
+// Allergy Care, 60°C, Steam, 1600 RPM.
+const SAMPLE_ALLERGY_STEAM = buf(
+    'aa5420ec002501021c021c0900030504010000000000000002000001006400000500000000000000000000002501023002302d00030b06010000008000000003000001006400000500000000000000000000f2bb',
+)
+
+// Cotton, 60°C, Steam, 1600 RPM.
+const SAMPLE_COTTON_STEAM = buf(
+    'aa5420ec002501031c031c0100030b03010000000000010002000001006400000400000000000000000000002501041104110100030b0601000000800001000300000100640000040000000000000000000015bb',
+)
+
+// Cotton with Rinse+ pressed (extra rinse count -> 2).
+const SAMPLE_RINSE_PLUS = buf(
+    'aa5420ec002501033703370100030706010000000000010004000001006400000400000000000000000000002501040c040c0100030706020000000000010004000001006400000500000000000000000000b9bb',
+)
+
+// Cotton with Pre-wash pressed.
+const SAMPLE_PREWASH = buf(
+    'aa5420ec002501033703370100030706010000000000010004000001006400000400000000000000000000002501040c040c01000307060100000040000100040000010064000005000000000000000000007ebb',
+)
+
+// Cotton with Intensive Wash pressed (wash intensity -> 4).
+const SAMPLE_INTENSIVE = buf(
+    'aa5420ec002501033703370100030706010000000000010004000001006400000400000000000000000000002501041604160100040706010000000000010004000001006400000400000000000000000000aabb',
+)
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('config exposes the option binary sensors', () => {
+        const { ha } = makeDevice()
+        const cfg = ha.devices[DEVICE_ID].config
+        assert.ok(cfg, 'config published')
+        const components = cfg!.components as Record<string, Record<string, unknown>>
+        for (const c of ['extra_rinse', 'prewash', 'steam', 'intensive_wash']) {
+            assert.ok(components[c], `component ${c} present`)
+            assert.equal(components[c].platform, 'binary_sensor')
+        }
+    })
+
+    test('Cotton 40°C 1600 RPM decodes with no options set', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_COTTON_STD)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.course, 'Cotton')
+        assert.equal(props.temp, 40)
+        assert.equal(props.spin, 1600)
+        assert.equal(props.extra_rinse, 'OFF')
+        assert.equal(props.turbowash, 'OFF')
+        assert.equal(props.prewash, 'OFF')
+        assert.equal(props.steam, 'OFF')
+        assert.equal(props.intensive_wash, 'OFF')
+    })
+
+    test('Allergy Care 60°C Steam 1600 RPM decodes steam=ON', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_ALLERGY_STEAM)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.course, 'Allergy Care')
+        assert.equal(props.temp, 60)
+        assert.equal(props.spin, 1600)
+        assert.equal(props.steam, 'ON')
+        assert.equal(props.turbowash, 'OFF')
+        assert.equal(props.prewash, 'OFF')
+        assert.equal(props.extra_rinse, 'OFF')
+        assert.equal(props.intensive_wash, 'OFF')
+    })
+
+    test('Cotton 60°C Steam decodes steam=ON', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_COTTON_STEAM)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.course, 'Cotton')
+        assert.equal(props.temp, 60)
+        assert.equal(props.steam, 'ON')
+        assert.equal(props.turbowash, 'OFF')
+    })
+
+    test('Rinse+ decodes extra_rinse=ON', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_RINSE_PLUS)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.extra_rinse, 'ON')
+        assert.equal(props.turbowash, 'OFF')
+        assert.equal(props.prewash, 'OFF')
+        assert.equal(props.steam, 'OFF')
+        assert.equal(props.intensive_wash, 'OFF')
+    })
+
+    test('Pre-wash decodes prewash=ON', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_PREWASH)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.prewash, 'ON')
+        assert.equal(props.turbowash, 'OFF')
+        assert.equal(props.steam, 'OFF')
+        assert.equal(props.extra_rinse, 'OFF')
+        assert.equal(props.intensive_wash, 'OFF')
+    })
+
+    test('Intensive Wash decodes intensive_wash=ON', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_INTENSIVE)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.intensive_wash, 'ON')
+        assert.equal(props.turbowash, 'OFF')
+        assert.equal(props.prewash, 'OFF')
+        assert.equal(props.steam, 'OFF')
+        assert.equal(props.extra_rinse, 'OFF')
+    })
+})


### PR DESCRIPTION
Thank you for your excellent work enabling local control for LG ThinQ devices.  I have added support for a front-loading washing machine F_V7_Y___W.B__QEUK/FV1409S4W, using the handler for F_V8_Y___W_B_2QEUK as a base.  The main change I've made is to remove TurboWash and Energy sensors as these are not featured on F_V7_Y___W.B__QEUK.