### PR TITLE
Map FV1413H2BA washer model F_VA_F___W.B__QEUK

### DIFF
--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -49,6 +49,8 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['F_V__Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK, // NOTE: we reuse F_V8_Y___W_B_2QEUK as the models appear to be compatible
     ['VCDWL2QEUK']: VCDWL2QEUK, // LG F4X7511TWS front-load washer (matched on modelId VCDWL2QEUK)
     ['F_V__F___W.B_1QEUK']: F_V__F___W_B_1QEUK,
+    // FV1413H2BA front-load washer SoftAP model F_VA_F___W.B__QEUK (deviceType 201)
+    ['F_VA_F___W.B__QEUK']: F_V__F___W_B_1QEUK,
     ['F_VB_F___W.B_2QEUK']: F_VB_F___W_B_2QEUK, // LG CV74J7S2QA washer/dryer combo
     ['T1789EFH_F']: T1789EFH_F, // LG WT7300CW top-loading washer
     ['RV13U6AM8W_D_US_WIFI']: RV13U6AM8W_D_US_WIFI, // LG DLE7300WE dryer


### PR DESCRIPTION
Register F_VA_F___W.B__QEUK (deviceType 201, RTK_RTL8711am) to the existing F_V__F___W.B_1QEUK front-load AABB washer handler.

Tested on LG model FV1413H2BA, and works perfectly with existing device support.