### PR TITLE
Initial support for LG GBBS322CEV refrigerator

### DIFF
--- a/cloud/devices/2REBGLUB_2P__.ts
+++ b/cloud/devices/2REBGLUB_2P__.ts
@@ -1,0 +1,173 @@
+// LG GBBS322CEV refrigerator
+// ThinQ2 model ID: 2REBGLUB_2P__
+// Device type: 101
+import HADevice from './base'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { DeviceDiscovery, type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import AABBDevice from './aabb_device'
+import {
+    convertFreezerTemperature,
+    convertFridgeTemperature,
+    freezerRange,
+    fridgeRange,
+    packStatus,
+    Status,
+    TemperatureUnit,
+    unpackStatus,
+} from './fridge_common'
+
+const STATUS_LENGTH = 96
+
+export default class Device extends AABBDevice {
+    readonly deviceConfig: DeviceDiscovery
+    temperatureUnit: TemperatureUnit | undefined
+
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        this.deviceConfig = HADevice.config(meta, { name: 'LG Fridge' })
+
+        // HomeAssistant configuration will be ready once we find out the temperature unit
+    }
+
+    setTemperatureUnit(unit: TemperatureUnit) {
+        if (this.temperatureUnit === unit) return
+
+        this.temperatureUnit = unit
+        // set or re-set the temperature unit
+        this.setConfig(
+            allowExtendedType({
+                ...this.deviceConfig,
+                components: {
+                    fridge_setpoint: {
+                        platform: 'number',
+                        device_class: 'temperature',
+                        unique_id: '$deviceid-fridge_setpoint',
+                        state_topic: '$this/fridge_setpoint',
+                        command_topic: '$this/fridge_setpoint/set',
+                        name: 'Fridge temperature',
+                        ...fridgeRange(unit),
+                    },
+                    express_cool: {
+                        platform: 'switch',
+                        unique_id: '$deviceid-express_cool',
+                        state_topic: '$this/express_cool',
+                        command_topic: '$this/express_cool/set',
+                        icon: 'mdi:snowflake-variant',
+                        name: 'Express Cool',
+                    },
+                    freezer_setpoint: {
+                        platform: 'number',
+                        device_class: 'temperature',
+                        unique_id: '$deviceid-freezer_setpoint',
+                        state_topic: '$this/freezer_setpoint',
+                        command_topic: '$this/freezer_setpoint/set',
+                        name: 'Freezer temperature',
+                        ...freezerRange(unit),
+                    },
+                    express_freeze: {
+                        platform: 'switch',
+                        unique_id: '$deviceid-express_freeze',
+                        state_topic: '$this/express_freeze',
+                        command_topic: '$this/express_freeze/set',
+                        icon: 'mdi:snowflake',
+                        name: 'Express Freeze',
+                    },
+                    door: {
+                        platform: 'binary_sensor',
+                        device_class: 'door',
+                        unique_id: '$deviceid-door',
+                        state_topic: '$this/door',
+                        name: 'Door',
+                    },
+                    // Expose the decoded drawer mode and its raw value for validation/debugging.
+                    drawer_mode: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-drawer_mode',
+                        state_topic: '$this/drawer_mode',
+                        icon: 'mdi:food',
+                        name: 'Drawer mode',
+                    },
+                    drawer_mode_raw: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-drawer_mode_raw',
+                        state_topic: '$this/drawer_mode_raw',
+                        icon: 'mdi:code-brackets',
+                        name: 'Drawer mode raw',
+                    },
+                },
+            }),
+        )
+    }
+
+    start() {
+        this.send(Buffer.from('F0ED1211010000010400', 'hex'))
+    }
+
+    processAABB(buf: Buffer) {
+        // I'm not sure what is the proper way to identify packet types, so let's match
+        // on the length and a few initial bytes
+
+        if (buf.length === 2 + STATUS_LENGTH * 2 && buf[0] == 0x10 && buf[1] == 0xec) {
+            // 10EC (prev status) (cur status)
+            this.processStatus(buf.subarray(2 + STATUS_LENGTH, 2 + STATUS_LENGTH * 2))
+        }
+
+        if (buf.length === 2 + STATUS_LENGTH && buf[0] == 0x10 && buf[1] == 0xeb) {
+            // 10EB (initial status)
+            this.processStatus(buf.subarray(2, 2 + STATUS_LENGTH))
+        }
+    }
+
+    drawerModeName(raw: number | undefined): string {
+        // Drawer mode observed at status offset 95:
+        // 0 = Cheese, 1 = Fish, 2 = Meat
+        if (raw === 0) return 'Cheese'
+        if (raw === 1) return 'Fish'
+        if (raw === 2) return 'Meat'
+        if (raw === 0xff || raw === undefined) return 'Unknown'
+        return 'Unknown ' + raw
+    }
+
+    processStatus(curStatus: Buffer) {
+        const s = unpackStatus(curStatus)
+        this.setTemperatureUnit(s.tempUnit ? 'C' : 'F')
+        this.publishProperty('door', s.anyDoorOpen === 1 ? 'ON' : 'OFF')
+        this.publishProperty('fridge_setpoint', convertFridgeTemperature(this.temperatureUnit!, s.fridgeSetpoint))
+        this.publishProperty('freezer_setpoint', convertFreezerTemperature(this.temperatureUnit!, s.freezerSetpoint))
+        this.publishProperty('express_cool', s.expressCool === 1 ? 'ON' : 'OFF')
+        this.publishProperty('express_freeze', s.expressFreeze === 2 ? 'ON' : 'OFF')
+
+        const drawerModeRaw = curStatus[95]
+        this.publishProperty('drawer_mode_raw', drawerModeRaw === undefined ? 'Unknown' : String(drawerModeRaw))
+        this.publishProperty('drawer_mode', this.drawerModeName(drawerModeRaw))
+    }
+
+    sendSetting(setting: Partial<Status>) {
+        this.send(Buffer.concat([Buffer.from('F017', 'hex'), packStatus(setting, STATUS_LENGTH)]))
+    }
+
+    setProperty(prop: string, mqttValue: string) {
+        // We shouldn't receive any setProperty calls before the temperatureUnit is set. But let's be safe
+        const unit = this.temperatureUnit || 'C'
+
+        let setting: Partial<Status> = {
+            tempUnit: unit === 'C' ? 1 : 0,
+        }
+
+        if (prop === 'fridge_setpoint') {
+            setting.fridgeSetpoint = convertFridgeTemperature(unit, Number(mqttValue))
+            this.sendSetting(setting)
+        } else if (prop === 'freezer_setpoint') {
+            setting.freezerSetpoint = convertFreezerTemperature(unit, Number(mqttValue))
+            this.sendSetting(setting)
+        } else if (prop === 'express_cool') {
+            setting.expressCool = mqttValue === 'ON' ? 1 : 0
+            this.sendSetting(setting)
+        } else if (prop === 'express_freeze') {
+            setting.expressFreeze = mqttValue === 'ON' ? 2 : 1
+            this.sendSetting(setting)
+        }
+    }
+}

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -7,6 +7,7 @@ import Dev_2REF11EBIVPC4 from './devices/2REF11EBIVPC4'
 import Dev_2RES1VE61NFA2 from './devices/2RES1VE61NFA2'
 import Dev_2REB1GLVB1__2 from './devices/2REB1GLVB1__2'
 import Dev_2RES1VE600FWC from './devices/2RES1VE600FWC'
+import Dev_2REBGLUB_2P__ from './devices/2REBGLUB_2P__'
 import Dev_STUDIO_HOOD from './devices/STUDIO_HOOD'
 import Y_V8_Y___W_B32QEUK from './devices/Y_V8_Y___W.B32QEUK'
 import F_V8_Y___W_B_2QEUK from './devices/F_V8_Y___W.B_2QEUK'
@@ -45,6 +46,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['2REF11EBIVPC4']: Dev_2REF11EBIVPC4,
     ['2RES1VE61NFA2']: Dev_2RES1VE61NFA2,
     ['2REB1GLVB1__2']: Dev_2REB1GLVB1__2,
+    ['2REBGLUB_2P__']: Dev_2REBGLUB_2P__, // LG GBBS322CEV refrigerator
     ['2RES1VE600FWC']: Dev_2RES1VE600FWC,
     ['STUDIO_HOOD']: Dev_STUDIO_HOOD,
     ['Y_V8_Y___W.B32QEUK']: Y_V8_Y___W_B32QEUK,

--- a/tests/cloud/devices/2REBGLUB_2P__.test.ts
+++ b/tests/cloud/devices/2REBGLUB_2P__.test.ts
@@ -1,0 +1,301 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/2REBGLUB_2P__'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf, hex } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = '2REBGLUB_2P__'
+const META: Metadata = {
+    modelId: MODEL_ID,
+    modelName: MODEL_ID,
+    swVersion: '1.0',
+}
+
+// Real packet captures from an LG GBBS322CEV refrigerator.
+// ThinQ2 model ID: 2REBGLUB_2P__
+// Device type: 101
+//
+// STATUS_LENGTH = 96. Frames:
+//   AA 0x66 10 EB <96 bytes> <checksum> BB
+//       Full/initial status
+//
+//   AA 0xC6 10 EC <96 previous> <96 current> <checksum> BB
+//       Status delta; only the current status block is decoded.
+
+// Fridge=3C, freezer=-20C, door closed,
+// Express Cool OFF, Express Freeze OFF,
+// drawer mode Cheese, unit Celsius.
+const SAMPLE_INITIAL = buf(
+    'AA6610EB02050601FFFFFF0201FFFFFF00FFFFFF0000FFFFFFFFFFFFFFFF010101FF02FFFFFFFFFFFFFFFFFF01FF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0078FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0005FFFFFFFFFF01010101000EBB',
+)
+
+// Same values as SAMPLE_INITIAL, but door open.
+const SAMPLE_DOOR_OPEN = buf(
+    'AA6610EB02050601FFFFFF0101FFFFFF00FFFFFF0000FFFFFFFFFFFFFFFF010101FF02FFFFFFFFFFFFFFFFFF01FF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0078FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0005FFFFFFFFFF01010101000FBB',
+)
+
+// Fridge=3C, freezer=-23C, door open,
+// Express Freeze ON, drawer mode Cheese.
+const SAMPLE_EXPRESS_FREEZE_ON = buf(
+    'AA6610EB02050902FFFFFF0101FFFFFF00FFFFFF0000FFFFFFFFFFFFFFFF010103FF02FFFFFFFFFFFFFFFFFF01FF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0078FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0005FFFFFFFFFF01010000000BBB',
+)
+
+// Fridge=3C, freezer=-20C, door open,
+// Express Cool ON, Express Freeze OFF,
+// drawer mode Cheese.
+const SAMPLE_EXPRESS_COOL_ON = buf(
+    'AA6610EB02050601FFFFFF0101FFFFFF00FFFFFF0100FFFFFFFFFFFFFFFF010103FF02FFFFFFFFFFFFFFFFFF01FF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0078FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0005FFFFFFFFFF01010000000EBB',
+)
+
+// Drawer mode Fish, raw value 1.
+const SAMPLE_DRAWER_FISH = buf(
+    'AA6610EB02050601FFFFFF0101FFFFFF00FFFFFF0000FFFFFFFFFFFFFFFF010103FF02FFFFFFFFFFFFFFFFFF01FF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0078FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0005FFFFFFFFFF010101010108BB',
+)
+
+// Drawer mode Meat, raw value 2.
+const SAMPLE_DRAWER_MEAT = buf(
+    'AA6610EB02050601FFFFFF0101FFFFFF00FFFFFF0000FFFFFFFFFFFFFFFF010103FF02FFFFFFFFFFFFFFFFFF01FF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0078FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0005FFFFFFFFFF01010101020BBB',
+)
+
+// Delta: previous state has the door open, current state has the door closed.
+// Fridge remains at 3C, freezer remains at -20C, and drawer mode remains Cheese.
+const SAMPLE_DELTA_DOOR_OPEN_TO_CLOSED = buf(
+    'AAC610EC02050601FFFFFF0101FFFFFF00FFFFFF0000FFFFFFFFFFFFFFFF010101FF02FFFFFFFFFFFFFFFFFF01FF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0078FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0005FFFFFFFFFF010101010002050601FFFFFF0201FFFFFF00FFFFFF0000FFFFFFFFFFFFFFFF010101FF02FFFFFFFFFFFFFFFFFF01FF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0078FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0005FFFFFFFFFF01010101005EBB',
+)
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('config is not published until a valid status frame establishes the temperature unit', () => {
+        const { ha } = makeDevice()
+
+        assert.equal(ha.devices[DEVICE_ID], undefined)
+    })
+
+    test('0x10EB full status publishes Celsius configuration and decodes the appliance state', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', SAMPLE_INITIAL)
+
+        const dev = ha.devices[DEVICE_ID]
+        assert.ok(dev?.config, 'Home Assistant configuration published')
+
+        const components = dev.config!.components as Record<string, Record<string, unknown>>
+
+        assert.equal(components.fridge_setpoint.unit_of_measurement, '°C')
+        assert.equal(components.fridge_setpoint.min, 1)
+        assert.equal(components.fridge_setpoint.max, 7)
+
+        assert.equal(components.freezer_setpoint.unit_of_measurement, '°C')
+        assert.equal(components.freezer_setpoint.min, -23)
+        assert.equal(components.freezer_setpoint.max, -15)
+
+        assert.ok(components.door, 'door component')
+        assert.ok(components.express_cool, 'express_cool component')
+        assert.ok(components.express_freeze, 'express_freeze component')
+        assert.ok(components.drawer_mode, 'drawer_mode component')
+        assert.ok(components.drawer_mode_raw, 'drawer_mode_raw component')
+
+        assert.equal(dev.properties.fridge_setpoint, 3)
+        assert.equal(dev.properties.freezer_setpoint, -20)
+        assert.equal(dev.properties.door, 'OFF')
+        assert.equal(dev.properties.express_cool, 'OFF')
+        assert.equal(dev.properties.express_freeze, 'OFF')
+        assert.equal(dev.properties.drawer_mode, 'Cheese')
+        assert.equal(dev.properties.drawer_mode_raw, '0')
+    })
+
+    test('0x10EB full status decodes an open door', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', SAMPLE_DOOR_OPEN)
+
+        const props = ha.devices[DEVICE_ID].properties
+
+        assert.equal(props.door, 'ON')
+        assert.equal(props.fridge_setpoint, 3)
+        assert.equal(props.freezer_setpoint, -20)
+    })
+
+    test('0x10EB full status decodes Express Freeze ON', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', SAMPLE_EXPRESS_FREEZE_ON)
+
+        const props = ha.devices[DEVICE_ID].properties
+
+        assert.equal(props.freezer_setpoint, -23)
+        assert.equal(props.express_freeze, 'ON')
+        assert.equal(props.express_cool, 'OFF')
+        assert.equal(props.door, 'ON')
+    })
+
+    test('0x10EB full status decodes Express Cool ON', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', SAMPLE_EXPRESS_COOL_ON)
+
+        const props = ha.devices[DEVICE_ID].properties
+
+        assert.equal(props.express_cool, 'ON')
+        assert.equal(props.express_freeze, 'OFF')
+        assert.equal(props.door, 'ON')
+    })
+
+    test('drawer mode raw 0 is decoded as Cheese', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', SAMPLE_INITIAL)
+
+        const props = ha.devices[DEVICE_ID].properties
+
+        assert.equal(props.drawer_mode_raw, '0')
+        assert.equal(props.drawer_mode, 'Cheese')
+    })
+
+    test('drawer mode raw 1 is decoded as Fish', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', SAMPLE_DRAWER_FISH)
+
+        const props = ha.devices[DEVICE_ID].properties
+
+        assert.equal(props.drawer_mode_raw, '1')
+        assert.equal(props.drawer_mode, 'Fish')
+    })
+
+    test('drawer mode raw 2 is decoded as Meat', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', SAMPLE_DRAWER_MEAT)
+
+        const props = ha.devices[DEVICE_ID].properties
+
+        assert.equal(props.drawer_mode_raw, '2')
+        assert.equal(props.drawer_mode, 'Meat')
+    })
+
+    test('0x10EC delta decodes only the current status block', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', SAMPLE_DELTA_DOOR_OPEN_TO_CLOSED)
+
+        const props = ha.devices[DEVICE_ID].properties
+
+        assert.equal(props.fridge_setpoint, 3)
+        assert.equal(props.freezer_setpoint, -20)
+        assert.equal(props.door, 'OFF')
+        assert.equal(props.express_cool, 'OFF')
+        assert.equal(props.express_freeze, 'OFF')
+        assert.equal(props.drawer_mode, 'Cheese')
+        assert.equal(props.drawer_mode_raw, '0')
+    })
+
+    test('frames not matching the AA..BB envelope are ignored', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', buf('001122'))
+
+        assert.equal(ha.devices[DEVICE_ID], undefined)
+    })
+
+    test('frames with an unrecognised inner shape are ignored', () => {
+        const { ha, thinq } = makeDevice()
+
+        // Valid AA..BB frame, but the inner packet type is not 0x10EB or 0x10EC.
+        thinq.emit('data', buf('AA08109901020304BB'))
+
+        assert.equal(ha.devices[DEVICE_ID], undefined)
+    })
+
+    test('start() sends the F0ED status query packet', () => {
+        const { thinq, dev } = makeDevice()
+
+        thinq.resetRecorder()
+        dev.start()
+
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(hex(thinq.outbox[0]), 'AA0EF0ED1211010000010400EBBB')
+    })
+
+    test('HA write fridge_setpoint=4C creates a 96-byte setting frame', () => {
+        const { thinq, dev } = makeDevice()
+
+        thinq.emit('data', SAMPLE_INITIAL)
+        thinq.resetRecorder()
+
+        dev.setProperty('fridge_setpoint', '4')
+
+        const pkt = thinq.outbox[0]
+
+        // Frame layout:
+        // AA <length> F0 17 <96-byte status> <checksum> BB
+        assert.equal(pkt[2], 0xf0)
+        assert.equal(pkt[3], 0x17)
+        assert.equal(pkt[4 + 1], 4)
+        assert.equal(pkt[4 + 8], 1)
+
+        // Unchanged fields use the 0xFF sentinel.
+        assert.equal(pkt[4 + 0], 0xff)
+        assert.equal(pkt[4 + 2], 0xff)
+    })
+
+    test('HA write freezer_setpoint=-20C creates the expected raw value', () => {
+        const { thinq, dev } = makeDevice()
+
+        thinq.emit('data', SAMPLE_INITIAL)
+        thinq.resetRecorder()
+
+        dev.setProperty('freezer_setpoint', '-20')
+
+        const pkt = thinq.outbox[0]
+
+        assert.equal(pkt[4 + 2], 6)
+        assert.equal(pkt[4 + 1], 0xff)
+        assert.equal(pkt[4 + 8], 1)
+    })
+
+    test('HA write express_cool=ON sets the Express Cool field', () => {
+        const { thinq, dev } = makeDevice()
+
+        thinq.emit('data', SAMPLE_INITIAL)
+        thinq.resetRecorder()
+
+        dev.setProperty('express_cool', 'ON')
+
+        const pkt = thinq.outbox[0]
+
+        assert.equal(pkt[4 + 16], 1)
+    })
+
+    test('HA write express_freeze=ON sets the Express Freeze field', () => {
+        const { thinq, dev } = makeDevice()
+
+        thinq.emit('data', SAMPLE_INITIAL)
+        thinq.resetRecorder()
+
+        dev.setProperty('express_freeze', 'ON')
+
+        const pkt = thinq.outbox[0]
+
+        assert.equal(pkt[4 + 3], 2)
+    })
+
+    test('HA write to an unknown property sends nothing', () => {
+        const { thinq, dev } = makeDevice()
+
+        thinq.emit('data', SAMPLE_INITIAL)
+        thinq.resetRecorder()
+
+        dev.setProperty('does-not-exist', '1')
+
+        assert.equal(thinq.outbox.length, 0)
+    })
+})


### PR DESCRIPTION
## Summary

Adds initial support for the LG GBBS322CEV refrigerator.

The appliance identifies itself as:

```yaml
model_id: 2REBGLUB_2P__
device_type: 101
protocol: ThinQ2
```

Closes #140.

## Supported features

The following features were tested with a real appliance and are exposed through Home Assistant MQTT discovery:

- Fridge temperature setpoint
- Freezer temperature setpoint
- Combined door state
- Express Cool
- Express Freeze
- Drawer mode:
  - Cheese
  - Fish
  - Meat
- Raw drawer mode value for validation and debugging

## Protocol details

The implementation is based on the existing `2RES1VE61NFA2` refrigerator decoder, but this appliance uses a 96-byte status block.

Observed packet formats:

```text
AA 0x66 10 EB <96-byte status> <checksum> BB
AA 0xC6 10 EC <96-byte previous status> <96-byte current status> <checksum> BB
```

The existing status query also works with this model:

```text
AA0EF0ED1211010000010400EBBB
```

## Confirmed field mapping

```yaml
fridge_setpoint:
  status_offset: 1
  formula: 8 - raw

freezer_setpoint:
  status_offset: 2
  formula: -14 - raw

express_freeze:
  status_offset: 3
  values:
    1: off
    2: on

door:
  status_offset: 7
  values:
    1: open
    2: closed

temperature_unit:
  status_offset: 8
  values:
    1: Celsius

express_cool:
  status_offset: 16
  values:
    0: off
    1: on

drawer_mode:
  status_offset: 95
  values:
    0: Cheese
    1: Fish
    2: Meat
```

The door field appears to be a combined state. Both the fridge door and freezer door produce the same open and closed values.

## Testing

The implementation was tested using a locally built Docker image with a real LG GBBS322CEV appliance.

Confirmed in Home Assistant:

```yaml
fridge_setpoint: working
freezer_setpoint: working
door: working
express_cool: working
express_freeze: working
drawer_mode: working
drawer_mode_raw: working
```

Automated tests use real packet captures and cover:

- Full `0x10EB` status decoding
- Current-state extraction from `0x10EC` delta packets
- Fridge and freezer setpoints
- Open and closed door states
- Express Cool
- Express Freeze
- Cheese, Fish, and Meat drawer modes
- Status query generation
- Home Assistant setting packet generation
- Invalid and unsupported packet handling

Full test suite result:

```text
tests: 426
passed: 426
failed: 0
```

## Files added or modified

```text
cloud/devices/2REBGLUB_2P__.ts
cloud/ha_bridge.ts
tests/cloud/devices/2REBGLUB_2P__.test.ts
```

## Notes

The implementation should be considered preliminary because additional appliance fields may still be unidentified.

The currently exposed features were verified against the real appliance and Home Assistant.