### PR TITLE
docs: link tested Home Assistant app package

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ Most of the findings from the reverse engineering process are available on the [
 
 See the [instructions](https://github.com/anszom/rethink/wiki/Installing-rethink‐cloud).
 
+### Home Assistant OS / Supervised
+
+Home Assistant OS and Supervised users can install the community-maintained
+[LG ThinQ Local Home Assistant App](https://github.com/akinin/rethink-home-assistant-app).
+It packages the upstream `rethink` image without forking the server code and includes
+Ingress, persistent configuration, MQTT integration, and bilingual documentation.
+
+The package is currently tested on `amd64`. Add the repository URL below to the Home
+Assistant app store, then follow the [English setup guide](https://github.com/akinin/rethink-home-assistant-app/blob/main/rethink/DOCS.en.md):
+
+```text
+https://github.com/akinin/rethink-home-assistant-app
+```
+
 ## Management
 
 A simple web interface is available on a user-defined port (default: 44401). The interface supports:


### PR DESCRIPTION
## Summary

- document the tested community-maintained Home Assistant OS / Supervised package
- link the English installation guide and the repository URL used by the app store
- clarify that the package wraps the upstream `rethink` image instead of forking server development
- state the currently tested `amd64` architecture

## Context

This provides an immediately usable path for the Home Assistant use case tracked in #34 while the native in-tree implementation in #127 is being reviewed. The change is deliberately documentation-only so it does not duplicate or conflict with that work.

The package repository is:
https://github.com/akinin/rethink-home-assistant-app

## Verification

- Prettier check passed
- TypeScript build passed
- upstream test suite passed: 343/343
