### PR TITLE
Add CST_570004_WW cassette AC support

### DIFF
--- a/cloud/devices/RAC_056905_WW.ts
+++ b/cloud/devices/RAC_056905_WW.ts
@@ -264,6 +264,20 @@ export default class Device extends TLVDevice {
         return undefined
     }
 
+    /** True if this tag was present in a values/notify packet (value may be 0). */
+    hasTag(id: number) {
+        return this.raw_clip_state[id] != null
+    }
+
+    /**
+     * Optional features are unlocked by caps feature-words when present.
+     * Some models (e.g. CST_570004_WW cassette) omit or use different caps bits
+     * but still report the state tags — unlock from either signal.
+     */
+    hasCapOrTag(capWord: number, capBit: number, stateTag: number) {
+        return !!(this.raw_clip_state[capWord] & capBit) || this.hasTag(stateTag)
+    }
+
     initMakeSetConfig() {
         const config: DeviceDiscovery & { components: { climate: ClimateComponent } } = allowExtendedType({
             ...HADevice.config(this.meta, { name: 'LG Air Conditioner' }),
@@ -295,6 +309,31 @@ export default class Device extends TLVDevice {
             writable: false,
             read_xform: (raw) => raw / 2,
         })
+
+        // Humidity: 0x336 is tenths of a percent (850 → 85.0). Present on cassette and some other IDUs.
+        if (this.hasTag(0x336)) {
+            config.components.climate.current_humidity_topic = '$this/humidity-'
+            // Intermediate object (same pattern as filter sensors) so HA sensor fields
+            // are not excess-property-checked against ComponentInfo.
+            const humidity = {
+                platform: 'sensor',
+                unique_id: '$deviceid-humidity',
+                name: 'Humidity',
+                device_class: 'humidity',
+                unit_of_measurement: '%',
+                state_class: 'measurement',
+                suggested_display_precision: 1,
+            }
+            config.components.humidity = humidity
+            this.addField(config, {
+                id: 0x336,
+                name: '',
+                comp: 'humidity',
+                writable: false,
+                read_xform: (raw) => raw / 10,
+            })
+        }
+
         this.addField(config, {
             id: 0x1f7,
             name: 'power',
@@ -348,9 +387,12 @@ export default class Device extends TLVDevice {
                     this.setProperty('climate-power', 'OFF')
                     return null
                 }
+                // Explicit power-on: some wall RAC units wake from a mode write alone,
+                // but cassette/variants like CST_570004_WW ignore mode changes while off.
+                this.raw_clip_state[0x1f7] = 1
                 return modes2clip[val]
             },
-            write_attach: [0x1fa, 0x1fe],
+            write_attach: [0x1f7, 0x1fa, 0x1fe],
         })
 
         this.addField(config, {
@@ -394,7 +436,7 @@ export default class Device extends TLVDevice {
             write_attach: [0x1f9, 0x1fa],
         })
 
-        if (this.raw_clip_state[0x2cd] & 4) {
+        if (this.hasCapOrTag(0x2cd, 4, 0x321)) {
             config['components']['climate']['swing_modes'] = ['1', '2', '3', '4', '5', '6', 'on', 'off']
             this.addField(config, {
                 id: 0x321,
@@ -421,7 +463,7 @@ export default class Device extends TLVDevice {
             })
         }
 
-        if (this.raw_clip_state[0x2cd] & 8) {
+        if (this.hasCapOrTag(0x2cd, 8, 0x322)) {
             config['components']['climate']['swing_horizontal_modes'] = [
                 '1',
                 '2',
@@ -558,7 +600,7 @@ export default class Device extends TLVDevice {
             (raw) => raw * 10,
         )
 
-        if (this.raw_clip_state[0x2cc] & 1) {
+        if (this.hasCapOrTag(0x2cc, 1, 0x20f)) {
             this.addModeDependentConfigSwitchField(
                 config,
                 0x20f,
@@ -570,23 +612,25 @@ export default class Device extends TLVDevice {
             )
         }
 
-        const jetCool: boolean = !!(this.raw_clip_state[0x2cd] & 1)
-        const jetHeat: boolean = !!(this.raw_clip_state[0x2cd] & 2)
+        // Jet: caps bits prefer cool/heat separately; if only the state tag is present, offer both.
+        const jetBits = (this.raw_clip_state[0x2cd] ?? 0) & 3
+        const jetCool: boolean = !!(jetBits & 1) || (this.hasTag(0x323) && jetBits === 0)
+        const jetHeat: boolean = !!(jetBits & 2) || (this.hasTag(0x323) && jetBits === 0)
         if (jetCool || jetHeat) {
             this.addJetField(config, 0x323, 'jet', 'Jet', 'mdi:wind-power', jetCool, jetHeat)
         }
 
-        if (this.raw_clip_state[0x2d3] & 1) {
+        if (this.hasCapOrTag(0x2d3, 1, 0x21a)) {
             // 15h - displayed in hex as "FH"
             this.addTimerField(config, 0x21a, 'sleeptimer', 'Sleep timer', 'mdi:bed-clock', 15)
         }
 
-        if (this.raw_clip_state[0x2d3] & 4) {
+        if (this.hasCapOrTag(0x2d3, 4, 0x21c) || this.hasTag(0x21b)) {
             this.addTimerField(config, 0x21c, 'starttimer', 'Turn-on timer', 'mdi:timer-play', 24)
             this.addTimerField(config, 0x21b, 'stoptimer', 'Turn-off timer', 'mdi:timer-stop', 24)
         }
 
-        if (this.raw_clip_state[0x2cc] & 2) {
+        if (this.hasCapOrTag(0x2cc, 2, 0x20d)) {
             // Can be enabled only when running in the cooling mode
             this.addModeDependentConfigSwitchField(
                 config,
@@ -599,14 +643,10 @@ export default class Device extends TLVDevice {
             )
         }
 
-        if (this.raw_clip_state[0x2cc] & 4) {
-            const compADry = {
-                platform: 'binary_sensor',
-                unique_id: '$deviceid-autodry',
-                name: 'Auto dry',
-                icon: 'mdi:hair-dryer',
-                entity_category: 'diagnostic',
-            }
+        if (this.hasCapOrTag(0x2cc, 4, 0x20e)) {
+            // CST capture: unsolicited 0x20e 1↔0 when toggled in ThinQ; same write path as other config switches.
+            this.addConfigSwitchField(config, 0x20e, 'autodry', 'Auto dry', 'mdi:hair-dryer')
+
             const compADryRem = {
                 platform: 'sensor',
                 unique_id: '$deviceid-autodryremain',
@@ -616,16 +656,7 @@ export default class Device extends TLVDevice {
                 suggested_display_precision: 0,
                 entity_category: 'diagnostic',
             }
-            config['components']['autodry'] = compADry
             config['components']['autodryremain'] = compADryRem
-
-            this.addField(config, {
-                id: 0x20e,
-                name: '',
-                comp: 'autodry',
-                writable: false,
-                read_xform: (raw) => (raw ? 'ON' : 'OFF'),
-            })
 
             this.addField(config, {
                 id: 0x225,
@@ -943,6 +974,7 @@ export default class Device extends TLVDevice {
             name: desc,
             icon: icon,
             entity_category: 'config',
+            optimistic: true,
         }
         config['components'][name] = comp
 

--- a/cloud/devices/tlv_device.ts
+++ b/cloud/devices/tlv_device.ts
@@ -136,12 +136,13 @@ export default class TLVDevice extends HADevice {
             buf[3] == 0x00 &&
             buf[4] == 0x00 &&
             buf[5] == 0x00 &&
-            buf[6] == 0x87 &&
+            (buf[6] == 0x87 || buf[6] == 0xa7) &&
             buf[7] == 0x02 &&
             (buf[8] == 0x01 || buf[8] == 0x04) &&
             /* && buf[9] is a "sequence" number */ buf[10] == buf.length - 13
         ) {
             // ignore the CRC, we assume that the modem verifies it :/
+            // 0x87 used by RAC/WIN; 0xA7 used by CST cassette and DHUM-style modules
             log('status', this.id, 'received TLV packet')
             this.processTLV(TLV.parse(buf.subarray(11, buf.length - 2)))
         }

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -36,6 +36,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     POT_056905_WW,
     RAC_056905_WW,
     ['RAC_0B0001_WW']: RAC_056905_WW, // a different European variant (deviceType 401, RTK_RTL8720cm), same TLV handler
+    ['CST_570004_WW']: RAC_056905_WW, // cassette AC (deviceType 401, clip_hna, 0xA7 device_packet framing), same TLV handler
     WIN_056905_WW,
     ['2REF11EIDA__4']: Dev_2REF11EIDA__4,
     ['2REF11EBIVPC4']: Dev_2REF11EBIVPC4,

--- a/cloud/homeassistant.ts
+++ b/cloud/homeassistant.ts
@@ -196,4 +196,5 @@ export type ClimateComponent = ComponentInfo & {
     fan_modes?: string[]
     swing_modes?: string[]
     swing_horizontal_modes?: string[]
+    current_humidity_topic?: string
 }

--- a/tests/cloud/devices/RAC_056905_WW.test.ts
+++ b/tests/cloud/devices/RAC_056905_WW.test.ts
@@ -37,10 +37,21 @@ const QUERY_RESPONSE_HEX =
     'CC90438B40BF600155BFE00271BFA00155C0200271BE509FBE90A01B01BED050C300C340C0C0C380' +
     '3E6B'
 
-// Bytes that the device sends in response to specific HA setProperty calls.
-const WRITE_MODE_FAN_ONLY_HEX = '01010400000065020101067E427E837F80B452'
-const WRITE_MODE_HEAT_HEX = '01010400000065020101077E447E837F902AF936'
+// Bytes that the cloud sends for HA setProperty calls (includes 0x1f7 power-on with mode writes).
+const WRITE_MODE_FAN_ONLY_HEX = '01010400000065020101087E427DC17E837F80E609'
+const WRITE_MODE_HEAT_HEX = '01010400000065020101097E447DC17E837F902AFD3D'
+const WRITE_MODE_COOL_FROM_OFF_HEX = '01010400000065020101097E407DC17E887F902C8C89'
 const WRITE_POWER_OFF_HEX = '01010400000065020101027DC00576'
+
+// Caps with eeprom tag only (no 0x2CC/0x2CD/0x2D3 feature bits) — models that unlock via state tags.
+const MINIMAL_CAPS_HEX = '0000040000008702010002b6819989'
+
+// Live CST_570004_WW values reply (kind 0xa7). Unlocks humidity/autodry/airclean/etc. from tags alone.
+// Includes 0x336=850 (85.0% RH), 0x20e/0x20f/0x20d=0, 0x21a=0, 0x321=0, power on cool.
+const CST_VALUES_HEX =
+    '000004000000a70204004b7dc17e407e887f502d7f902a7f0086808840d4c0d500c84081408180c940' +
+    '8340838083c08fc0cd40cd00ccc0cda00352d56007f3d5a00960bc9089d5d03cd61020c9009c4087cb' +
+    'ac40e9c1ad27'
 
 function makeDevice() {
     const ha = new MockHAConnection()
@@ -96,8 +107,9 @@ describe(MODEL_ID, () => {
         assert.ok(components.sleeptimer, 'sleeptimer (because 0x2D3 bit 0x1)')
         assert.ok(components.starttimer, 'starttimer (because 0x2D3 bit 0x4)')
         assert.ok(components.stoptimer, 'stoptimer (because 0x2D3 bit 0x4)')
-        // Conversely, airclean (0x2CC bit 0x1) is not unlocked.
-        assert.ok(!components.airclean, 'airclean off (0x2CC bit 0x1 unset)')
+        // airclean: 0x2CC bit 0x1 is unset on this caps capture, but values include tag 0x20f=0,
+        // so tag-based unlock still registers the entity.
+        assert.ok(components.airclean, 'airclean from values tag 0x20f')
 
         // Swing modes registered because 0x2CD has both 0x4 and 0x8.
         assert.deepEqual(components.climate.swing_modes, ['1', '2', '3', '4', '5', '6', 'on', 'off'])
@@ -186,6 +198,45 @@ describe(MODEL_ID, () => {
         dev.drop()
     })
 
+    test('HA write climate-mode=cool from OFF includes power=ON', (t) => {
+        const { thinq, dev, ha } = buildReadyDevice(t)
+        // Off-state matching a CST_570004_WW capture: power=0, last mode=cool, fan=auto, set=22C
+        dev.raw_clip_state[0x1f7] = 0
+        dev.raw_clip_state[0x1f9] = 0
+        dev.raw_clip_state[0x1fa] = 8
+        dev.raw_clip_state[0x1fe] = 44
+
+        ha.setProperty(DEVICE_ID, 'climate', 'mode_command', 'cool')
+
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(hex(thinq.outbox[0]), WRITE_MODE_COOL_FROM_OFF_HEX.toUpperCase())
+        assert.equal(dev.raw_clip_state[0x1f7], 1)
+
+        dev.drop()
+    })
+
+    // CST capture: autodry toggles as unsolicited 0x20e 1↔0; write is a single-tag TLV.
+    const WRITE_AUTODRY_ON_HEX = '010104000000650201010283816D5D'
+    const WRITE_AUTODRY_OFF_HEX = '010104000000650201010283807D7C'
+
+    test('HA write autodry ON/OFF emits 0x20e TLV', (t) => {
+        const { thinq, dev, ha } = buildReadyDevice(t)
+        dev.raw_clip_state[0x20e] = 0
+
+        ha.setProperty(DEVICE_ID, 'autodry', 'command', 'ON')
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(hex(thinq.outbox[0]), WRITE_AUTODRY_ON_HEX.toUpperCase())
+        assert.equal(dev.raw_clip_state[0x20e], 1)
+
+        thinq.resetRecorder()
+        ha.setProperty(DEVICE_ID, 'autodry', 'command', 'OFF')
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(hex(thinq.outbox[0]), WRITE_AUTODRY_OFF_HEX.toUpperCase())
+        assert.equal(dev.raw_clip_state[0x20e], 0)
+
+        dev.drop()
+    })
+
     test('constructor sends a queryCaps packet on the wire', () => {
         const { thinq, dev } = makeDevice()
         if (dev.query_caps_timeout) {
@@ -194,6 +245,47 @@ describe(MODEL_ID, () => {
         }
         assert.equal(thinq.outbox.length, 1)
         assert.equal(hex(thinq.outbox[0]), CAPS_REQUEST_HEX.toUpperCase())
+        dev.drop()
+    })
+
+    test('CST values without feature-cap bits unlock humidity and diagnostics from state tags', (t) => {
+        enableMockTimers(t)
+        const { ha, thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+
+        thinq.emit('data', buf(MINIMAL_CAPS_HEX))
+        thinq.emit('data', buf(CST_VALUES_HEX))
+        // filter probe times out (no priv reply on this path)
+        tickMockTimers(t, 6000)
+
+        const device = ha.devices[DEVICE_ID]
+        assert.ok(device, 'HA configuration published')
+        const components = device.config!.components as Record<string, Record<string, unknown>>
+
+        assert.ok(components.humidity, 'humidity sensor from tag 0x336')
+        assert.equal(components.humidity.device_class, 'humidity')
+        assert.equal(components.climate.current_humidity_topic, '$this/humidity-')
+        assert.ok(components.autodry, 'autodry from tag 0x20e')
+        assert.ok(components.airclean, 'air purify from tag 0x20f')
+        assert.ok(components.energysave, 'energy save from tag 0x20d')
+        assert.ok(components.sleeptimer, 'sleep timer from tag 0x21a')
+        assert.ok(components.climate.swing_modes, 'vertical swing from tag 0x321')
+        // Horizontal swing tag absent on this capture
+        assert.ok(!components.climate.swing_horizontal_modes)
+
+        // Re-feed values so registered fields publish (initial pass was before config)
+        thinq.emit('data', buf(CST_VALUES_HEX))
+
+        assert.equal(ha.getProperty(DEVICE_ID, 'humidity', 'state'), 85)
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'current_temperature'), 22.5)
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'mode_state'), 'cool')
+        assert.equal(ha.getProperty(DEVICE_ID, 'autodry', 'state'), 'OFF')
+        assert.equal(ha.getProperty(DEVICE_ID, 'airclean', 'state'), 'OFF')
+        // Energy save only publishes while in cool (mode=0) and powered on
+        assert.equal(ha.getProperty(DEVICE_ID, 'energysave', 'state'), 'OFF')
+        assert.equal(ha.getProperty(DEVICE_ID, 'sleeptimer', 'state'), 0)
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'swing_mode_state'), 'off')
+
         dev.drop()
     })
 })

--- a/tests/util/packet-codec.test.ts
+++ b/tests/util/packet-codec.test.ts
@@ -22,6 +22,20 @@ test('decode: fromDevice TLV packet, CRC valid', () => {
     assert.ok(d.tlv.length > 0)
 })
 
+// CST_570004_WW / DHUM-style fromDevice uses kind 0xa7 instead of 0x87
+const FROM_DEVICE_A7 =
+    '000004000000a70204000c7dc17e417f902a7e887f502d19e9'
+
+test('decode: fromDevice TLV packet with kind 0xa7', () => {
+    const d = decodePacket(FROM_DEVICE_A7)
+    assert.equal(d.protocol, 'tlv')
+    if (d.protocol !== 'tlv') return
+    assert.equal(d.direction, 'fromDevice')
+    assert.equal(d.crcOk, true)
+    assert.equal(d.frame.kind, 0xa7)
+    assert.ok(d.tlv.some((t) => t.t === 0x1f7))
+})
+
 test('decode: toDevice TLV packet, CRC valid', () => {
     const d = decodePacket(TO_DEVICE)
     assert.equal(d.protocol, 'tlv')

--- a/util/packet-codec.ts
+++ b/util/packet-codec.ts
@@ -53,7 +53,7 @@ export type DecodedTlv = {
     crcOk: boolean
     tlv: TLV.TLV[]
     frame: {
-        kind: number // uart byte4: 0x87 fromDevice, 0x65 toDevice
+        kind: number // uart byte4: 0x87/0xa7 fromDevice, 0x65 toDevice
         byte5: number
         byte6: number
         byte7: number
@@ -159,8 +159,9 @@ export function decodePacket(hex: string): Decoded {
     }
 
     // TLV: identify by the uart "kind" byte at index 6
-    if (buf.length >= 13 && buf[2] === 0x04 && (buf[6] === 0x87 || buf[6] === 0x65)) {
-        const fromDevice = buf[6] === 0x87
+    // 0x87 = classic RAC/WIN fromDevice; 0xa7 = CST/DHUM/POT-style fromDevice; 0x65 = toDevice
+    if (buf.length >= 13 && buf[2] === 0x04 && (buf[6] === 0x87 || buf[6] === 0xa7 || buf[6] === 0x65)) {
+        const fromDevice = buf[6] === 0x87 || buf[6] === 0xa7
         const len = buf[10]
         if (11 + len + 2 > buf.length) {
             return { protocol: 'unknown', hex, reason: 'TLV length field overruns buffer' }


### PR DESCRIPTION
Map cassette model CST_570004_WW to the RAC TLV handler and accept 0xA7 fromDevice framing in tlv_device (required for this platform). Explicitly power on with non-off climate mode writes; unlock autodry, air purify, energy save, timers, and swing from state tags when caps bits are missing; expose 0x336 humidity sensor. Decode 0xA7 in packet-codec; autodry is a writable switch.

LG AC Cassette models tested: `ARNU36GTNA4` and `ARNU18GTQA4`. Internal model `CST_570004_WW` reported. These models don't have built-in wifi; was connected using wifi module accessory `PWFMDD200` through wifi module port on main board.

This has one unique feature: humidity reporting. All other features are generic to other devices as well.

This did require some refactoring due to difference in behavior vs base device. Tested base device on other compatible units without issue; no regressions found.