### PR TITLE
 Expand LG RAC support (deviceType 401, modern caps & 0xA7 TLV)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,36 +13,45 @@ aid, or simply to allow the user to still use the original LG app alongside Home
 
 The following appliances are currently supported in rethink:
 
-- Air Conditioners:
-    - 👍 LG DualCool family (Standard 2, Deluxe with and without air purifier, etc.) wall-mounted Air Conditioner IDUs - high level of support. What's missing are mostly some features of higher-end models and more diagnostic coverage,
-    - 👍 LW1822HRSM, Smart Window Air Conditioner - mostly working,
-    - 👍 LP1022FVSM Portable Air Conditioner - mostly working,
-- Fridges:
-    - 🫤 LF28H8330S, Standard-Depth 4-Door French Door Refrigerator - preliminary support,
-    - 🫤 GSJV70PZTE, LG Side by Side Refrigerator - preliminary support,
-    - 🫤 GSB470BASZ, American Style Side by Side Refrigerator - preliminary support,
-    - 🫤 GA-B509CMUM - preliminary support,
-- Washing Machines:
-    - 🫤 (model name unknown) Washing Machine - preliminary support
-    - 👍 F2J7HG1W, Washing Machine - mostly working,
-    - 🫤 F4WV508S2E, Front-Loading Washing Machine - preliminary support
-    - 🫤 F4WV709P1E, Front-Loading Washing Machine - preliminary support
-    - 🫤 TW4V9RW9W - preliminary support
-    - 👍 F4X7511TWS (VCDWL2QEUK), Front-Load Washing Machine - mostly working
-    - 🫤 WT7300CW - preliminary support
-    - 👍 WM3900HBA (F3L2CYU\_\_), Front-Load Washing Machine - mostly working
-    - 👍 FV1413H2B, Washing Machine - mostly working,
-    - 👍 F3L7CYK5W_US_WIFI, Front-Load Washing Machine - mostly working
-- Dryers:
-    - 🫤 DLE7300WE - preliminary support
-    - 👍 DLEX3900B (RV13B6BSD_D_US_WIFI), Electric Dryer - mostly working
-    - 👍 RV13B6ES_D_US_WIFI, Electric Dryer - mostly working
-- WashTowers (combined washer+dryer):
-    - 👍 WKEX200HBA (WTL_FXU_BDV_NA_01), WashTower - mostly working
-- Dehumidifiers
-    - 👍 MD19GQGE0, Smart Dehumidifier - mostly working
-- Range Hoods:
-    - 👍 HCED3015D (STUDIO_HOOD), Generic identifier and probably works with multiple models. Working.
+| Model / Description                                                  | Status                   | Tested | Contributor              |
+| -------------------------------------------------------------------- | ------------------------ | ------ | ------------------------ |
+| **Air Conditioners**                                                 |                          |        |                          |
+| LG DualCool family (Standard 2, Deluxe with/without air purifier)    | 👍 High level of support | Yes    | anszom, maciejsszmigiero |
+| WZ12AWN SNU3 / S3NW12TZXBB (DualCool 12k Inverter AC)                | 👍 High level of support | Yes    | nacorsito                |
+| WZ18AWN SNU1 / S3NW18TZXBA (DualCool 18k Inverter AC)                | 👍 High level of support | Yes    | nacorsito                |
+| WZ09* / S3NW09*, WZ24* / S3NW24* (DualCool series - shared protocol) | 👍 High level of support | No     | nacorsito                |
+| Modern ThinQ2 RAC (deviceType 401 / 917be+ firmware)                 | 👍 High level of support | No     | nacorsito                |
+| LW1822HRSM (Smart Window Air Conditioner)                            | 👍 Mostly working        | Yes    | kheston                  |
+| LP1022FVSM (Portable Air Conditioner)                                | 👍 Mostly working        | Yes    | walker0643               |
+| **Refrigerators**                                                    |                          |        |                          |
+| LF28H8330S (Standard-Depth 4-Door French Door Refrigerator)          | 🫤 Preliminary support   | No     | anszom                   |
+| GSJV70PZTE (LG Side by Side Refrigerator)                            | 🫤 Preliminary support   | No     | anszom                   |
+| GSB470BASZ (American Style Side by Side Refrigerator)                | 🫤 Preliminary support   | No     | anszom                   |
+| GA-B509CMUM                                                          | 🫤 Preliminary support   | No     | anszom                   |
+| 2REF11EBIVPC4                                                        | 🫤 Preliminary support   | No     | NadavK                   |
+| **Washing Machines & Combos**                                        |                          |        |                          |
+| (model name unknown) Washing Machine                                 | 🫤 Preliminary support   | No     | anszom                   |
+| F2J7HG1W (ThinQ 1 Washing Machine)                                   | 👍 Mostly working        | Yes    | anszom                   |
+| F4WV508S2E (Front-Loading Washing Machine)                           | 🫤 Preliminary support   | No     | pabbloo                  |
+| F4WV709P1E (Front-Loading Washing Machine)                           | 🫤 Preliminary support   | No     | ToniH1987                |
+| TW4V9RW9W                                                            | 🫤 Preliminary support   | No     | anszom                   |
+| F4X7511TWS (VCDWL2QEUK), Front-Load Washing Machine                  | 👍 Mostly working        | Yes    | maslygan                 |
+| WT7300CW                                                             | 🫤 Preliminary support   | No     | tberg                    |
+| WM3900HBA (F3L2CYU\_\_), Front-Load Washing Machine                  | 👍 Mostly working        | Yes    | bateman.joseph           |
+| FV1413H2B (F_V**F\_**W_B_1QEUK), Washing Machine                     | 👍 Mostly working        | Yes    | artemon_93, stevenbower  |
+| F3L7CYK5W_US_WIFI (Front-Load Washing Machine)                       | 👍 Mostly working        | Yes    | Danimal4326              |
+| W4WR70E61 (Y_V8_F\_\_\_W.B_2QEUK), Washer/Dryer Combo                | 👍 Mostly working        | Yes    | max.obenaus              |
+| CV74J7S2QA (F_VB_F\_\_\_W.B_2QEUK), Washer/Dryer Combo               | 👍 Mostly working        | Yes    | joonas.palosuo           |
+| **Dryers**                                                           |                          |        |                          |
+| DLE7300WE (RV13U6AM8W_D_US_WIFI)                                     | 🫤 Preliminary support   | No     | tberg                    |
+| DLEX3900B (RV13B6BSD_D_US_WIFI), Electric Dryer                      | 👍 Mostly working        | Yes    | bateman.joseph           |
+| RV13B6ES_D_US_WIFI (Electric Dryer)                                  | 👍 Mostly working        | Yes    | Danimal4326              |
+| **WashTowers**                                                       |                          |        |                          |
+| WKEX200HBA (WTL_FXU_BDV_NA_01), WashTower                            | 👍 Mostly working        | Yes    | schmittjoseph            |
+| **Dehumidifiers**                                                    |                          |        |                          |
+| MD19GQGE0 (DHUM_056905_WW), Smart Dehumidifier                       | 👍 Mostly working        | Yes    | stevenbower              |
+| **Range Hoods**                                                      |                          |        |                          |
+| HCED3015D (STUDIO_HOOD), Generic identifier                          | 👍 Working               | Yes    | B1223GS87                |
 
 The supported appliances can be used "out of the box" with HomeAssistant or another compatible MQTT consumer.  
 Appliances not listed above can still be used with the bridge mode, but they will not be translated to MQTT. Contributions are welcome!

--- a/cloud/devices/RAC_056905_WW.ts
+++ b/cloud/devices/RAC_056905_WW.ts
@@ -86,8 +86,8 @@ export default class Device extends TLVDevice {
     }
 
     isCapsResponse(tlvArray: TLV.TLV[]) {
-        /* eeprom checksum */
-        return tlvArray.some(({ t, v }) => t === 0x2da)
+        /* eeprom checksum (0x2da on older firmware, 0x2db or 0x2c1 on modern firmware) */
+        return tlvArray.some(({ t, v }) => t === 0x2da || t === 0x2db || t === 0x2c1)
     }
 
     isValuesResponse(tlvArray: TLV.TLV[]) {

--- a/cloud/devices/tlv_device.ts
+++ b/cloud/devices/tlv_device.ts
@@ -152,7 +152,7 @@ export default class TLVDevice extends HADevice {
             buf[3] == 0x00 &&
             buf[4] == 0x00 &&
             buf[5] == 0x00 &&
-            buf[6] == 0x87 &&
+            (buf[6] == 0x87 || buf[6] == 0xa7) &&
             buf[7] == 0xfd &&
             buf[8] == 0x03 &&
             buf[10] == buf.length - 13
@@ -165,7 +165,7 @@ export default class TLVDevice extends HADevice {
             buf[3] == 0x00 &&
             buf[4] == 0x00 &&
             buf[5] == 0x00 &&
-            buf[6] == 0x87 &&
+            (buf[6] == 0x87 || buf[6] == 0xa7) &&
             buf[7] == 0xfd &&
             buf[8] == 0x10 &&
             buf[9] == 0x00 &&

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -40,6 +40,12 @@ const t2deviceTypes: Record<string, T2Factory> = {
     POT_056905_WW,
     RAC_056905_WW,
     ['RAC_0B0001_WW']: RAC_056905_WW, // a different European variant (deviceType 401, RTK_RTL8720cm), same TLV handler
+    ['WZ12AWN']: RAC_056905_WW,
+    ['WZ12AWN SNU3']: RAC_056905_WW,
+    ['S3NW12TZXBB']: RAC_056905_WW,
+    ['WZ18AWN']: RAC_056905_WW,
+    ['WZ18AWN SNU1']: RAC_056905_WW,
+    ['S3NW18TZXBA']: RAC_056905_WW,
     WIN_056905_WW,
     ['2REF11EIDA__4']: Dev_2REF11EIDA__4,
     ['2REF11EBIVPC4']: Dev_2REF11EBIVPC4,
@@ -92,7 +98,20 @@ class Bridge {
             const devclass = t1deviceTypes[meta.modelId]
             if (devclass) hadevice = new devclass(this.HA, thinqdev, meta)
         } else if (thinqdev.platform === 'thinq2') {
-            const devclass = t2deviceTypes[meta.modelId]
+            let devclass = t2deviceTypes[meta.modelId]
+            if (!devclass && meta.modelName) {
+                devclass = t2deviceTypes[meta.modelName]
+            }
+            if (!devclass) {
+                const isRac =
+                    String(meta.deviceType) === '401' ||
+                    (typeof meta.modelId === 'string' && /^RAC_/i.test(meta.modelId)) ||
+                    (typeof meta.modelName === 'string' && /^(WZ|S3NW)/i.test(meta.modelName)) ||
+                    (typeof meta.modelId === 'string' && /^(WZ|S3NW)/i.test(meta.modelId))
+                if (isRac) {
+                    devclass = RAC_056905_WW
+                }
+            }
             if (devclass) hadevice = new devclass(this.HA, thinqdev, meta)
         }
 

--- a/rethink-setup.ts
+++ b/rethink-setup.ts
@@ -1,4 +1,6 @@
 import * as tls from 'node:tls'
+import * as fs from 'node:fs'
+import * as crypto from 'node:crypto'
 import jsonSplitter from './util/json_splitter'
 import * as mtosp from './util/mtosp'
 
@@ -17,21 +19,37 @@ const [host, wifiname, wifipass] = process.argv.slice(2)
 
 async function request(xml: string) {
     const socket = await new Promise<tls.TLSSocket>((resolve, reject) => {
-        const socket = tls.connect({ host: host, port: 5500, rejectUnauthorized: false }, () => resolve(socket))
-        socket.on('error', reject)
+        const timer = setTimeout(() => reject(new Error('Connection timeout to ' + host)), 4000)
+        const socket = tls.connect({ host: host, port: 5500, rejectUnauthorized: false }, () => {
+            clearTimeout(timer)
+            resolve(socket)
+        })
+        socket.on('error', (err) => {
+            clearTimeout(timer)
+            reject(err)
+        })
     })
 
     try {
         socket.write(mtosp.format(xml))
 
         return await new Promise<string>((resolve, reject) => {
-            socket.on('error', reject)
+            const timer = setTimeout(() => reject(new Error('ThinQ1 request timeout')), 3000)
+            socket.on('error', (err) => {
+                clearTimeout(timer)
+                reject(err)
+            })
 
             const splitter = mtosp.splitter()
             socket.on('data', (data) => {
                 try {
-                    for (const byte of data) splitter(byte, resolve)
+                    for (const byte of data)
+                        splitter(byte, (msg) => {
+                            clearTimeout(timer)
+                            resolve(msg)
+                        })
                 } catch (err) {
+                    clearTimeout(timer)
                     reject(err)
                 }
             })
@@ -66,13 +84,21 @@ async function thinq1Setup() {
     console.log('ThinQ2 setup successful, see rethink-cloud logs for a follow-up')
 }
 
-function thinq2Setup() {
-    // NOTE: keep the base64 lines at column 0 — no leading whitespace *inside* the PEM. The
-    // RTL8720cm "CLIP" firmware (DeviceType 202, protocolVer 4.9) uses a strict PEM parser that
-    // rejects in-band tabs/spaces: with indentation it fails its RSA-encrypt step in getDeviceInfo
-    // (returns encrypt_val:'' and extra ...encryptRes:ffff) and then loops on /route forever. Older
-    // firmware tolerates the whitespace. Same key bytes, just clean framing.
-    const publicKey = `-----BEGIN PUBLIC KEY-----
+function getPublicKey(): string {
+    const caCertPaths = ['./data/ca.cert', 'data/ca.cert', '/app/data/ca.cert', '../data/ca.cert']
+    for (const p of caCertPaths) {
+        if (fs.existsSync(p)) {
+            try {
+                const certPem = fs.readFileSync(p, 'utf8')
+                const keyObj = crypto.createPublicKey(certPem)
+                return keyObj.export({ type: 'spki', format: 'pem' }).toString().trim() + '\n'
+            } catch (e) {
+                console.warn(`Failed to extract public key from ${p}:`, e)
+            }
+        }
+    }
+    // Fallback to default bundled public key
+    return `-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApYRAZXRWijMuWNr9LHOJ
 fcPcZHDYcO3CwRF9olsPvtJpkrDXR7jEDA6qPHF1jvJ7ArxDLVj8rbkwXb3oXNmN
 Sc+n0DPNDiRgghDaDyJpN0qfzmt06MKdihVScwghyYKWD+oA9d1+j3wy3W32he+X
@@ -82,9 +108,36 @@ qA1bDeDvjP7QC93lGxmwIYR0H8VVQq7gBZYWpPfsRSfwsE/PCMrF1WS4sPnSauaV
 QwIDAQAB
 -----END PUBLIC KEY-----
 `
+}
+
+function thinq2Setup() {
+    let hostname = 'common.lgthinq.com'
+    let httpsPort = 443
+    let mqttsPort = 8883
+
+    const configPaths = ['./data/config.json', 'data/config.json', '/app/data/config.json', '../data/config.json']
+    for (const p of configPaths) {
+        if (fs.existsSync(p)) {
+            try {
+                const raw = fs.readFileSync(p, 'utf8')
+                const mHost = raw.match(/"hostname"\s*:\s*"([^"]+)"/)
+                const mHttps = raw.match(/"https_port"\s*:\s*(\d+)/)
+                const mMqtts = raw.match(/"mqtts_port"\s*:\s*(\d+)/)
+                if (mHost) hostname = mHost[1]
+                if (mHttps) httpsPort = parseInt(mHttps[1], 10)
+                if (mMqtts) mqttsPort = parseInt(mMqtts[1], 10)
+                break
+            } catch (e) {}
+        }
+    }
+
+    const publicKey = getPublicKey()
+
     return new Promise<void>((resolve, reject) => {
         console.log(`Connecting to ${host}:5500`)
+        const timer = setTimeout(() => reject(new Error('ThinQ2 connection timeout to ' + host)), 30000)
         const socket = tls.connect({ host: host, port: 5500, rejectUnauthorized: false }, function () {
+            clearTimeout(timer)
             console.log('TLS connection established')
             socket.write(
                 JSON.stringify({ type: 'request', cmd: 'setDeviceInit', data: { set: 'true', constantConnect: 'Y' } }),
@@ -111,6 +164,8 @@ QwIDAQAB
                                 timezone: '+0100',
                                 publicKey,
                                 constantConnect: 'Y',
+                                mqttServer: `ssl://${hostname}:${mqttsPort}`,
+                                apiServer: `https://${hostname}:${httpsPort}`,
                             },
                         }),
                     )
@@ -171,14 +226,14 @@ QwIDAQAB
 }
 
 ;(async () => {
-    // We try the ThinQ 1 protocol first. The formatting should be rejected by ThinQ2 appliances. Hopefully.
+    // We try the ThinQ 1 protocol first. The formatting should be rejected by ThinQ2 appliances.
     try {
         console.log('Trying ThinQ 1 setup')
         await thinq1Setup()
     } catch (err) {
         console.log('ThinQ 1 setup failed', err)
         console.log('Trying ThinQ 2 setup')
-        thinq2Setup()
+        await thinq2Setup()
     }
 })()
 

--- a/tests/cloud/devices/RAC_056905_WW.test.ts
+++ b/tests/cloud/devices/RAC_056905_WW.test.ts
@@ -196,4 +196,18 @@ describe(MODEL_ID, () => {
         assert.equal(hex(thinq.outbox[0]), CAPS_REQUEST_HEX.toUpperCase())
         dev.drop()
     })
+
+    test('0xA7 modern firmware caps response triggers values query', (t) => {
+        enableMockTimers(t)
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+
+        // Real packet capture from modern firmware (917be) sending 0xA7 command byte and tags 0x2db/0x2c1
+        const MODERN_CAPS_HEX =
+            '000004000000A702010167B001B05057B0A001FEB0C0B100B2103DB280B2C4B300B4C4B5A08000B500B540B35030D402B85020B8903EB8D020B9103EBAD020BB103EBC6002014281B5C0B61038B648B5C1B61038B648B5C2B61038B648B5C6B61038B648B5C4B61038B648B6F00917BEBD411578'
+
+        thinq.emit('data', buf(MODERN_CAPS_HEX))
+        assert.equal(dev.query_caps_timeout, undefined, 'query_caps_timeout cleared on caps response')
+        dev.drop()
+    })
 })

--- a/tests/cloud/ha_bridge.test.ts
+++ b/tests/cloud/ha_bridge.test.ts
@@ -1,0 +1,36 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import Bridge from '@/cloud/ha_bridge'
+import RAC_056905_WW from '@/cloud/devices/RAC_056905_WW'
+import { MockHAConnection, MockThinq2Device } from '@/tests/helpers/mocks'
+
+describe('ha_bridge AC model matching', () => {
+    const testCases = [
+        { modelId: 'WZ12AWN', modelName: 'WZ12AWN SNU3', deviceType: '401' },
+        { modelId: 'WZ12AWN SNU3', modelName: 'S3NW12TZXBB', deviceType: '401' },
+        { modelId: 'S3NW12TZXBB', modelName: 'WZ12AWN', deviceType: '401' },
+        { modelId: 'WZ18AWN', modelName: 'WZ18AWN SNU1', deviceType: '401' },
+        { modelId: 'WZ18AWN SNU1', modelName: 'S3NW18TZXBA', deviceType: '401' },
+        { modelId: 'S3NW18TZXBA', modelName: 'WZ18AWN', deviceType: '401' },
+        { modelId: 'RAC_CUSTOM_01', modelName: 'LG Inverter AC', deviceType: '401' },
+        { modelId: 'UNKNOWN_ID', modelName: 'S3NW12TZXBB', deviceType: '401' },
+        { modelId: 'UNKNOWN_ID', modelName: 'Unknown AC', deviceType: '401' },
+    ]
+
+    for (const tc of testCases) {
+        test(`maps ${tc.modelId} (${tc.modelName}) to RAC_056905_WW`, () => {
+            const ha = new MockHAConnection()
+            const bridge = new Bridge(ha.asConnection())
+            const thinq = new MockThinq2Device('ac-test-1', {
+                modelId: tc.modelId,
+                modelName: tc.modelName,
+                deviceType: tc.deviceType,
+            })
+
+            bridge.newDevice(thinq as any)
+            const hadev = bridge.haDevices.get('ac-test-1')
+            assert.ok(hadev, `Device should be registered for ${tc.modelId}`)
+            assert.ok(hadev instanceof RAC_056905_WW, `Device should be instance of RAC_056905_WW for ${tc.modelId}`)
+        })
+    }
+})


### PR DESCRIPTION
### Summary
Adds support for modern LG DualCool Room Air Conditioners (RAC) running newer firmware (`917be` and European/Global `WZ`/`S3NW` inverter series), improves provisioning reliability with custom CA certs, and formats the supported appliances list in `README.md` into a structured table with contributor attribution.

### Key Changes
1. **Capabilities Tag Detection (`cloud/devices/RAC_056905_WW.ts`):**
   - Newer RAC firmware omits the legacy `0x2da` EEPROM tag, sending `0x2db` or `0x2c1` instead.
   - Expanded `isCapsResponse()` to accept `0x2db` and `0x2c1` to prevent devices from getting stuck in a capabilities query retry loop.

2. **TLV Private Data Command Byte (`cloud/devices/tlv_device.ts`):**
   - Allow `0xA7` command bytes alongside `0x87` in `processPrivData` and `processPrivDataCmdResp` frames.

3. **HA Bridge Model Aliases & Fallbacks (`cloud/ha_bridge.ts`):**
   - Added explicit mappings for `WZ12AWN`, `WZ18AWN`, and `S3NW` series.
   - Added fallback logic: when `meta.modelId` is not found, fallback to `meta.modelName` or map appliances reporting `deviceType === 401` / `RAC_` to `RAC_056905_WW`.

4. **Dynamic RSA Key in Provisioning Tool (`rethink-setup.ts`):**
   - Extracts the public key dynamically from `./data/ca.cert` using Node `crypto` (falling back to bundled key), fixing `encryptRes:ffff` errors when custom CA certificates are generated.
   - Added connection (4s) and read (3s) socket timeouts so `thinq1Setup` gracefully falls through to `thinq2Setup` without hanging.

5. **Unit Tests & Documentation:**
   - Added `tests/cloud/ha_bridge.test.ts` for model matching & fallbacks.
   - Added `0xA7` modern caps test in `tests/cloud/devices/RAC_056905_WW.test.ts`.
   - Converted `README.md` supported appliances list into a clean, categorized table with contributor credits.

### Testing
- Tested on physical LG DualCool units (`WZ12AWN SNU3 / S3NW12TZXBB` and `WZ18AWN SNU1 / S3NW18TZXBA`) with full bidirectional Home Assistant climate control and live telemetry.
- All test suites passing (`npm test`).
- TypeScript build succeeds cleanly (`npm run build`).