### PR TITLE
feat(dishwasher): Add LG Dishwasher (H11) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The following appliances are currently supported in rethink:
     - 👍 DLEX3900B (RV13B6BSD_D_US_WIFI), Electric Dryer - mostly working
 - WashTowers (combined washer+dryer):
     - 👍 WKEX200HBA (WTL_FXU_BDV_NA_01), WashTower - mostly working
+- Dishwashers:
+    - 👍 DUE2BG.AKOR (H11), Dishwasher - mostly working
 
 The supported appliances can be used "out of the box" with HomeAssistant or another compatible MQTT consumer.  
 Appliances not listed above can still be used with the bridge mode, but they will not be translated to MQTT. Contributions are welcome!

--- a/cloud/devices/H11.ts
+++ b/cloud/devices/H11.ts
@@ -1,0 +1,232 @@
+import HADevice from './base'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { DeviceDiscovery, type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import AABBDevice from './aabb_device'
+
+const DISHWASHER_STATES: Record<number, string> = {
+    1: 'INITIAL',
+    2: 'RUNNING',
+    3: 'PAUSE',
+    4: 'STANDBY',
+}
+
+const COURSES: Record<number, string> = {
+    0x00: 'OFF',
+    0x01: 'AUTO',
+    0x12: 'ONE_HOUR',
+    0x05: 'NORMAL/ECO',
+    0x02: 'HEAVY/INTENSIVE',
+    0x10: 'SILENT_NIGHT',
+    0x08: 'EXPRESS',
+    0x0b: 'DOWNLOAD_CYCLE',
+    0x09: 'MACHINE_CLEAN',
+}
+
+const SMART_COURSES: Record<number, string> = {
+    0x05: 'GREASY_TABLEWARE',
+    0x0d: 'MACHINE_CLEAN',
+    0x0f: 'PLASTIC_WASH',
+}
+
+const RINSE_LEVELS: Record<number, string> = {
+    0x00: 'OFF',
+    0x10: 'LEVEL_1',
+    0x20: 'LEVEL_2',
+    0x30: 'LEVEL_3',
+}
+
+export default class Device extends AABBDevice {
+    readonly deviceConfig: DeviceDiscovery
+
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        this.deviceConfig = HADevice.config(meta, { name: 'LG Dishwasher' })
+
+        this.setConfig(
+            allowExtendedType({
+                ...this.deviceConfig,
+                components: {
+                    power: {
+                        platform: 'switch',
+                        unique_id: '$deviceid-power',
+                        state_topic: '$this/power',
+                        command_topic: '$this/power/set',
+                        name: 'Power',
+                        icon: 'mdi:power',
+                    },
+                    state: {
+                        platform: 'sensor',
+                        icon: 'mdi:washing-machine',
+                        unique_id: '$deviceid-state',
+                        state_topic: '$this/state',
+                        name: 'State',
+                    },
+                    course: {
+                        platform: 'sensor',
+                        icon: 'mdi:dishwasher',
+                        unique_id: '$deviceid-course',
+                        state_topic: '$this/course',
+                        name: 'Course',
+                    },
+                    remain_time: {
+                        platform: 'sensor',
+                        icon: 'mdi:timer-sand',
+                        unique_id: '$deviceid-remain_time',
+                        state_topic: '$this/remain_time',
+                        name: 'Remain Time',
+                        unit_of_measurement: 'min',
+                    },
+                    course_time: {
+                        platform: 'sensor',
+                        icon: 'mdi:timer',
+                        unique_id: '$deviceid-course_time',
+                        state_topic: '$this/course_time',
+                        name: 'Course Time',
+                        unit_of_measurement: 'min',
+                    },
+                    door: {
+                        platform: 'binary_sensor',
+                        device_class: 'door',
+                        unique_id: '$deviceid-door',
+                        state_topic: '$this/door',
+                        name: 'Door',
+                        payload_on: 'OPEN',
+                        payload_off: 'CLOSE',
+                    },
+                    high_temp_dry: {
+                        platform: 'binary_sensor',
+                        icon: 'mdi:weather-sunny',
+                        unique_id: '$deviceid-high_temp_dry',
+                        state_topic: '$this/high_temp_dry',
+                        name: 'High Temp Dry',
+                        payload_on: 'ON',
+                        payload_off: 'OFF',
+                    },
+                    sterilize: {
+                        platform: 'binary_sensor',
+                        icon: 'mdi:thermometer-high',
+                        unique_id: '$deviceid-sterilize',
+                        state_topic: '$this/sterilize',
+                        name: 'Sterilize',
+                        payload_on: 'ON',
+                        payload_off: 'OFF',
+                    },
+                    rinse_level: {
+                        platform: 'sensor',
+                        icon: 'mdi:water-plus',
+                        unique_id: '$deviceid-rinse_level',
+                        state_topic: '$this/rinse_level',
+                        name: 'Rinse Level',
+                    },
+                    delay_start: {
+                        platform: 'sensor',
+                        icon: 'mdi:clock-fast',
+                        unique_id: '$deviceid-delay_start',
+                        state_topic: '$this/delay_start',
+                        name: 'Delay Start (Hours)',
+                        unit_of_measurement: 'h',
+                    },
+                    remote_start: {
+                        platform: 'binary_sensor',
+                        icon: 'mdi:remote',
+                        unique_id: '$deviceid-remote_start',
+                        state_topic: '$this/remote_start',
+                        name: 'Remote Start',
+                        payload_on: 'ON',
+                        payload_off: 'OFF',
+                    },
+                },
+            }),
+        )
+    }
+
+    setProperty(prop: string, mqttValue: string) {
+        if (prop === 'power') {
+            if (mqttValue === 'ON') {
+                this.send(Buffer.from('F02616', 'hex')) // Wake Up
+            } else if (mqttValue === 'OFF') {
+                this.send(Buffer.from('F02612', 'hex')) // Immediate Power Off
+            }
+        }
+    }
+
+    processAABB(buf: Buffer) {
+        if (buf[0] === 0x32 && buf[1] === 0xec) {
+            const payloadLen = buf.length - 2
+            const halfLen = Math.floor(payloadLen / 2)
+            if (halfLen > 10) {
+                const curStatus = buf.subarray(2 + halfLen, buf.length)
+                this.processStatus(curStatus)
+            }
+        }
+    }
+
+    processStatus(curStatus: Buffer) {
+        if (curStatus[0] === 0x00 && curStatus[1] === 0x18) {
+            const data = curStatus.subarray(2, 26) // 24 bytes
+
+            const stateCode = data[0]
+            const processCode = data[1]
+            const stateStr = DISHWASHER_STATES[stateCode] || `UNKNOWN(${stateCode})`
+
+            // 전원 상태는 STANDBY(4) 이거나 취소 중(processCode: 0x63)일 때 OFF로 처리하여 스위치 튕김 방지
+            const isPowerOff = stateCode === 4 || processCode === 0x63
+
+            this.publishProperty('state', stateStr)
+            this.publishProperty('power', isPowerOff ? 'OFF' : 'ON')
+
+            // Course (Index 5)
+            const baseCourseCode = data[5]
+            const smartCourseCode = data[20]
+
+            let courseStr = ''
+            if (smartCourseCode !== 0) {
+                // If a smart course is active, use it instead of the base course
+                courseStr =
+                    SMART_COURSES[smartCourseCode] ||
+                    `DOWNLOAD_COURSE(0x${smartCourseCode.toString(16).padStart(2, '0')})`
+            } else {
+                courseStr = COURSES[baseCourseCode] || `UNKNOWN(0x${baseCourseCode.toString(16).padStart(2, '0')})`
+            }
+
+            this.publishProperty('course', courseStr)
+
+            // Initial(Course) Time (Index 3: hour, Index 4: minute)
+            const initialHour = data[3]
+            const initialMinute = data[4]
+            this.publishProperty('course_time', initialHour * 60 + initialMinute)
+
+            // Remain Time (Index 7: hour, Index 8: minute)
+            const remainHour = data[7]
+            const remainMinute = data[8]
+            this.publishProperty('remain_time', remainHour * 60 + remainMinute)
+
+            // Delay Start Hour (Index 9)
+            const delayHour = data[9]
+            this.publishProperty('delay_start', delayHour)
+
+            // Door (Index 11 bit 0x02)
+            const isDoorOpen = (data[11] & 0x02) !== 0
+            this.publishProperty('door', isDoorOpen ? 'OPEN' : 'CLOSE')
+
+            // High Temp Dry (Index 12 bit 0x04)
+            const isExtraDry = (data[12] & 0x04) !== 0
+            this.publishProperty('high_temp_dry', isExtraDry ? 'ON' : 'OFF')
+
+            // Sterilize (Index 12 bit 0x08)
+            const isHighTemp = (data[12] & 0x08) !== 0
+            this.publishProperty('sterilize', isHighTemp ? 'ON' : 'OFF')
+
+            // Remote Start (Index 15 bit 0x02)
+            const isRemoteStart = (data[15] & 0x02) !== 0
+            this.publishProperty('remote_start', isRemoteStart ? 'ON' : 'OFF')
+
+            // Rinse Level (Index 21)
+            const rinseCode = data[21]
+            const rinseStr = RINSE_LEVELS[rinseCode] || `UNKNOWN(${rinseCode})`
+            this.publishProperty('rinse_level', rinseStr)
+        }
+    }
+}

--- a/cloud/devices/H11.ts
+++ b/cloud/devices/H11.ts
@@ -40,21 +40,24 @@ const RINSE_LEVELS: Record<number, string> = {
 export default class Device extends AABBDevice {
     readonly deviceConfig: DeviceDiscovery
 
-    targetCourse: number = 0x01
-    targetDelay: number = 0
-    targetHighTemp: boolean = false
-    targetExtraDry: boolean = false
-    targetExtraRinse: number = 0
+    // Cache states to allow partial updates via SET command
+    private targetCourse: number = 0x01
+    private targetDelay: number = 0
+    private targetExtraRinse: number = 0
+    private targetHighTemp: boolean = false
+    private targetExtraDry: boolean = false
 
-    // Cached setting states
-    cachedRinseLevel: number = 0
-    cachedSaltLevel: number = 0
-    cachedBuzzerLevel: string = 'LOW'
-    cachedEndAlarmSound: boolean = false
-    cachedCleanReminder: boolean = false
-    cachedAutoDry: boolean = false
-    cachedBrightness: boolean = false
-    cachedRemoteStartMode: string = 'ONE_TIME'
+    private cachedRinseLevel: number = 2
+    private cachedSaltLevel: number = 2
+    private cachedBuzzerLevel: string = 'HIGH'
+    private cachedEndAlarmSound: boolean = true
+    private cachedCleanReminder: boolean = true
+    private cachedAutoDry: boolean = true
+    private cachedBrightness: boolean = true
+    private cachedRemoteStartMode: string = 'OFF'
+
+    private lastStatSequence: number = -1
+
     constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
         super(HA, thinq)
         this.deviceConfig = HADevice.config(meta, { name: 'LG Dishwasher' })
@@ -109,6 +112,16 @@ export default class Device extends AABBDevice {
                         name: 'Door',
                         payload_on: 'OPEN',
                         payload_off: 'CLOSE',
+                    },
+                    energy_consumption: {
+                        platform: 'sensor',
+                        device_class: 'energy',
+                        state_class: 'total_increasing',
+                        unique_id: '$deviceid-energy_consumption',
+                        state_topic: '$this/energy_consumption',
+                        name: 'Energy Consumption',
+                        unit_of_measurement: 'Wh',
+                        icon: 'mdi:flash',
                     },
                     high_temp_dry: {
                         platform: 'binary_sensor',
@@ -454,7 +467,24 @@ export default class Device extends AABBDevice {
                 const curStatus = buf.subarray(2 + halfLen, buf.length)
                 this.processStatus(curStatus)
             }
+        } else if (buf[0] === 0x32 && buf[1] === 0x3e) {
+            this.processStatistics(buf)
         }
+    }
+
+    processStatistics(buf: Buffer) {
+        if (buf.length < 7) return
+
+        const sequence = buf[6]
+        if (sequence === this.lastStatSequence) {
+            // Deduplicate burst packets
+            return
+        }
+        this.lastStatSequence = sequence
+
+        // 32 3e [Delta Wh 2B] [Accum Wh 2B] [Seq]
+        const energyAccum = buf.readUInt16BE(4)
+        this.publishProperty('energy_consumption', energyAccum.toString())
     }
 
     processStatus(curStatus: Buffer) {

--- a/cloud/devices/H11.ts
+++ b/cloud/devices/H11.ts
@@ -40,6 +40,12 @@ const RINSE_LEVELS: Record<number, string> = {
 export default class Device extends AABBDevice {
     readonly deviceConfig: DeviceDiscovery
 
+    targetCourse: number = 0x01
+    targetDelay: number = 0
+    targetHighTemp: boolean = false
+    targetExtraDry: boolean = false
+    targetExtraRinse: number = 0
+
     constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
         super(HA, thinq)
         this.deviceConfig = HADevice.config(meta, { name: 'LG Dishwasher' })
@@ -137,9 +143,108 @@ export default class Device extends AABBDevice {
                         payload_on: 'ON',
                         payload_off: 'OFF',
                     },
+                    pause: {
+                        platform: 'button',
+                        icon: 'mdi:pause',
+                        unique_id: '$deviceid-pause',
+                        command_topic: '$this/pause/set',
+                        name: 'Pause',
+                        payload_press: 'PRESS',
+                    },
+                    resume: {
+                        platform: 'button',
+                        icon: 'mdi:play',
+                        unique_id: '$deviceid-resume',
+                        command_topic: '$this/resume/set',
+                        name: 'Resume',
+                        payload_press: 'PRESS',
+                    },
+                    cancel: {
+                        platform: 'button',
+                        icon: 'mdi:stop',
+                        unique_id: '$deviceid-cancel',
+                        command_topic: '$this/cancel/set',
+                        name: 'Cancel / Drain Stop',
+                        payload_press: 'PRESS',
+                    },
+                    target_course: {
+                        platform: 'select',
+                        icon: 'mdi:washing-machine',
+                        unique_id: '$deviceid-target_course',
+                        state_topic: '$this/target_course',
+                        command_topic: '$this/target_course/set',
+                        name: 'Target Course',
+                        options: [
+                            'AUTO',
+                            'ONE_HOUR',
+                            'NORMAL/ECO',
+                            'HEAVY/INTENSIVE',
+                            'SILENT_NIGHT',
+                            'EXPRESS',
+                            'DOWNLOAD_CYCLE',
+                            'MACHINE_CLEAN',
+                        ],
+                    },
+                    target_delay: {
+                        platform: 'number',
+                        icon: 'mdi:clock-start',
+                        unique_id: '$deviceid-target_delay',
+                        state_topic: '$this/target_delay',
+                        command_topic: '$this/target_delay/set',
+                        name: 'Delay Start Hour',
+                        min: 0,
+                        max: 12,
+                        step: 1,
+                    },
+                    target_high_temp: {
+                        platform: 'switch',
+                        icon: 'mdi:thermometer-high',
+                        unique_id: '$deviceid-target_high_temp',
+                        state_topic: '$this/target_high_temp',
+                        command_topic: '$this/target_high_temp/set',
+                        name: 'High Temp',
+                        payload_on: 'ON',
+                        payload_off: 'OFF',
+                    },
+                    target_extra_dry: {
+                        platform: 'switch',
+                        icon: 'mdi:weather-sunny',
+                        unique_id: '$deviceid-target_extra_dry',
+                        state_topic: '$this/target_extra_dry',
+                        command_topic: '$this/target_extra_dry/set',
+                        name: 'Extra Dry',
+                        payload_on: 'ON',
+                        payload_off: 'OFF',
+                    },
+                    target_extra_rinse: {
+                        platform: 'select',
+                        icon: 'mdi:water-plus',
+                        unique_id: '$deviceid-target_extra_rinse',
+                        state_topic: '$this/target_extra_rinse',
+                        command_topic: '$this/target_extra_rinse/set',
+                        name: 'Extra Rinse',
+                        options: ['0', '1', '2', '3'],
+                    },
+                    start_course: {
+                        platform: 'button',
+                        icon: 'mdi:play-circle',
+                        unique_id: '$deviceid-start_course',
+                        command_topic: '$this/start_course/set',
+                        name: 'Start Course',
+                        payload_press: 'PRESS',
+                    },
                 },
             }),
         )
+    }
+
+    start() {
+        super.start()
+        this.publishProperty('target_course', 'AUTO')
+        this.publishProperty('target_delay', 0)
+        this.publishProperty('target_high_temp', 'OFF')
+        this.publishProperty('target_extra_dry', 'OFF')
+        this.publishProperty('target_extra_rinse', '0')
     }
 
     setProperty(prop: string, mqttValue: string) {
@@ -149,6 +254,62 @@ export default class Device extends AABBDevice {
             } else if (mqttValue === 'OFF') {
                 this.send(Buffer.from('F02612', 'hex')) // Immediate Power Off
             }
+        } else if (prop === 'pause') {
+            this.send(Buffer.from('F02613', 'hex')) // Pause
+        } else if (prop === 'resume') {
+            this.send(Buffer.from('F02614', 'hex')) // Resume
+        } else if (prop === 'cancel') {
+            this.send(Buffer.from('F02611', 'hex')) // Course Cancel / Drain Stop
+        } else if (prop === 'target_course') {
+            const coursesReverse: Record<string, number> = {
+                AUTO: 0x01,
+                ONE_HOUR: 0x12,
+                'NORMAL/ECO': 0x05,
+                'HEAVY/INTENSIVE': 0x02,
+                SILENT_NIGHT: 0x10,
+                EXPRESS: 0x08,
+                DOWNLOAD_CYCLE: 0x0b,
+                MACHINE_CLEAN: 0x09,
+            }
+            if (coursesReverse[mqttValue]) {
+                this.targetCourse = coursesReverse[mqttValue]
+                this.publishProperty('target_course', mqttValue)
+            }
+        } else if (prop === 'target_delay') {
+            const val = parseInt(mqttValue, 10)
+            if (!isNaN(val)) {
+                this.targetDelay = val
+                this.publishProperty('target_delay', val)
+            }
+        } else if (prop === 'target_high_temp') {
+            this.targetHighTemp = mqttValue === 'ON'
+            this.publishProperty('target_high_temp', mqttValue)
+        } else if (prop === 'target_extra_dry') {
+            this.targetExtraDry = mqttValue === 'ON'
+            this.publishProperty('target_extra_dry', mqttValue)
+        } else if (prop === 'target_extra_rinse') {
+            const val = parseInt(mqttValue, 10)
+            if (!isNaN(val)) {
+                this.targetExtraRinse = val
+                this.publishProperty('target_extra_rinse', mqttValue)
+            }
+        } else if (prop === 'start_course') {
+            // f0 26 10 [Course] [DelayHour] [Opt2] [Opt3] [Opt4] [Opt5]
+            let opt3 = 0
+            if (this.targetHighTemp) opt3 |= 0x08
+            if (this.targetExtraDry) opt3 |= 0x04
+
+            let opt4 = 0
+            if (this.targetExtraRinse === 1) opt4 |= 0x08
+            else if (this.targetExtraRinse === 2) opt4 |= 0x10
+            else if (this.targetExtraRinse === 3) opt4 |= 0x18
+
+            if (this.targetCourse === 0x0b) {
+                // Download cycle flag
+                opt4 |= 0x40
+            }
+
+            this.send(Buffer.from([0xf0, 0x26, 0x10, this.targetCourse, this.targetDelay, 0x00, opt3, opt4, 0x00]))
         }
     }
 

--- a/cloud/devices/H11.ts
+++ b/cloud/devices/H11.ts
@@ -46,6 +46,15 @@ export default class Device extends AABBDevice {
     targetExtraDry: boolean = false
     targetExtraRinse: number = 0
 
+    // Cached setting states
+    cachedRinseLevel: number = 0
+    cachedSaltLevel: number = 0
+    cachedBuzzerLevel: string = 'LOW'
+    cachedEndAlarmSound: boolean = false
+    cachedCleanReminder: boolean = false
+    cachedAutoDry: boolean = false
+    cachedBrightness: boolean = false
+    cachedRemoteStartMode: string = 'ONE_TIME'
     constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
         super(HA, thinq)
         this.deviceConfig = HADevice.config(meta, { name: 'LG Dishwasher' })
@@ -120,11 +129,84 @@ export default class Device extends AABBDevice {
                         payload_off: 'OFF',
                     },
                     rinse_level: {
-                        platform: 'sensor',
+                        platform: 'number',
                         icon: 'mdi:water-plus',
                         unique_id: '$deviceid-rinse_level',
                         state_topic: '$this/rinse_level',
+                        command_topic: '$this/rinse_level/set',
                         name: 'Rinse Level',
+                        min: 0,
+                        max: 4,
+                        step: 1,
+                    },
+                    salt_level: {
+                        platform: 'number',
+                        icon: 'mdi:shaker',
+                        unique_id: '$deviceid-salt_level',
+                        state_topic: '$this/salt_level',
+                        command_topic: '$this/salt_level/set',
+                        name: 'Salt Level',
+                        min: 0,
+                        max: 4,
+                        step: 1,
+                    },
+                    buzzer_level: {
+                        platform: 'select',
+                        icon: 'mdi:volume-high',
+                        unique_id: '$deviceid-buzzer_level',
+                        state_topic: '$this/buzzer_level',
+                        command_topic: '$this/buzzer_level/set',
+                        name: 'Buzzer Level',
+                        options: ['OFF', 'LOW', 'HIGH'],
+                    },
+                    end_alarm_sound: {
+                        platform: 'switch',
+                        icon: 'mdi:music-note',
+                        unique_id: '$deviceid-end_alarm_sound',
+                        state_topic: '$this/end_alarm_sound',
+                        command_topic: '$this/end_alarm_sound/set',
+                        name: 'End Alarm Sound',
+                        payload_on: 'ON',
+                        payload_off: 'OFF',
+                    },
+                    clean_reminder: {
+                        platform: 'switch',
+                        icon: 'mdi:lightbulb',
+                        unique_id: '$deviceid-clean_reminder',
+                        state_topic: '$this/clean_reminder',
+                        command_topic: '$this/clean_reminder/set',
+                        name: 'Clean Reminder Light',
+                        payload_on: 'ON',
+                        payload_off: 'OFF',
+                    },
+                    auto_dry: {
+                        platform: 'switch',
+                        icon: 'mdi:weather-sunny',
+                        unique_id: '$deviceid-auto_dry',
+                        state_topic: '$this/auto_dry',
+                        command_topic: '$this/auto_dry/set',
+                        name: 'Auto Dry',
+                        payload_on: 'ON',
+                        payload_off: 'OFF',
+                    },
+                    brightness: {
+                        platform: 'switch',
+                        icon: 'mdi:brightness-6',
+                        unique_id: '$deviceid-brightness',
+                        state_topic: '$this/brightness',
+                        command_topic: '$this/brightness/set',
+                        name: 'Time Indicator Brightness',
+                        payload_on: 'HIGH',
+                        payload_off: 'LOW',
+                    },
+                    remote_start_mode: {
+                        platform: 'select',
+                        icon: 'mdi:remote',
+                        unique_id: '$deviceid-remote_start_mode',
+                        state_topic: '$this/remote_start_mode',
+                        command_topic: '$this/remote_start_mode/set',
+                        name: 'Remote Start Mode',
+                        options: ['PERMANENT', 'ONE_TIME', 'OFF'],
                     },
                     delay_start: {
                         platform: 'sensor',
@@ -247,6 +329,27 @@ export default class Device extends AABBDevice {
         this.publishProperty('target_extra_rinse', '0')
     }
 
+    sendSettings() {
+        let opt1 = 0x00
+        if (this.cachedEndAlarmSound) opt1 |= 0x40
+        if (this.cachedAutoDry) opt1 |= 0x20
+        if (this.cachedCleanReminder) opt1 |= 0x08
+        if (this.cachedBuzzerLevel === 'HIGH') opt1 |= 0x04
+        else if (this.cachedBuzzerLevel === 'LOW') opt1 |= 0x02
+
+        let opt2 = 0x00
+        if (this.cachedRemoteStartMode === 'OFF') opt2 = 0xc0
+        else if (this.cachedRemoteStartMode === 'PERMANENT') opt2 = 0x80
+        else if (this.cachedRemoteStartMode === 'ONE_TIME') opt2 = 0x40
+
+        let opt3 = 0x00
+        if (this.cachedBrightness) opt3 |= 0x40
+
+        this.send(
+            Buffer.from([0xf0, 0x26, this.cachedRinseLevel, this.cachedSaltLevel, opt1, opt2, opt3, 0x00, 0x00, 0x00]),
+        )
+    }
+
     setProperty(prop: string, mqttValue: string) {
         if (prop === 'power') {
             if (mqttValue === 'ON') {
@@ -293,6 +396,36 @@ export default class Device extends AABBDevice {
                 this.targetExtraRinse = val
                 this.publishProperty('target_extra_rinse', mqttValue)
             }
+        } else if (prop === 'rinse_level') {
+            const val = parseInt(mqttValue, 10)
+            if (!isNaN(val)) {
+                this.cachedRinseLevel = val
+                this.sendSettings()
+            }
+        } else if (prop === 'salt_level') {
+            const val = parseInt(mqttValue, 10)
+            if (!isNaN(val)) {
+                this.cachedSaltLevel = val
+                this.sendSettings()
+            }
+        } else if (prop === 'buzzer_level') {
+            this.cachedBuzzerLevel = mqttValue
+            this.sendSettings()
+        } else if (prop === 'end_alarm_sound') {
+            this.cachedEndAlarmSound = mqttValue === 'ON'
+            this.sendSettings()
+        } else if (prop === 'clean_reminder') {
+            this.cachedCleanReminder = mqttValue === 'ON'
+            this.sendSettings()
+        } else if (prop === 'auto_dry') {
+            this.cachedAutoDry = mqttValue === 'ON'
+            this.sendSettings()
+        } else if (prop === 'brightness') {
+            this.cachedBrightness = mqttValue === 'HIGH'
+            this.sendSettings()
+        } else if (prop === 'remote_start_mode') {
+            this.cachedRemoteStartMode = mqttValue
+            this.sendSettings()
         } else if (prop === 'start_course') {
             // f0 26 10 [Course] [DelayHour] [Opt2] [Opt3] [Opt4] [Opt5]
             let opt3 = 0
@@ -384,10 +517,33 @@ export default class Device extends AABBDevice {
             const isRemoteStart = (data[15] & 0x02) !== 0
             this.publishProperty('remote_start', isRemoteStart ? 'ON' : 'OFF')
 
-            // Rinse Level (Index 21)
-            const rinseCode = data[21]
-            const rinseStr = RINSE_LEVELS[rinseCode] || `UNKNOWN(${rinseCode})`
-            this.publishProperty('rinse_level', rinseStr)
+            // Parse Settings
+            this.cachedRinseLevel = data[13]
+            this.cachedSaltLevel = data[14]
+            this.publishProperty('rinse_level', this.cachedRinseLevel)
+            this.publishProperty('salt_level', this.cachedSaltLevel)
+
+            this.cachedAutoDry = (data[11] & 0x10) !== 0
+            this.cachedCleanReminder = (data[11] & 0x40) !== 0
+            this.publishProperty('auto_dry', this.cachedAutoDry ? 'ON' : 'OFF')
+            this.publishProperty('clean_reminder', this.cachedCleanReminder ? 'ON' : 'OFF')
+
+            if ((data[15] & 0x80) !== 0) this.cachedBuzzerLevel = 'HIGH'
+            else if ((data[15] & 0x40) !== 0) this.cachedBuzzerLevel = 'LOW'
+            else this.cachedBuzzerLevel = 'OFF'
+            this.publishProperty('buzzer_level', this.cachedBuzzerLevel)
+
+            const remoteBits = data[16] & 0xc0
+            if (remoteBits === 0xc0) this.cachedRemoteStartMode = 'OFF'
+            else if (remoteBits === 0x80) this.cachedRemoteStartMode = 'PERMANENT'
+            else if (remoteBits === 0x40) this.cachedRemoteStartMode = 'ONE_TIME'
+            this.publishProperty('remote_start_mode', this.cachedRemoteStartMode)
+
+            this.cachedEndAlarmSound = (data[16] & 0x04) !== 0
+            this.publishProperty('end_alarm_sound', this.cachedEndAlarmSound ? 'ON' : 'OFF')
+
+            this.cachedBrightness = (data[19] & 0x40) !== 0
+            this.publishProperty('brightness', this.cachedBrightness ? 'HIGH' : 'LOW')
         }
     }
 }

--- a/cloud/devices/H11.ts
+++ b/cloud/devices/H11.ts
@@ -66,6 +66,11 @@ export default class Device extends AABBDevice {
             allowExtendedType({
                 ...this.deviceConfig,
                 components: {
+                    // ── Status Sensors (read-only, sourced from 32ec status packet) ──────────
+
+                    // Wakes the device up (ON → f0 26 16) or powers it off (OFF → f0 26 12).
+                    // The switch is forced to OFF when the device is in STANDBY (state=4)
+                    // or during the drain-after-cancel process (processCode=0x63).
                     power: {
                         platform: 'switch',
                         unique_id: '$deviceid-power',
@@ -74,6 +79,8 @@ export default class Device extends AABBDevice {
                         name: 'Power',
                         icon: 'mdi:power',
                     },
+                    // Current operating state of the dishwasher.
+                    // data[0]: 01=INITIAL, 02=RUNNING, 03=PAUSE, 04=STANDBY
                     state: {
                         platform: 'sensor',
                         device_class: 'enum',
@@ -83,6 +90,9 @@ export default class Device extends AABBDevice {
                         name: 'State',
                         options: Array.from(new Set([...Object.values(DISHWASHER_STATES), 'unknown'])),
                     },
+                    // Active wash course name.
+                    // If a download (smart) course is running, data[20] (smart course ID) takes
+                    // priority over the base course code in data[5].
                     course: {
                         platform: 'sensor',
                         device_class: 'enum',
@@ -90,8 +100,12 @@ export default class Device extends AABBDevice {
                         unique_id: '$deviceid-course',
                         state_topic: '$this/course',
                         name: 'Course',
-                        options: Array.from(new Set([...Object.values(COURSES), ...Object.values(SMART_COURSES), 'unknown'])),
+                        options: Array.from(
+                            new Set([...Object.values(COURSES), ...Object.values(SMART_COURSES), 'unknown']),
+                        ),
                     },
+                    // Remaining time until the current course finishes.
+                    // Computed as data[7] (hour) * 60 + data[8] (minute).
                     remain_time: {
                         platform: 'sensor',
                         icon: 'mdi:timer-sand',
@@ -100,6 +114,8 @@ export default class Device extends AABBDevice {
                         name: 'Remain Time',
                         unit_of_measurement: 'min',
                     },
+                    // Total (initial) course duration set when the cycle started.
+                    // Computed as data[3] (hour) * 60 + data[4] (minute).
                     course_time: {
                         platform: 'sensor',
                         icon: 'mdi:timer',
@@ -108,6 +124,8 @@ export default class Device extends AABBDevice {
                         name: 'Course Time',
                         unit_of_measurement: 'min',
                     },
+                    // Door open/close state.
+                    // data[11] bit 0x02: 1=OPEN, 0=CLOSE
                     door: {
                         platform: 'binary_sensor',
                         device_class: 'door',
@@ -117,6 +135,9 @@ export default class Device extends AABBDevice {
                         payload_on: 'OPEN',
                         payload_off: 'CLOSE',
                     },
+                    // Accumulated energy consumption for the current wash cycle.
+                    // Sourced from the separate 32 3e statistics packet (not the 32 ec status packet).
+                    // buf[4~5] (big-endian uint16) = total Wh for this cycle.
                     energy_consumption: {
                         platform: 'sensor',
                         device_class: 'energy',
@@ -127,24 +148,48 @@ export default class Device extends AABBDevice {
                         unit_of_measurement: 'Wh',
                         icon: 'mdi:flash',
                     },
-                    high_temp_dry: {
+                    // Whether extra high-heat drying is currently active.
+                    // The device applies additional heat after the wash cycle to improve drying.
+                    // data[12] bit 0x04
+                    extra_dry: {
                         platform: 'binary_sensor',
                         icon: 'mdi:weather-sunny',
-                        unique_id: '$deviceid-high_temp_dry',
-                        state_topic: '$this/high_temp_dry',
-                        name: 'High Temp Dry',
+                        unique_id: '$deviceid-extra_dry',
+                        state_topic: '$this/extra_dry',
+                        name: 'Extra Dry',
                         payload_on: 'ON',
                         payload_off: 'OFF',
                     },
-                    sterilize: {
+                    // Whether high-temperature sanitizing wash is currently active.
+                    // Heats the wash water to 70°C+ to kill bacteria.
+                    // data[12] bit 0x08
+                    high_temp: {
                         platform: 'binary_sensor',
                         icon: 'mdi:thermometer-high',
-                        unique_id: '$deviceid-sterilize',
-                        state_topic: '$this/sterilize',
-                        name: 'Sterilize',
+                        unique_id: '$deviceid-high_temp',
+                        state_topic: '$this/high_temp',
+                        name: 'High Temp',
                         payload_on: 'ON',
                         payload_off: 'OFF',
                     },
+                    // Current extra rinse count reported by the device.
+                    // data[21]: 0x00=Off, 0x10=Level 1, 0x20=Level 2, 0x30=Level 3
+                    // Read-back counterpart of target_extra_rinse.
+                    extra_rinse: {
+                        platform: 'sensor',
+                        device_class: 'enum',
+                        icon: 'mdi:water-plus',
+                        unique_id: '$deviceid-extra_rinse',
+                        state_topic: '$this/extra_rinse',
+                        name: 'Extra Rinse (Current)',
+                        options: Object.values(RINSE_LEVELS),
+                    },
+
+                    // ── Settings (bidirectional, sent via f0 26 Settings Set command) ─────────
+
+                    // Rinse aid dispensing level. Range 0–4.
+                    // Sent as [Rinse] byte in: f0 26 [Rinse] [Salt] [Opt1] [Opt2] [Opt3] ...
+                    // Read back from data[13].
                     rinse_level: {
                         platform: 'number',
                         icon: 'mdi:water-plus',
@@ -156,6 +201,9 @@ export default class Device extends AABBDevice {
                         max: 4,
                         step: 1,
                     },
+                    // Water softener salt dispensing level. Range 0–4.
+                    // Sent as [Salt] byte in the Settings Set command.
+                    // Read back from data[14].
                     salt_level: {
                         platform: 'number',
                         icon: 'mdi:shaker',
@@ -167,6 +215,9 @@ export default class Device extends AABBDevice {
                         max: 4,
                         step: 1,
                     },
+                    // Appliance alert beep volume during operation.
+                    // Opt1 bit 0x04=HIGH, bit 0x02=LOW, both off=OFF.
+                    // Read back from data[15] bits 0x80 (HIGH) / 0x40 (LOW).
                     buzzer_level: {
                         platform: 'select',
                         icon: 'mdi:volume-high',
@@ -176,6 +227,8 @@ export default class Device extends AABBDevice {
                         name: 'Buzzer Level',
                         options: ['OFF', 'LOW', 'HIGH'],
                     },
+                    // Plays a completion melody when the wash cycle finishes.
+                    // Opt1 bit 0x40. Read back from data[16] bit 0x04.
                     end_alarm_sound: {
                         platform: 'switch',
                         icon: 'mdi:music-note',
@@ -186,6 +239,8 @@ export default class Device extends AABBDevice {
                         payload_on: 'ON',
                         payload_off: 'OFF',
                     },
+                    // LED indicator light that reminds the user to clean the filter.
+                    // Opt1 bit 0x08. Read back from data[11] bit 0x40.
                     clean_reminder: {
                         platform: 'switch',
                         icon: 'mdi:lightbulb',
@@ -196,6 +251,8 @@ export default class Device extends AABBDevice {
                         payload_on: 'ON',
                         payload_off: 'OFF',
                     },
+                    // Automatically opens the door slightly after the cycle ends to assist drying.
+                    // Opt1 bit 0x20. Read back from data[11] bit 0x10.
                     auto_dry: {
                         platform: 'switch',
                         icon: 'mdi:weather-sunny',
@@ -206,6 +263,8 @@ export default class Device extends AABBDevice {
                         payload_on: 'ON',
                         payload_off: 'OFF',
                     },
+                    // Brightness of the time display panel on the appliance.
+                    // ON=HIGH, OFF=LOW. Opt3 bit 0x40. Read back from data[19] bit 0x40.
                     brightness: {
                         platform: 'switch',
                         icon: 'mdi:brightness-6',
@@ -216,6 +275,10 @@ export default class Device extends AABBDevice {
                         payload_on: 'HIGH',
                         payload_off: 'LOW',
                     },
+                    // Controls whether the appliance accepts remote start commands.
+                    // PERMANENT: always enabled, ONE_TIME: enabled for one cycle only, OFF: disabled.
+                    // Opt2 bits 0x80=PERMANENT, 0x40=ONE_TIME, 0xc0=OFF.
+                    // Read back from data[16] bits 0xc0.
                     remote_start_mode: {
                         platform: 'select',
                         icon: 'mdi:remote',
@@ -225,6 +288,8 @@ export default class Device extends AABBDevice {
                         name: 'Remote Start Mode',
                         options: ['PERMANENT', 'ONE_TIME', 'OFF'],
                     },
+                    // Delay start hours as currently set on the device.
+                    // 0 means no delay (start immediately). Read back from data[9].
                     delay_start: {
                         platform: 'sensor',
                         icon: 'mdi:clock-fast',
@@ -233,6 +298,9 @@ export default class Device extends AABBDevice {
                         name: 'Delay Start (Hours)',
                         unit_of_measurement: 'h',
                     },
+                    // Whether the physical Remote Start button on the appliance is currently active.
+                    // The user must press this button before a remote start command can be accepted.
+                    // data[15] bit 0x02.
                     remote_start: {
                         platform: 'binary_sensor',
                         icon: 'mdi:remote',
@@ -242,6 +310,10 @@ export default class Device extends AABBDevice {
                         payload_on: 'ON',
                         payload_off: 'OFF',
                     },
+
+                    // ── Control Buttons (write-only, f0 26 commands) ──────────────────────────
+
+                    // Pauses the running wash cycle. Sends: f0 26 13
                     pause: {
                         platform: 'button',
                         icon: 'mdi:pause',
@@ -250,6 +322,7 @@ export default class Device extends AABBDevice {
                         name: 'Pause',
                         payload_press: 'PRESS',
                     },
+                    // Resumes a paused wash cycle. Sends: f0 26 14
                     resume: {
                         platform: 'button',
                         icon: 'mdi:play',
@@ -258,6 +331,9 @@ export default class Device extends AABBDevice {
                         name: 'Resume',
                         payload_press: 'PRESS',
                     },
+                    // Cancels the current cycle. Sends: f0 26 11
+                    // The device drains residual water (~1 min, RUNNING state with processCode 0x63)
+                    // before powering off. Pressing again during drain stops pumping immediately.
                     cancel: {
                         platform: 'button',
                         icon: 'mdi:stop',
@@ -266,6 +342,14 @@ export default class Device extends AABBDevice {
                         name: 'Cancel / Drain Stop',
                         payload_press: 'PRESS',
                     },
+
+                    // ── Target Controls (pre-select options before Remote Start) ───────────────
+                    // These entities stage the parameters for the next remote start command.
+                    // All values are assembled into a single f0 26 10 packet by start_course.
+
+                    // Selects the wash course for the next remote start.
+                    // Becomes the [Course] byte in: f0 26 10 [Course] [DelayHour] [Opt2] [Opt3] [Opt4] [Opt5]
+                    // 'Off' is excluded — the device must run a valid course.
                     target_course: {
                         platform: 'select',
                         icon: 'mdi:washing-machine',
@@ -273,8 +357,10 @@ export default class Device extends AABBDevice {
                         state_topic: '$this/target_course',
                         command_topic: '$this/target_course/set',
                         name: 'Target Course',
-                        options: Object.values(COURSES).filter(c => c !== 'Off'),
+                        options: Object.values(COURSES).filter((c) => c !== 'Off'),
                     },
+                    // Sets the delay before the cycle starts. 0 = start immediately.
+                    // Range 0–12 hours. Becomes [DelayHour] in the remote start command.
                     target_delay: {
                         platform: 'number',
                         icon: 'mdi:clock-start',
@@ -286,6 +372,9 @@ export default class Device extends AABBDevice {
                         max: 12,
                         step: 1,
                     },
+                    // Enables sanitizing wash for the next cycle.
+                    // Sets opt3 bit 0x08 in the remote start command.
+                    // Read-back counterpart: high_temp (data[12] bit 0x08).
                     target_high_temp: {
                         platform: 'switch',
                         icon: 'mdi:thermometer-high',
@@ -296,6 +385,9 @@ export default class Device extends AABBDevice {
                         payload_on: 'ON',
                         payload_off: 'OFF',
                     },
+                    // Enables extra high-heat drying for the next cycle.
+                    // Sets opt3 bit 0x04 in the remote start command.
+                    // Read-back counterpart: extra_dry (data[12] bit 0x04).
                     target_extra_dry: {
                         platform: 'switch',
                         icon: 'mdi:weather-sunny',
@@ -306,6 +398,10 @@ export default class Device extends AABBDevice {
                         payload_on: 'ON',
                         payload_off: 'OFF',
                     },
+                    // Number of additional rinse cycles to perform (0–3).
+                    // Sets opt4 bits: 1→0x08, 2→0x10, 3→0x18 in the remote start command.
+                    // Also sets opt4 bit 0x40 when course is Download Cycle (0x0b).
+                    // Read-back counterpart: extra_rinse (data[21]).
                     target_extra_rinse: {
                         platform: 'number',
                         icon: 'mdi:water-plus',
@@ -317,6 +413,8 @@ export default class Device extends AABBDevice {
                         max: 3,
                         step: 1,
                     },
+                    // Sends the remote start command using all staged target_* values.
+                    // Assembles and transmits: f0 26 10 [Course] [DelayHour] 0x00 [Opt3] [Opt4] 0x00
                     start_course: {
                         platform: 'button',
                         icon: 'mdi:play-circle',
@@ -462,10 +560,18 @@ export default class Device extends AABBDevice {
 
     processAABB(buf: Buffer) {
         if (buf[0] === 0x32 && buf[1] === 0xec) {
-            // H11 status packet is typically 54 bytes long
-            if (buf.length === 54) {
-                const curStatus = buf.subarray(28, buf.length)
-                this.processStatus(curStatus)
+            // Scan for '00 18' status TLV blocks starting at offset 2.
+            // Older firmware sends 54-byte packets (two 26-byte blocks).
+            // Newer firmware sends larger packets (e.g. 94 bytes) with additional
+            // TLV data appended after each 24-byte status block.
+            let offset = 2
+            while (offset + 26 <= buf.length) {
+                if (buf[offset] === 0x00 && buf[offset + 1] === 0x18) {
+                    this.processStatus(buf.subarray(offset))
+                    offset += 2 + 0x18 // tag(1) + len(1) + data(24)
+                } else {
+                    offset++
+                }
             }
         } else if (buf[0] === 0x32 && buf[1] === 0x3e) {
             this.processStatistics(buf)
@@ -550,13 +656,13 @@ export default class Device extends AABBDevice {
             const isDoorOpen = (data[11] & 0x02) !== 0
             this.publishProperty('door', isDoorOpen ? 'OPEN' : 'CLOSE')
 
-            // Extra Dry (Index 12 bit 0x04)
+            // 추가 건조 (Index 12 bit 0x04): 세척 후 고열 추가 건조 활성 여부
             const isExtraDry = (data[12] & 0x04) !== 0
-            this.publishProperty('high_temp_dry', isExtraDry ? 'ON' : 'OFF')
+            this.publishProperty('extra_dry', isExtraDry ? 'ON' : 'OFF')
 
-            // High Temp (Index 12 bit 0x08)
+            // 고온 세척 (Index 12 bit 0x08): 고온 가열로 살균 세척 활성 여부
             const isHighTemp = (data[12] & 0x08) !== 0
-            this.publishProperty('sterilize', isHighTemp ? 'ON' : 'OFF')
+            this.publishProperty('high_temp', isHighTemp ? 'ON' : 'OFF')
 
             // Remote Start (Index 15 bit 0x02)
             const isRemoteStart = (data[15] & 0x02) !== 0
@@ -595,6 +701,15 @@ export default class Device extends AABBDevice {
             // Brightness (Index 19 bit 0x40)
             this.cachedBrightness = (data[19] & 0x40) !== 0
             this.publishProperty('brightness', this.cachedBrightness ? 'HIGH' : 'LOW')
+
+            // Extra Rinse (Index 21): 0x00=0회, 0x10=1회, 0x20=2회, 0x30=3회
+            const extraRinseRaw = data[21]
+            const extraRinseStr = RINSE_LEVELS[extraRinseRaw] ?? RINSE_LEVELS[0x00]
+            this.publishProperty('extra_rinse', extraRinseStr)
+            // Sync target_extra_rinse (0~3) from device state
+            this.targetExtraRinse =
+                extraRinseRaw === 0x10 ? 1 : extraRinseRaw === 0x20 ? 2 : extraRinseRaw === 0x30 ? 3 : 0
+            this.publishProperty('target_extra_rinse', this.targetExtraRinse)
         }
     }
 }

--- a/cloud/devices/H11.ts
+++ b/cloud/devices/H11.ts
@@ -6,35 +6,35 @@ import { allowExtendedType } from '@/util/casting'
 import AABBDevice from './aabb_device'
 
 const DISHWASHER_STATES: Record<number, string> = {
-    1: 'INITIAL',
-    2: 'RUNNING',
-    3: 'PAUSE',
-    4: 'STANDBY',
+    1: 'Initial',
+    2: 'Running',
+    3: 'Pause',
+    4: 'Standby',
 }
 
 const COURSES: Record<number, string> = {
-    0x00: 'OFF',
-    0x01: 'AUTO',
-    0x12: 'ONE_HOUR',
-    0x05: 'NORMAL/ECO',
-    0x02: 'HEAVY/INTENSIVE',
-    0x10: 'SILENT_NIGHT',
-    0x08: 'EXPRESS',
-    0x0b: 'DOWNLOAD_CYCLE',
-    0x09: 'MACHINE_CLEAN',
+    0x00: 'Off',
+    0x01: 'Auto',
+    0x12: 'One hour',
+    0x05: 'Normal/Eco',
+    0x02: 'Heavy/Intensive',
+    0x10: 'Silent night',
+    0x08: 'Express',
+    0x0b: 'Download cycle',
+    0x09: 'Machine clean',
 }
 
 const SMART_COURSES: Record<number, string> = {
-    0x05: 'GREASY_TABLEWARE',
-    0x0d: 'MACHINE_CLEAN',
-    0x0f: 'PLASTIC_WASH',
+    0x05: 'Greasy tableware',
+    0x0d: 'Machine clean',
+    0x0f: 'Plastic wash',
 }
 
 const RINSE_LEVELS: Record<number, string> = {
-    0x00: 'OFF',
-    0x10: 'LEVEL_1',
-    0x20: 'LEVEL_2',
-    0x30: 'LEVEL_3',
+    0x00: 'Off',
+    0x10: 'Level 1',
+    0x20: 'Level 2',
+    0x30: 'Level 3',
 }
 
 export default class Device extends AABBDevice {
@@ -76,17 +76,21 @@ export default class Device extends AABBDevice {
                     },
                     state: {
                         platform: 'sensor',
+                        device_class: 'enum',
                         icon: 'mdi:washing-machine',
                         unique_id: '$deviceid-state',
                         state_topic: '$this/state',
                         name: 'State',
+                        options: Array.from(new Set([...Object.values(DISHWASHER_STATES), 'unknown'])),
                     },
                     course: {
                         platform: 'sensor',
+                        device_class: 'enum',
                         icon: 'mdi:dishwasher',
                         unique_id: '$deviceid-course',
                         state_topic: '$this/course',
                         name: 'Course',
+                        options: Array.from(new Set([...Object.values(COURSES), ...Object.values(SMART_COURSES), 'unknown'])),
                     },
                     remain_time: {
                         platform: 'sensor',
@@ -269,16 +273,7 @@ export default class Device extends AABBDevice {
                         state_topic: '$this/target_course',
                         command_topic: '$this/target_course/set',
                         name: 'Target Course',
-                        options: [
-                            'AUTO',
-                            'ONE_HOUR',
-                            'NORMAL/ECO',
-                            'HEAVY/INTENSIVE',
-                            'SILENT_NIGHT',
-                            'EXPRESS',
-                            'DOWNLOAD_CYCLE',
-                            'MACHINE_CLEAN',
-                        ],
+                        options: Object.values(COURSES).filter(c => c !== 'Off'),
                     },
                     target_delay: {
                         platform: 'number',
@@ -312,13 +307,15 @@ export default class Device extends AABBDevice {
                         payload_off: 'OFF',
                     },
                     target_extra_rinse: {
-                        platform: 'select',
+                        platform: 'number',
                         icon: 'mdi:water-plus',
                         unique_id: '$deviceid-target_extra_rinse',
                         state_topic: '$this/target_extra_rinse',
                         command_topic: '$this/target_extra_rinse/set',
                         name: 'Extra Rinse',
-                        options: ['0', '1', '2', '3'],
+                        min: 0,
+                        max: 3,
+                        step: 1,
                     },
                     start_course: {
                         platform: 'button',
@@ -335,14 +332,15 @@ export default class Device extends AABBDevice {
 
     start() {
         super.start()
-        this.publishProperty('target_course', 'AUTO')
+        this.publishProperty('target_course', 'Auto')
         this.publishProperty('target_delay', 0)
         this.publishProperty('target_high_temp', 'OFF')
         this.publishProperty('target_extra_dry', 'OFF')
-        this.publishProperty('target_extra_rinse', '0')
+        this.publishProperty('target_extra_rinse', 0)
     }
 
     sendSettings() {
+        // Opt1 (End Alarm, Auto Dry, Clean Reminder, Buzzer)
         let opt1 = 0x00
         if (this.cachedEndAlarmSound) opt1 |= 0x40
         if (this.cachedAutoDry) opt1 |= 0x20
@@ -350,11 +348,13 @@ export default class Device extends AABBDevice {
         if (this.cachedBuzzerLevel === 'HIGH') opt1 |= 0x04
         else if (this.cachedBuzzerLevel === 'LOW') opt1 |= 0x02
 
+        // Opt2 (Remote Start Mode)
         let opt2 = 0x00
         if (this.cachedRemoteStartMode === 'OFF') opt2 = 0xc0
         else if (this.cachedRemoteStartMode === 'PERMANENT') opt2 = 0x80
         else if (this.cachedRemoteStartMode === 'ONE_TIME') opt2 = 0x40
 
+        // Opt3 (Brightness)
         let opt3 = 0x00
         if (this.cachedBrightness) opt3 |= 0x40
 
@@ -363,6 +363,16 @@ export default class Device extends AABBDevice {
         )
     }
 
+    /**
+     * f0 26 Control Packets:
+     * - Wake Up: f0 26 16
+     * - Power Off: f0 26 12
+     * - Pause: f0 26 13
+     * - Resume: f0 26 14
+     * - Cancel / Drain Stop: f0 26 11
+     * - Settings Set: f0 26 [Rinse] [Salt] [Opt1] [Opt2] [Opt3] [Opt4] [Opt5] [Opt6] [Opt7]
+     * - Remote Start: f0 26 10 [Course] [DelayHour] [Opt2] [Opt3] [Opt4] [Opt5]
+     */
     setProperty(prop: string, mqttValue: string) {
         if (prop === 'power') {
             if (mqttValue === 'ON') {
@@ -377,18 +387,9 @@ export default class Device extends AABBDevice {
         } else if (prop === 'cancel') {
             this.send(Buffer.from('F02611', 'hex')) // Course Cancel / Drain Stop
         } else if (prop === 'target_course') {
-            const coursesReverse: Record<string, number> = {
-                AUTO: 0x01,
-                ONE_HOUR: 0x12,
-                'NORMAL/ECO': 0x05,
-                'HEAVY/INTENSIVE': 0x02,
-                SILENT_NIGHT: 0x10,
-                EXPRESS: 0x08,
-                DOWNLOAD_CYCLE: 0x0b,
-                MACHINE_CLEAN: 0x09,
-            }
-            if (coursesReverse[mqttValue]) {
-                this.targetCourse = coursesReverse[mqttValue]
+            const courseKey = Object.keys(COURSES).find((k) => COURSES[parseInt(k, 10)] === mqttValue)
+            if (courseKey !== undefined) {
+                this.targetCourse = parseInt(courseKey, 10)
                 this.publishProperty('target_course', mqttValue)
             }
         } else if (prop === 'target_delay') {
@@ -461,10 +462,9 @@ export default class Device extends AABBDevice {
 
     processAABB(buf: Buffer) {
         if (buf[0] === 0x32 && buf[1] === 0xec) {
-            const payloadLen = buf.length - 2
-            const halfLen = Math.floor(payloadLen / 2)
-            if (halfLen > 10) {
-                const curStatus = buf.subarray(2 + halfLen, buf.length)
+            // H11 status packet is typically 54 bytes long
+            if (buf.length === 54) {
+                const curStatus = buf.subarray(28, buf.length)
                 this.processStatus(curStatus)
             }
         } else if (buf[0] === 0x32 && buf[1] === 0x3e) {
@@ -487,15 +487,32 @@ export default class Device extends AABBDevice {
         this.publishProperty('energy_consumption', energyAccum.toString())
     }
 
+    /**
+     * 32ec Status Packet (00 18 Tag Block - 24 bytes) Offset Mapping:
+     * [0] State: 01(INITIAL), 02(RUNNING), 03(PAUSE), 04(STANDBY)
+     * [3~4] Initial Time (Hour, Minute)
+     * [5] Course Code (0x01: AUTO, etc.)
+     * [7~8] Remain Time (Hour, Minute)
+     * [9] Delay Start (예약 시간)
+     * [11] Door & Opt1: 0x40(Clean Reminder ON), 0x10(Auto Dry ON), 0x02(Door OPEN)
+     * [12] Wash Options: 0x04(Extra Dry ON), 0x08(High Temp ON)
+     * [13] Rinse Level (0x00 ~ 0x04)
+     * [14] Salt Level (0x00 ~ 0x04)
+     * [15] Buzzer & Remote: 0x80(Buzzer HIGH), 0x40(Buzzer LOW), 0x02(Remote Start Active)
+     * [16] Opt2: 0x80(Remote PERMANENT), 0x40(Remote ONE_TIME), 0xc0(Remote OFF), 0x04(End Alarm Sound ON)
+     * [19] Opt3 (밝기): 0x40(Brightness HIGH)
+     * [20] Smart Course (다운로드 코스 ID)
+     * [21] Extra Rinse: 00(0회), 10(1회), 20(2회), 30(3회)
+     */
     processStatus(curStatus: Buffer) {
         if (curStatus[0] === 0x00 && curStatus[1] === 0x18) {
             const data = curStatus.subarray(2, 26) // 24 bytes
 
             const stateCode = data[0]
             const processCode = data[1]
-            const stateStr = DISHWASHER_STATES[stateCode] || `UNKNOWN(${stateCode})`
+            const stateStr = DISHWASHER_STATES[stateCode] || 'unknown'
 
-            // 전원 상태는 STANDBY(4) 이거나 취소 중(processCode: 0x63)일 때 OFF로 처리하여 스위치 튕김 방지
+            // To prevent the switch from bouncing, treat the power as OFF when the state is Standby (4) or cancelling (processCode: 0x63)
             const isPowerOff = stateCode === 4 || processCode === 0x63
 
             this.publishProperty('state', stateStr)
@@ -508,11 +525,9 @@ export default class Device extends AABBDevice {
             let courseStr = ''
             if (smartCourseCode !== 0) {
                 // If a smart course is active, use it instead of the base course
-                courseStr =
-                    SMART_COURSES[smartCourseCode] ||
-                    `DOWNLOAD_COURSE(0x${smartCourseCode.toString(16).padStart(2, '0')})`
+                courseStr = SMART_COURSES[smartCourseCode] || 'unknown'
             } else {
-                courseStr = COURSES[baseCourseCode] || `UNKNOWN(0x${baseCourseCode.toString(16).padStart(2, '0')})`
+                courseStr = COURSES[baseCourseCode] || 'unknown'
             }
 
             this.publishProperty('course', courseStr)
@@ -535,11 +550,11 @@ export default class Device extends AABBDevice {
             const isDoorOpen = (data[11] & 0x02) !== 0
             this.publishProperty('door', isDoorOpen ? 'OPEN' : 'CLOSE')
 
-            // High Temp Dry (Index 12 bit 0x04)
+            // Extra Dry (Index 12 bit 0x04)
             const isExtraDry = (data[12] & 0x04) !== 0
             this.publishProperty('high_temp_dry', isExtraDry ? 'ON' : 'OFF')
 
-            // Sterilize (Index 12 bit 0x08)
+            // High Temp (Index 12 bit 0x08)
             const isHighTemp = (data[12] & 0x08) !== 0
             this.publishProperty('sterilize', isHighTemp ? 'ON' : 'OFF')
 
@@ -548,30 +563,36 @@ export default class Device extends AABBDevice {
             this.publishProperty('remote_start', isRemoteStart ? 'ON' : 'OFF')
 
             // Parse Settings
+            // Rinse & Salt Level (Index 13, 14)
             this.cachedRinseLevel = data[13]
             this.cachedSaltLevel = data[14]
             this.publishProperty('rinse_level', this.cachedRinseLevel)
             this.publishProperty('salt_level', this.cachedSaltLevel)
 
+            // Auto Dry & Clean Reminder (Index 11)
             this.cachedAutoDry = (data[11] & 0x10) !== 0
             this.cachedCleanReminder = (data[11] & 0x40) !== 0
             this.publishProperty('auto_dry', this.cachedAutoDry ? 'ON' : 'OFF')
             this.publishProperty('clean_reminder', this.cachedCleanReminder ? 'ON' : 'OFF')
 
+            // Buzzer Level (Index 15)
             if ((data[15] & 0x80) !== 0) this.cachedBuzzerLevel = 'HIGH'
             else if ((data[15] & 0x40) !== 0) this.cachedBuzzerLevel = 'LOW'
             else this.cachedBuzzerLevel = 'OFF'
             this.publishProperty('buzzer_level', this.cachedBuzzerLevel)
 
+            // Remote Start Mode (Index 16 bits 0xc0)
             const remoteBits = data[16] & 0xc0
             if (remoteBits === 0xc0) this.cachedRemoteStartMode = 'OFF'
             else if (remoteBits === 0x80) this.cachedRemoteStartMode = 'PERMANENT'
             else if (remoteBits === 0x40) this.cachedRemoteStartMode = 'ONE_TIME'
             this.publishProperty('remote_start_mode', this.cachedRemoteStartMode)
 
+            // End Alarm Sound (Index 16 bit 0x04)
             this.cachedEndAlarmSound = (data[16] & 0x04) !== 0
             this.publishProperty('end_alarm_sound', this.cachedEndAlarmSound ? 'ON' : 'OFF')
 
+            // Brightness (Index 19 bit 0x40)
             this.cachedBrightness = (data[19] & 0x40) !== 0
             this.publishProperty('brightness', this.cachedBrightness ? 'HIGH' : 'LOW')
         }

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -1,5 +1,6 @@
 import POT_056905_WW from './devices/POT_056905_WW'
 import WTDN3 from './devices/WTDN3'
+import H11 from './devices/H11'
 import RAC_056905_WW from './devices/RAC_056905_WW'
 import WIN_056905_WW from './devices/WIN_056905_WW'
 import Dev_2REF11EIDA__4 from './devices/2REF11EIDA__4'
@@ -42,6 +43,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['2RES1VE61NFA2']: Dev_2RES1VE61NFA2,
     ['2REB1GLVB1__2']: Dev_2REB1GLVB1__2,
     ['2RES1VE600FWC']: Dev_2RES1VE600FWC,
+    ['H11']: H11,
     ['Y_V8_Y___W.B32QEUK']: Y_V8_Y___W_B32QEUK,
     ['F_V7_Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK, // NOTE: we reuse F_V8_Y___W_B_2QEUK as the models appear to be compatible
     ['F_V8_Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK,

--- a/tests/cloud/devices/H11.test.ts
+++ b/tests/cloud/devices/H11.test.ts
@@ -1,0 +1,122 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/H11'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'H11'
+const META: Metadata = { modelId: MODEL_ID, modelName: 'H11', swVersion: '0.0.0' }
+
+// Mock 32ec packet (54 bytes)
+// 0~27: padding/old status
+// 28~29: 00 18
+// 30: State (02 = RUNNING)
+// 31: Process (00)
+// 32: unused
+// 33, 34: Initial time (01, 30 = 1 hour 30 min)
+// 35: Course (01 = AUTO)
+// 36: unused
+// 37, 38: Remain time (01, 15 = 1 hour 15 min)
+// 39: Delay start (00 = off)
+// 40: unused
+// 41: Door & Opt1 (0x40 = Clean Reminder ON)
+// 42: Wash Options (0x0c = High Temp + Extra Dry)
+// 43: Rinse Level (02)
+// 44: Salt Level (03)
+// 45: Buzzer & Remote (0x80 = Buzzer High)
+// 46: Opt2 (0x80 = Remote Permanent)
+// 47: unused
+// 48: unused
+// 49: Opt3 (0x40 = Brightness High)
+// 50: Smart Course (00 = none)
+// 51: Extra Rinse (10 = 1 level)
+// 52, 53: unused
+const RUNNING_STATUS = buf(
+    '00000000000000000000000000000000000000000000000000000000001802000001300100010f0000400c0203808000004000100000'
+)
+
+describe('H11 Dishwasher', () => {
+    test('parses RUNNING status correctly', () => {
+        const ha = new MockHAConnection()
+        const thinq = new MockThinq2Device(DEVICE_ID, META as any)
+        const dut = new DUT(ha as any, thinq as any, META)
+        dut.start()
+
+        // Send 32 ec status
+        const packet = Buffer.alloc(54)
+        packet[0] = 0x32
+        packet[1] = 0xec
+        RUNNING_STATUS.copy(packet, 2, 2) // Copy from index 2 onwards
+
+        dut.processAABB(packet)
+
+        assert.equal(ha.devices[DEVICE_ID].properties['state'], 'Running')
+        assert.equal(ha.devices[DEVICE_ID].properties['power'], 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties['course'], 'Auto')
+        assert.equal(ha.devices[DEVICE_ID].properties['course_time'], 108) // 1h 30m
+        assert.equal(ha.devices[DEVICE_ID].properties['remain_time'], 75) // 1h 15m
+        assert.equal(ha.devices[DEVICE_ID].properties['delay_start'], 0)
+        assert.equal(ha.devices[DEVICE_ID].properties['door'], 'CLOSE')
+        assert.equal(ha.devices[DEVICE_ID].properties['high_temp_dry'], 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties['sterilize'], 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties['remote_start'], 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties['rinse_level'], 2)
+        assert.equal(ha.devices[DEVICE_ID].properties['salt_level'], 3)
+        assert.equal(ha.devices[DEVICE_ID].properties['auto_dry'], 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties['clean_reminder'], 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties['buzzer_level'], 'HIGH')
+        assert.equal(ha.devices[DEVICE_ID].properties['remote_start_mode'], 'PERMANENT')
+        assert.equal(ha.devices[DEVICE_ID].properties['end_alarm_sound'], 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties['brightness'], 'HIGH')
+    })
+
+    test('generates CONTROL packets correctly (sendSettings)', () => {
+        const ha = new MockHAConnection()
+        const thinq = new MockThinq2Device(DEVICE_ID, META as any)
+        const dut = new DUT(ha as any, thinq as any, META)
+        dut.start()
+
+        // Configure cached settings first
+        dut.cachedRinseLevel = 0x02
+        dut.cachedSaltLevel = 0x03
+        dut.cachedAutoDry = true
+        dut.cachedCleanReminder = false
+        dut.cachedBuzzerLevel = 'HIGH'
+        dut.cachedRemoteStartMode = 'PERMANENT'
+        dut.cachedEndAlarmSound = false
+        dut.cachedBrightness = true
+
+        dut.sendSettings()
+
+        // 1st sent packet: f0 26 [Rinse 02] [Salt 03] [Opt1 24] [Opt2 80] [Opt3 40] 00 00 00
+        // Opt1 = 0x20 (Auto Dry) + 0x04 (Buzzer HIGH) = 0x24
+        // Opt2 = 0x80 (Remote PERMANENT)
+        // Opt3 = 0x40 (Brightness)
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(thinq.outbox[0].toString('hex'), 'aa0ef0260203248040000000e2bb')
+    })
+
+    test('generates REMOTE START packet correctly', () => {
+        const ha = new MockHAConnection()
+        const thinq = new MockThinq2Device(DEVICE_ID, META as any)
+        const dut = new DUT(ha as any, thinq as any, META)
+        dut.start()
+
+        // Set target options
+        dut.setProperty('target_course', 'One hour') // 0x12
+        dut.setProperty('target_delay', '3')
+        dut.setProperty('target_high_temp', 'ON') // 0x08
+        dut.setProperty('target_extra_dry', 'ON') // 0x04
+        dut.setProperty('target_extra_rinse', '1') // 0x08
+
+        dut.setProperty('start_course', 'ON')
+
+        // f0 26 10 [Course] [Delay] 00 [Opt3] [Opt4] 00
+        // Opt3 = 0x08 + 0x04 = 0x0c
+        // Opt4 = 0x08 (Rinse 1)
+        const lastPayload = thinq.outbox[thinq.outbox.length - 1]
+        assert.equal(lastPayload.toString('hex'), 'aa0df026101203000c080053bb')
+    })
+}
+)


### PR DESCRIPTION
This PR adds support for the LG Dishwasher to the local AABB packet parser.
- **Actual Model Name**: DUE2BG.AKOR
- **LG ThinQ / Rethink Internal Model ID**: H11

It includes read-only sensors for monitoring the dishwasher's state and full remote control capabilities reverse-engineered from the ThinQ app, including comprehensive auxiliary settings.

### Features Added
- **State Monitoring**: `state`, `course`, `remain_time`
- **Basic Control**: Power `switch`, Pause `button`, Resume `button`, Cancel / Drain Stop `button`
- **Remote Start Options**: 
  - Allows selecting Target Course (Auto, 1 Hour, Normal, Download Cycle, etc.)
  - Delay Start Hour (1~12 hours)
  - Washing Options: High Temp (`0x08`), Extra Dry (`0x04`), Extra Rinse (1~3 levels)
  - `start_course` button dynamically constructs the `f0 26 10` control payload based on the selected virtual entities.
- **Comprehensive Settings Control**: 
  - Added 7 entities for configuring auxiliary device settings directly from HA: `salt_level`, `rinse_level`, `buzzer_level`, `end_alarm_sound`, `clean_reminder`, `auto_dry`, and `brightness`.
  - Added `remote_start_mode` (Permanent, One-Time, Off) to configure the machine's behavior after cycles.

---

### 🔍 Complete Packet Analysis & Protocol Structure (For Reviewers)

During the development of this parser, we successfully decoded the complete structure of the AABB local protocol for both status reporting and appliance control. Here is the full breakdown of the protocol for the H11 Dishwasher:

#### 1. Status Payload (`32 ec` -> `00 18` Tag Block)
The machine reports its current state using `32 ec` packets. The second half of the payload contains a `00 18` tag block followed by 24 bytes of data. Key offsets (starting at 0):
- **`[0]` (State)**: `01` (INITIAL), `02` (RUNNING), `03` (PAUSE), `04` (STANDBY)
- **`[3] & [4]` (Initial Time)**: Initial Course Time (Hour, Minute)
- **`[5]` (Course)**: Base Course Code (e.g., `01`: Auto, `12`: 1 Hour, `0b`: Download Cycle)
- **`[7] & [8]` (Remain Time)**: Remaining Time (Hour, Minute)
- **`[9]` (Delay Start)**: Delay start time in hours (`0` means disabled)
- **`[11]` (Opt1 & Door)**: `0x40` (Clean Reminder LED ON), `0x10` (Auto Dry ON), `0x02` (Door Open)
- **`[12]` (Wash Options)**: `0x04` (Extra Dry ON), `0x08` (High Temp ON)
- **`[13]` (Rinse Level)**: Rinse dispenser level (`0x00` ~ `0x04`)
- **`[14]` (Salt Level)**: Salt dispenser level (`0x00` ~ `0x04`)
- **`[15]` (Buzzer & Btn)**: `0x80` (Buzzer HIGH), `0x40` (Buzzer LOW), `0x00` (Buzzer OFF). *(Note: `0x02` represents the physical Remote Start button state)*
- **`[16]` (Opt2)**: `0x80` (Remote Control: PERMANENT), `0x40` (ONE-TIME), `0xc0` (OFF). `0x04` (End Alarm Sound ON)
- **`[19]` (Opt3)**: `0x40` (Display Brightness HIGH)
- **`[20]` (Smart Course)**: Specific Downloaded Course ID (e.g., `0x0f`: Plastic, `0x0d`: Tub Clean)
- **`[21]` (Extra Rinse)**: `00` (0), `10` (1 level), `20` (2 levels), `30` (3 levels)

#### 2. Control Commands (`f0 26`)
Unlike washing machines (`32 0a`), the dishwasher uses `f0 26` packets for control.
- **Power On / Wake Up**: `f0 26 16`
- **Power Off (Immediate)**: `f0 26 12`
- **Pause / Resume**: `f0 26 13` / `f0 26 14`
- **Cancel Course & Drain**: `f0 26 11` *(Pumps for 1 min, then powers off)*
- **Start Course**: `f0 26 10 [Course] [DelayHour] [Opt2=0x00] [Opt3] [Opt4] [Opt5=0x00]`
  - `[Opt3]` (Wash Options): `0x08` (High Temp), `0x04` (Extra Dry). Both = `0x0c`.
  - `[Opt4]` (Rinse Levels): `0x08` (1), `0x10` (2), `0x18` (3). *(Note: The `0x40` flag must be added if the course is `0b` Download Cycle)*
- **Settings Control**: `f0 26 [Rinse] [Salt] [Opt1] [Opt2] [Opt3] 00 00 00 00`
  - Overwrites all auxiliary settings at once. Our implementation caches existing user preferences and applies bitwise operations to update only the requested setting without altering others.

#### 3. Note on "Downloaded Courses"
Changing the specific "Downloaded Course" assignment (e.g., changing from *Tub Clean* to *Pots & Pans*) **cannot** be executed via the local network. When changed via the app, the machine downloads the cycle algorithm payload directly from LG Cloud (HTTPS/MQTT). We can monitor the active course ID by reading byte `[20]`, but we cannot push a new assignment locally.
