### PR TITLE
hassio: add Home Assistant add-on support

### DIFF
--- a/hassio/DOCS.md
+++ b/hassio/DOCS.md
@@ -1,0 +1,87 @@
+# Rethink
+
+De-cloud LG ThinQ appliances and expose them to Home Assistant over MQTT,
+without the official LG app or cloud. The add-on runs `rethink-cloud`, which
+emulates the ThinQ cloud on your local network and translates the device
+protocol into Home Assistant MQTT discovery.
+
+## How it works
+
+Appliances are hard-coded to talk to LG's cloud by DNS name. To use this
+add-on you redirect those names to your Home Assistant host, where the add-on
+answers on the device-facing ports. It then publishes each device to your MQTT
+broker, and Home Assistant discovers it automatically.
+
+## Requirements
+
+- An MQTT broker reachable by Home Assistant. The
+  [Mosquitto broker add-on](https://github.com/home-assistant/addons/tree/master/mosquitto)
+  is the easiest option and is detected automatically (the add-on declares
+  `mqtt:need`).
+- A way to redirect the ThinQ DNS names to the Home Assistant host IP
+  (e.g. your router's DNS, Pi-hole/AdGuard, or a local DNS override). See the
+  [project wiki](https://github.com/anszom/rethink/wiki/Installing-rethink%E2%80%90cloud).
+
+## Installation
+
+1. Install and start an MQTT broker (e.g. Mosquitto).
+2. Install this add-on and set the options below.
+3. Start the add-on and open the **Web UI** (Ingress) to watch devices connect.
+4. Redirect the ThinQ DNS names to Home Assistant and (re)connect your device.
+
+The management web interface is served through **Ingress**, so it opens
+directly from the add-on page — no extra port or login is required for it.
+
+## Options
+
+These are the options exposed under the add-on's **Configuration** tab. The
+defaults come straight from `config.yaml`.
+
+| Option             | Default                                  | Description                                                                                                                                    |
+| ------------------ | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `hostname`         | `rethink.lan`                            | The DNS name your appliances are redirected to. Must be a hostname, not an IP — it becomes the CN of the generated CA/server certificate.      |
+| `discovery_prefix` | `homeassistant`                          | MQTT discovery prefix. Must match Home Assistant's MQTT discovery prefix.                                                                      |
+| `rethink_prefix`   | `rethink`                                | Prefix for the add-on's own MQTT topics.                                                                                                       |
+| `bridge`           | `false`                                  | Enable ThinQ cloud bridge mode, forwarding messages to the real LG cloud so the official app keeps working. Configure the login in the Web UI. |
+| `mqtt_url`         | _(empty)_                                | Leave empty to use the Home Assistant MQTT service automatically. Set it (e.g. `mqtt://192.168.1.10:1883`) to use an external broker.          |
+| `mqtt_user`        | _(empty)_                                | Username for `mqtt_url` (ignored when the MQTT service is auto-detected).                                                                      |
+| `mqtt_pass`        | _(empty)_                                | Password for `mqtt_url` (ignored when the MQTT service is auto-detected).                                                                      |
+| `log`              | `status, incoming, HTTPS, publish, MGMT` | Log categories to enable. Allowed values: `status`, `incoming`, `HTTPS`, `publish`, `MGMT`, or `all` for everything.                           |
+
+The device-facing ports are not options — they are configured under the
+add-on's **Network** panel (see **Ports** below).
+
+## Ports
+
+The add-on exposes the device-facing ports below (from the `ports` mapping in
+`config.yaml`). Appliances connect to the Home Assistant host on these.
+
+| Port        | Purpose                            |
+| ----------- | ---------------------------------- |
+| `4443/tcp`  | Thinq2 HTTPS (device provisioning) |
+| `8885/tcp`  | Thinq2 MQTTS (device connection)   |
+| `46030/tcp` | Thinq1 HTTPS (device provisioning) |
+| `47878/tcp` | Thinq1 device connection           |
+
+To change a host port, edit the mapping in the add-on's **Network** panel.
+Changing a port from its default may reduce compatibility with some devices.
+
+The management interface is served through **Ingress** (internal port
+`44401`); no host port is needed for it.
+
+## Data & persistence
+
+The add-on maps its `addon_config` directory to `/app/data` (read-write), so
+everything below survives restarts and updates:
+
+- `ca.key` / `ca.cert` — the generated CA/server certificate (created on first
+  run for your `hostname`).
+- `config.json` — the effective configuration rendered from your options.
+- `state/` — bridge mode state (when `bridge` is enabled).
+
+Changing `hostname` regenerates the certificate on the next start.
+
+## Notes
+
+LG ThinQ is a trademark of LG and is used here for identification only. This
+project is not affiliated with LG. It is provided WITHOUT ANY WARRANTY.

--- a/hassio/config.yaml
+++ b/hassio/config.yaml
@@ -1,0 +1,82 @@
+# Add-on identity
+name: Rethink
+version: 'dev'
+slug: rethink
+description: >-
+    De-cloud LG ThinQ appliances and bridge them to Home Assistant over MQTT.
+url: https://github.com/anszom/rethink
+arch:
+    - aarch64
+    - amd64
+    - armv7
+
+# Container image & init
+image: ghcr.io/anszom/rethink:dev
+init: true
+
+# Startup / lifecycle
+startup: application
+boot: auto
+
+# Supervisor API & services
+hassio_api: true
+services:
+    - mqtt:need
+
+# Ingress web UI panel
+ingress: true
+ingress_port: 44401
+ingress_entry: /
+panel_icon: mdi:home-automation
+panel_title: Rethink
+
+# Device-facing ports. Appliances connect to the Home Assistant host on these
+# ports once you redirect the ThinQ DNS names to the host (see docs).
+ports:
+    443/tcp: 4443
+    8883/tcp: 8885
+    46030/tcp: 46030
+    47878/tcp: 47878
+ports_description:
+    4443/tcp: Thinq2 HTTPS (device provisioning)
+    8885/tcp: Thinq2 MQTTS (device connection)
+    46030/tcp: Thinq1 HTTPS (device provisioning)
+    47878/tcp: Thinq1 device connection
+
+# User-configurable options & their defaults
+options:
+    hostname: rethink.lan
+    discovery_prefix: homeassistant
+    rethink_prefix: rethink
+    bridge: false
+    mqtt_url: ''
+    mqtt_user: ''
+    mqtt_pass: ''
+    log:
+        - status
+        - incoming
+        - HTTPS
+        - publish
+        - MGMT
+
+# Validation schema for the options above
+schema:
+    # DNS name the appliances are redirected to. Must be a hostname, not an IP. (Hassio Host: 8cdb1514-rethink)
+    hostname: str
+    discovery_prefix: str
+    rethink_prefix: str
+    # Enable ThinQ cloud bridge mode (keeps the official LG app working).
+    bridge: bool
+    # Leave mqtt_url empty to auto-use the Home Assistant MQTT service.
+    # Set it (e.g. mqtt://192.168.1.10:1883) to use an external broker.
+    mqtt_url: str?
+    mqtt_user: str?
+    mqtt_pass: password?
+    log:
+        - list(status|incoming|HTTPS|publish|MGMT|all)
+
+# Persistent storage
+map:
+    - type: addon_config
+      read_only: false
+      path: /app/data

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,3 @@
+name: Home Assistant Rethink
+url: https://github.com/anszom/rethink
+maintainer: anszom

--- a/rethink-cloud.ts
+++ b/rethink-cloud.ts
@@ -1,6 +1,6 @@
 import express from 'express'
 import stripJsonComments from 'strip-json-comments'
-import { mkdirSync, readFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync } from 'node:fs'
 import * as https from 'node:https'
 import { spawnSync } from 'node:child_process'
 import { dirname, resolve } from 'node:path'
@@ -15,6 +15,7 @@ import { DeviceAcceptor as T2Acceptor } from './cloud/thinq2/device'
 import { Connection as HA_connection } from './cloud/homeassistant'
 import HA_bridge from './cloud/ha_bridge'
 import { normalize as normalizeConfig, RawConfig, CA } from './util/config'
+import { loadHassioConfig, HASSIO_OPTIONS } from './util/hassio'
 import * as Management from './management'
 
 import log, { setFilter as setLogFilter } from './util/logging'
@@ -24,7 +25,15 @@ import { JSONStorage } from './bridge/state'
 
 const configPath = resolve(process.argv[2] ?? './config.json')
 const configDir = dirname(configPath)
-const config = normalizeConfig(JSON.parse(stripJsonComments(readFileSync(configPath).toString('utf-8'))) as RawConfig)
+let rawConfig: RawConfig
+if (existsSync(HASSIO_OPTIONS)) {
+    // Home Assistant add-on mode: build the config from the add-on options instead of a config file.
+    console.log('Home Assistant add-on mode: loading options from ' + HASSIO_OPTIONS)
+    rawConfig = await loadHassioConfig()
+} else {
+    rawConfig = JSON.parse(stripJsonComments(readFileSync(configPath).toString('utf-8'))) as RawConfig
+}
+const config = normalizeConfig(rawConfig)
 
 config.ca_key_file = resolve(configDir, config.ca_key_file)
 config.ca_cert_file = resolve(configDir, config.ca_cert_file)

--- a/tests/util/hassio.test.ts
+++ b/tests/util/hassio.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { loadHassioConfig } from '@/util/hassio'
+
+describe('loadHassioConfig', () => {
+    let dir: string
+    const write = (name: string, obj: unknown) => {
+        const p = join(dir, name)
+        writeFileSync(p, JSON.stringify(obj))
+        return p
+    }
+
+    before(() => {
+        dir = mkdtempSync(join(tmpdir(), 'rethink-hassio-'))
+        // Make sure the Supervisor lookup is never attempted in these tests.
+        delete process.env.SUPERVISOR_TOKEN
+    })
+    after(() => rmSync(dir, { recursive: true, force: true }))
+
+    test('an explicit mqtt_url is used verbatim and bridge maps to a state dir', async () => {
+        const path = write('explicit.json', {
+            hostname: 'my.lan',
+            bridge: true,
+            mqtt_url: 'mqtt://10.0.0.5:1883',
+            mqtt_user: 'u',
+            mqtt_pass: 'p',
+            log: ['status', 'all'],
+        })
+        const c = await loadHassioConfig(path)
+
+        assert.equal(c.hostname, 'my.lan')
+        assert.equal(c.homeassistant.mqtt_url, 'mqtt://10.0.0.5:1883')
+        assert.equal(c.homeassistant.mqtt_user, 'u')
+        assert.equal(c.homeassistant.mqtt_pass, 'p')
+        assert.equal(c.https_port, 443)
+        assert.equal(c.mqtts_port, 8883) // default applied
+        assert.equal(c.management_port, 44401)
+        assert.deepEqual(c.bridge, { storage_path: 'state' })
+        assert.deepEqual(c.log, ['status', 'all'])
+    })
+
+    test('empty options fall back to defaults and a localhost broker, with no bridge', async () => {
+        const path = write('empty.json', {})
+        const c = await loadHassioConfig(path)
+
+        assert.equal(c.hostname, 'rethink.lan')
+        assert.equal(c.homeassistant.mqtt_url, 'mqtt://localhost:1883')
+        assert.equal(c.homeassistant.discovery_prefix, 'homeassistant')
+        assert.equal(c.homeassistant.rethink_prefix, 'rethink')
+        assert.equal(c.advertise_requested_host, false)
+        assert.equal(c.thinq1_https_port, undefined)
+        assert.equal(c.thinq1_port, undefined)
+        assert.equal(c.bridge, undefined)
+        assert.deepEqual(c.log, ['status', 'incoming', 'HTTPS', 'publish', 'MGMT'])
+    })
+})

--- a/util/hassio.ts
+++ b/util/hassio.ts
@@ -1,0 +1,81 @@
+import { readFileSync } from 'node:fs'
+import fetch from 'node-fetch'
+import { RawConfig } from './config'
+
+// The Home Assistant Supervisor writes the add-on options to /data/options.json
+// and mounts the persistent data volume at /data. The presence of the options
+// file is what marks "add-on mode" in rethink-cloud.
+export const HASSIO_OPTIONS = '/data/options.json'
+
+// User-facing options as defined by the add-on schema (config.yaml). Everything
+// is optional here; sensible defaults are applied below.
+type Options = {
+    hostname?: string
+    discovery_prefix?: string
+    rethink_prefix?: string
+    bridge?: boolean
+    mqtt_url?: string
+    mqtt_user?: string
+    mqtt_pass?: string
+    log?: string[]
+}
+
+type MqttService = {
+    data?: { host?: string; port?: number; username?: string; password?: string }
+}
+
+// Resolve the MQTT broker: an explicit URL wins, otherwise ask the Supervisor
+// for the Home Assistant MQTT service, otherwise fall back to localhost.
+async function resolveMqtt(opts: Options): Promise<{ url: string; user: string; pass: string }> {
+    if (opts.mqtt_url) return { url: opts.mqtt_url, user: opts.mqtt_user ?? '', pass: opts.mqtt_pass ?? '' }
+
+    const token = process.env.SUPERVISOR_TOKEN
+    if (token) {
+        try {
+            const resp = await fetch('http://supervisor/services/mqtt', {
+                headers: { Authorization: `Bearer ${token}` },
+            })
+            if (resp.ok) {
+                const { data } = (await resp.json()) as MqttService
+                if (data?.host && data?.port)
+                    return {
+                        url: `mqtt://${data.host}:${data.port}`,
+                        user: data.username ?? '',
+                        pass: data.password ?? '',
+                    }
+            }
+        } catch {
+            // Supervisor unreachable or MQTT service not provided: use the fallback.
+        }
+    }
+
+    return { url: 'mqtt://localhost:1883', user: opts.mqtt_user ?? '', pass: opts.mqtt_pass ?? '' }
+}
+
+// Build a RawConfig from the add-on options. File paths (ca_*, storage_path)
+// are left relative and resolved against HASSIO_DATA by the caller.
+export async function loadHassioConfig(optionsPath: string = HASSIO_OPTIONS): Promise<RawConfig> {
+    const opts = JSON.parse(readFileSync(optionsPath).toString('utf-8')) as Options
+    const mqtt = await resolveMqtt(opts)
+
+    const config: RawConfig = {
+        hostname: opts.hostname ?? 'rethink.lan',
+        homeassistant: {
+            mqtt_url: mqtt.url,
+            discovery_prefix: opts.discovery_prefix ?? 'homeassistant',
+            rethink_prefix: opts.rethink_prefix ?? 'rethink',
+            mqtt_user: mqtt.user,
+            mqtt_pass: mqtt.pass,
+        },
+        ca_key_file: 'ca.key',
+        ca_cert_file: 'ca.cert',
+        https_port: 443,
+        mqtts_port: 8883,
+        mqtt_port: 1884,
+        management_port: 44401,
+        log: opts.log ?? ['status', 'incoming', 'HTTPS', 'publish', 'MGMT'],
+    }
+
+    if (opts.bridge) config.bridge = { storage_path: 'state' }
+    return config
+}


### PR DESCRIPTION
### Summary

This PR packages `rethink-cloud` as a native **Home Assistant add-on**, so it can
be installed from the Add-on Store, configured from the UI, and managed through
the Supervisor — no manual config file editing or separate container required.

Running as an add-on is opt-in and fully backward compatible: the existing
`config.json` flow is untouched. The add-on path only activates when the Home
Assistant Supervisor's options file (`/data/options.json`) is present.

### What's included

- **`hassio/config.yaml`** — Add-on manifest: identity, supported architectures
  (`aarch64`, `amd64`, `armv7`), device-facing ports, Ingress web UI panel,
  the `mqtt:need` service dependency, and the user-configurable options schema.
- **`hassio/DOCS.md`** — End-user documentation shown on the add-on page:
  how it works, requirements, installation, options reference, ports, and
  data/persistence notes.
- **`repository.yaml`** — Add-on repository descriptor so the repo can be added
  to Home Assistant as a custom add-on source.
- **`util/hassio.ts`** — Builds a `RawConfig` from the add-on options
  (`/data/options.json`), with sensible defaults and MQTT broker resolution.
- **`tests/util/hassio.test.ts`** — Unit tests covering option parsing, defaults,
  and MQTT resolution.
- **`rethink-cloud.ts`** — Detects add-on mode via the options file and loads the
  config from options instead of `config.json`; the file-based path is unchanged.

### How it works

1. The Supervisor writes user options to `/data/options.json` and mounts the
   persistent data volume.
2. On startup, `rethink-cloud` checks for that file. If present, it calls
   `loadHassioConfig()` to build the config from options; otherwise it reads
   `config.json` as before.
3. MQTT resolution: an explicit `mqtt_url` wins; otherwise the add-on asks the
   Supervisor for the Home Assistant MQTT service (`mqtt:need`, auto-detected);
   otherwise it falls back to `mqtt://localhost:1883`.
4. The management web interface is exposed through **Ingress**, so it opens
   directly from the add-on page with no extra port or login.

### Configuration

All options are exposed under the add-on's **Configuration** tab and validated
against the schema in `config.yaml`. Key options: `hostname`, `discovery_prefix`,
`rethink_prefix`, `bridge` (ThinQ cloud bridge mode), `mqtt_url` / `mqtt_user` /
`mqtt_pass`, and `log`. See `hassio/DOCS.md` for the full reference.

### Testing

- `tests/util/hassio.test.ts` covers option parsing, default fallbacks, and MQTT
  broker resolution (explicit URL, Supervisor service, localhost fallback).
- Backward compatibility: with no `/data/options.json`, the existing
  `config.json` flow runs unchanged.

### Notes

- Fully backward compatible — non-add-on usage is unaffected.
- LG ThinQ is a trademark of LG, used for identification only. This project is
  not affiliated with LG and is provided WITHOUT ANY WARRANTY.

<img width="1107" height="957" alt="image" src="https://github.com/user-attachments/assets/d3dc6f66-4981-444e-b635-f4676fabfc1d" />
<img width="1073" height="790" alt="image" src="https://github.com/user-attachments/assets/257f3b02-4058-4721-b43c-20d8c07f78ce" />

