### PR TITLE
Add RH10V9_CH heat-pump dryer support

### DIFF
--- a/cloud/devices/RH10V9_CH.ts
+++ b/cloud/devices/RH10V9_CH.ts
@@ -1,0 +1,162 @@
+import HADevice from './base'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import AABBDevice from './aabb_device'
+import log from '@/util/logging'
+
+/**
+ * LG heat-pump dryer — SoftAP model RH10V9_CH (deviceType 202, e.g. RH10V9 family).
+ *
+ * AABB frames (inner body after AA/len, before checksum/BB):
+ *   0x30 0xEB + 27-byte record   — single status (poll reply / reconnect)
+ *   0x30 0xEC + 27B prev + 27B curr — dual status (unsolicited updates)
+ *
+ * Same dryer family byte 0x30 as US RV13* units, but records are 27B (not 28/29)
+ * and omit the 0x1b marker used on some NA models.
+ *
+ * Record layout (from live polls):
+ *   rec[0]  remaining hours
+ *   rec[1]  remaining minutes
+ *   rec[2]  phase/status (0=off, 1=initial, … — drying codes not yet seen live)
+ *   rec[17] options bitfield (seen 0x00 / 0x08)
+ *   rec[21] unknown (seen 0x00 idle-awake, 0x03 while module reported off)
+ *   rec[25] constant 0x75 in all captures so far
+ *
+ * 0x30 0x31 — identity/serial frame (SAA…), ignored for state.
+ *
+ * Monitor enable F0ED1121… is required; without it the module only MQTT-pings.
+ * Note: polls often return a frozen MCU snapshot. If the panel is used only
+ * locally without remote/smart features, running-state bytes may never update.
+ */
+
+const RECORD_LEN = 27
+
+const STATUS: Record<number, string> = {
+    0x00: 'Off',
+    0x01: 'Initial',
+    0x03: 'Pause',
+    0x32: 'Drying',
+    0x33: 'Cooling',
+    0x04: 'End',
+}
+
+export default class Device extends AABBDevice {
+    private monitorTimer: ReturnType<typeof setInterval> | undefined
+
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: 'LG Dryer' }),
+                components: {
+                    power: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-power',
+                        state_topic: '$this/power',
+                        name: 'Power',
+                        icon: 'mdi:tumble-dryer',
+                        device_class: 'running',
+                    },
+                    status: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-status',
+                        state_topic: '$this/status',
+                        name: 'Status',
+                        icon: 'mdi:state-machine',
+                    },
+                    remaining_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-remaining_time',
+                        state_topic: '$this/remaining_time',
+                        name: 'Remaining time',
+                        icon: 'mdi:timer-outline',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                    },
+                    // Diagnostic raw fields until course/temp/dry-level are mapped
+                    flags: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-flags',
+                        state_topic: '$this/flags',
+                        name: 'Flags (raw)',
+                        icon: 'mdi:flag',
+                        entity_category: 'diagnostic',
+                    },
+                    raw_b21: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-raw_b21',
+                        state_topic: '$this/raw_b21',
+                        name: 'Raw byte 21',
+                        icon: 'mdi:numeric',
+                        entity_category: 'diagnostic',
+                    },
+                },
+            }),
+        )
+    }
+
+    start() {
+        this.sendMonitorEnable()
+        // A few retries while the dryer MCU wakes; then stop spamming.
+        let n = 0
+        this.monitorTimer = setInterval(() => {
+            this.sendMonitorEnable()
+            if (++n >= 8 && this.monitorTimer) {
+                clearInterval(this.monitorTimer)
+                this.monitorTimer = undefined
+            }
+        }, 15_000)
+    }
+
+    drop() {
+        if (this.monitorTimer) {
+            clearInterval(this.monitorTimer)
+            this.monitorTimer = undefined
+        }
+        super.drop()
+    }
+
+    private sendMonitorEnable() {
+        // Laundry-style unsolicited-status enable (required on this model).
+        log('status', this.id, 'RH10V9: monitor enable')
+        this.send(Buffer.from('F0ED1121010000001800', 'hex'))
+    }
+
+    private processRecord(rec: Buffer) {
+        if (rec.length < RECORD_LEN) return
+
+        const phase = rec[2]
+        const remaining = rec[0] * 60 + rec[1]
+        const flags = rec[17]
+        const b21 = rec[21]
+
+        this.publishProperty('status', STATUS[phase] ?? `0x${phase.toString(16)}`)
+        this.publishProperty('remaining_time', remaining)
+        this.publishProperty('power', phase !== 0 ? 'ON' : 'OFF')
+        this.publishProperty('flags', flags)
+        this.publishProperty('raw_b21', b21)
+    }
+
+    processAABB(buf: Buffer) {
+        if (buf[0] !== 0x30) return
+
+        // Device identity / serial (SAA…) — no cycle state
+        if (buf[1] === 0x31) return
+
+        if (buf[1] === 0xeb && buf.length === 2 + RECORD_LEN) {
+            // Single 27-byte status record
+            this.processRecord(buf.subarray(2, 2 + RECORD_LEN))
+        } else if (buf[1] === 0xec && buf.length === 2 + 2 * RECORD_LEN) {
+            // Dual records: previous then current (use current = second half)
+            this.processRecord(buf.subarray(2 + RECORD_LEN, 2 + 2 * RECORD_LEN))
+        } else {
+            log('status', this.id, 'RH10V9 unhandled AABB', buf.toString('hex'))
+        }
+    }
+
+    setProperty(_prop: string, _mqttValue: string) {
+        // Read-only for now
+    }
+}

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -18,6 +18,7 @@ import RV13U6AM8W_D_US_WIFI from './devices/RV13U6AM8W_D_US_WIFI'
 import F3L2CYU__ from './devices/F3L2CYU__'
 import RV13B6BSD_D_US_WIFI from './devices/RV13B6BSD_D_US_WIFI'
 import WTL_FXU_BDV_NA_01 from './devices/WTL_FXU_BDV_NA_01'
+import RH10V9_CH from './devices/RH10V9_CH'
 import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
 import { type Connection } from './homeassistant'
@@ -54,6 +55,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['RV13U6AM8W_D_US_WIFI']: RV13U6AM8W_D_US_WIFI, // LG DLE7300WE dryer
     ['F3L2CYU__']: F3L2CYU__, // LG front-load washer
     ['RV13B6BSD_D_US_WIFI']: RV13B6BSD_D_US_WIFI, // LG electric dryer
+    ['RH10V9_CH']: RH10V9_CH, // LG heat-pump dryer (e.g. RV10VHP2V SoftAP model RH10V9_CH)
     WTL_FXU_BDV_NA_01, // LG WashTower
 }
 

--- a/tests/cloud/devices/RH10V9_CH.test.ts
+++ b/tests/cloud/devices/RH10V9_CH.test.ts
@@ -1,0 +1,109 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/RH10V9_CH'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf, hex } from '@/tests/helpers/mocks'
+import { enableMockTimers, tickMockTimers } from '@/tests/helpers/timers'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'RH10V9_CH'
+const META: Metadata = { modelId: MODEL_ID, modelName: 'RH10V9_CH', swVersion: '2.10.114' }
+
+// Live captures from RH10V9_CH (heat-pump dryer) after F0ED monitor enable.
+
+// 0xEB poll reply: phase=0x01 (Initial), remaining 0h25m, flags=0
+const SAMPLE_EB_IDLE = buf('AA2130EB00190100000000000000000000000000000000000000000000750020BB')
+
+// 0xEB after flag change: phase=0x01, remaining 25m, flags=0x08
+const SAMPLE_EB_FLAGS = buf('AA2130EB00190100000000000000000000000000000800000000000000750028BB')
+
+// 0xEC dual: prev flags=0, curr flags=0x08; both phase=Initial, 25m remaining
+const SAMPLE_EC = buf(
+    'AA3C30EC001901000000000000000000000000000000000000000000007500' +
+        '0019010000000000000000000000000000080000000000000075007DBB',
+)
+
+// Synthetic 0xEB: phase=0x32 (Drying), remaining 1h05m=65 (checksum not validated by driver)
+const SAMPLE_EB_DRYING = buf(
+    'AA2130EB' + '010532' + '00'.repeat(22) + '7500' + '00BB',
+)
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('start sends laundry monitor-enable F0ED', (t) => {
+        enableMockTimers(t)
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.start()
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(hex(thinq.outbox[0]), 'AA0EF0ED1121010000001800B5BB')
+        dev.drop()
+    })
+
+    test('0xEB idle publishes Initial, 25 min remaining, power ON', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', SAMPLE_EB_IDLE)
+        assert.equal(ha.getProperty(DEVICE_ID, 'status', 'state'), 'Initial')
+        assert.equal(ha.getProperty(DEVICE_ID, 'remaining_time', 'state'), 25)
+        assert.equal(ha.getProperty(DEVICE_ID, 'power', 'state'), 'ON')
+        assert.equal(ha.getProperty(DEVICE_ID, 'flags', 'state'), 0)
+        dev.drop()
+    })
+
+    test('0xEB publishes flags byte when set', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', SAMPLE_EB_FLAGS)
+        assert.equal(ha.getProperty(DEVICE_ID, 'flags', 'state'), 8)
+        assert.equal(ha.getProperty(DEVICE_ID, 'remaining_time', 'state'), 25)
+        dev.drop()
+    })
+
+    test('0xEC uses current (second) record', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', SAMPLE_EC)
+        assert.equal(ha.getProperty(DEVICE_ID, 'status', 'state'), 'Initial')
+        assert.equal(ha.getProperty(DEVICE_ID, 'remaining_time', 'state'), 25)
+        assert.equal(ha.getProperty(DEVICE_ID, 'flags', 'state'), 8)
+        dev.drop()
+    })
+
+    test('0xEB drying phase and hour:minute remaining', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', SAMPLE_EB_DRYING)
+        assert.equal(ha.getProperty(DEVICE_ID, 'status', 'state'), 'Drying')
+        assert.equal(ha.getProperty(DEVICE_ID, 'remaining_time', 'state'), 65)
+        assert.equal(ha.getProperty(DEVICE_ID, 'power', 'state'), 'ON')
+        dev.drop()
+    })
+
+    test('0x31 identity frame is ignored', () => {
+        const { ha, thinq, dev } = makeDevice()
+        const idFrame = buf(
+            'AA373031020153414133383439303532370146129B000040000000000002534141333939333439353600000AC20000400000000000D2BB',
+        )
+        thinq.emit('data', idFrame)
+        assert.equal(ha.getProperty(DEVICE_ID, 'status', 'state'), undefined)
+        dev.drop()
+    })
+
+    test('monitor retries then stops', (t) => {
+        enableMockTimers(t)
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.start()
+        assert.equal(thinq.outbox.length, 1)
+        tickMockTimers(t, 15_000 * 8)
+        // initial + 8 interval fires
+        assert.ok(thinq.outbox.length >= 9)
+        const after = thinq.outbox.length
+        tickMockTimers(t, 15_000 * 3)
+        assert.equal(thinq.outbox.length, after, 'no more polls after 8 retries')
+        dev.drop()
+    })
+})


### PR DESCRIPTION
Add RH10V9_CH (deviceType 202) support.

Tested on LG dryer model RV10VHP2V.

Note: Has basic reporting and functionality, but a lot of core features still missing (TBD).