### PR TITLE
Add support for the LG WFV474PGV oven

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The following appliances are currently supported in rethink:
     - 👍 HCED3015D (STUDIO_HOOD), Generic identifier and probably works with multiple models. Working.
 - Stylers:
     - 👍 S5BBP (ST_B_E4H01Y_APL), Styler - mostly working
+- Ovens and Ranges:
+    - 🫤 WFV474PGV, Double oven/range - preliminary status, timer, cancel, and constrained remote-start support
 
 The supported appliances can be used "out of the box" with HomeAssistant or another compatible MQTT consumer.  
 Appliances not listed above can still be used with the bridge mode, but they will not be translated to MQTT. Contributions are welcome!

--- a/cloud/devices/WFV474PGV.ts
+++ b/cloud/devices/WFV474PGV.ts
@@ -1,0 +1,789 @@
+import HADevice from './base'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import AABBDevice from './aabb_device'
+import log from '@/util/logging'
+
+// LG oven reporting modelName "WFV474PGV" (deviceType 301, QCOM_QCA4010).
+//
+// Live captures establish the transport framing, status fields, timer commands, cavity cancel
+// selectors, and four remote-start operation profiles. Observed frame types:
+//
+//   0x40 0xEB  single current-status block, sent in reply to the status query in start()
+//   0x40 0xEC  previous and current status blocks, concatenated in that order
+//   0x40 0x31  component manifest (observed serial SAA39155903)
+//   0x40 0x72  one-shot event (timer expiry: 03 F5 0A; upper cook completion: 00 04 0A)
+//
+// Cloud-to-device writes seen so far are the F0 43 family (0x20 cavity start, 0x21 preference /
+// clock write, 0x23 timer) and the F0 44 cavity cancel.
+//
+// The known EB frame is 0x44 bytes on the wire and the EC frame is 0x82 bytes, making each status
+// block 62 bytes. Bytes that are not decoded stay out of Home Assistant; frames that are not
+// understood are logged only.
+//
+// The LG app presents three tabs: Cooktop, Upper Oven, and Lower Oven. Both oven tabs expose
+// temperature and cook time, and the app also has a settable timer. Writes are limited to captured
+// command shapes. The Upper operation exposed by the LG app is Bake; command operation 0x01 reports
+// as mode 0x81.
+//
+// The oven enforces the Remote Start arming lockout itself: a start sent to an unarmed cavity is
+// answered with the rejection acknowledgement below and nothing happens. The Start buttons are
+// gated in Home Assistant through the readiness topic's availability, and no further check is made
+// here — see the "Safety interlocks" rule in CONTRIBUTING.md.
+
+const CLASS_BYTE = 0x40
+const SINGLE_STATUS_FRAME_TYPE = 0xeb
+const STATUS_FRAME_TYPE = 0xec
+const STATUS_RECORD_LENGTH = 62
+
+// Confirmed by live off -> on and on -> off transitions on 2026-08-22. The status record contains
+// five repeated 5-byte cooktop slots beginning at offset 36. Their leading bytes all changed
+// 0x00 -> 0x01 in one EC frame when the cooktop was turned on, remained 0x01 while it stayed on, and
+// returned 0x01 -> 0x00 together in the turn-off EC frame. A later test with only the physical middle
+// burner on still made all five groups identical, confirming that these are redundant copies of a
+// global cooktop state/run time rather than independent burner states. Treat the cooktop as active
+// when any copy is active.
+const COOKTOP_SLOT_STATE_OFFSETS = [36, 41, 46, 51, 56]
+const COOKTOP_SLOT_LENGTH = 5
+
+// Confirmed by setting the app timer to 09:01:13 and observing both the initial status and the
+// 09:01:01 -> 09:00:59 rollover. Values are ordinary binary integers, not BCD.
+const TIMER_SECONDS_OFFSET = 30
+const TIMER_MINUTES_OFFSET = 31
+const TIMER_HOURS_OFFSET = 32
+
+// Preference write, subcommand 0x21, captured twice on 2026-08-29 from the LG app's Clock Settings
+// -> "Sync with smartphone". The app's Preference screen defaults every row to "No Change" and
+// cannot read any of these values back from the appliance, so one frame carries the whole set and
+// marks each untouched field 0x80. That is also what the three 0x80 bytes in the timer command are.
+// Payload layout, zero-based:
+//
+//   0      clock hours
+//   1      clock minutes
+//   2      hour format / meridiem — see CLOCK_HOUR_FORMAT_24H
+//   3      auto conversion
+//   4      temperature adjustment unit
+//   5      upper temperature adjustment, signed
+//   6      lower temperature adjustment, signed
+//   7      preheating alarm light
+//   8      beeper volume
+//   9      temperature unit shown on the oven's own display
+//   11     0xFF when untouched, a distinct sentinel from the 0x80 used everywhere else
+//   others not yet identified; every capture so far left them at 0x80
+//
+// The 0x0E length byte does not match the 13-byte payload, unlike the 0x20 start and 0x23 timer
+// subcommands where the equivalent byte does, so it is reproduced from the captures rather than
+// computed from the payload.
+const PREFERENCE_COMMAND_PREFIX = [0xf0, 0x43, 0x21, 0x0e]
+const PREFERENCE_PAYLOAD_LENGTH = 13
+const PREFERENCE_NO_CHANGE = 0x80
+const PREFERENCE_FF_INDEX = 11
+const PREFERENCE_FF_NO_CHANGE = 0xff
+const CLOCK_HOURS_INDEX = 0
+const CLOCK_MINUTES_INDEX = 1
+const CLOCK_HOUR_FORMAT_INDEX = 2
+// Byte 2 was 0x01 with the hour sent as 11, and 0x00 with the same wall-clock time sent as 23. That
+// fits both "hour format selector" and "meridiem flag", and the wire alone cannot separate them.
+// The handler writes the 0x00 shape, which carries the full 0-23 hour and is therefore unambiguous
+// under either reading; the 0x01 shape is not exposed until its meaning is confirmed.
+const CLOCK_HOUR_FORMAT_24H = 0x00
+
+// Captured one Save per value on 2026-08-29: Mute, then High, then Low, each leaving every other
+// payload byte at its no-change sentinel. Listed in the order the LG app's Beeper Volume screen
+// presents them.
+const BEEPER_VOLUME_INDEX = 8
+const BEEPER_VOLUMES = ['High', 'Low', 'Mute'] as const
+type BeeperVolume = (typeof BEEPER_VOLUMES)[number]
+const BEEPER_VOLUME_VALUES: Record<BeeperVolume, number> = { High: 0x02, Low: 0x01, Mute: 0x00 }
+
+// Captured Off then On on 2026-08-29, each leaving every other payload byte at its sentinel. The
+// light blinks when a cavity reaches its setpoint and keeps blinking until the door is opened.
+const PREHEAT_ALARM_LIGHT_INDEX = 7
+const PREHEAT_ALARM_LIGHT_OFF = 0x00
+const PREHEAT_ALARM_LIGHT_ON = 0x01
+
+// Captured °C then °F on 2026-08-29. This is the unit the appliance displays; it does NOT change
+// the status record, which kept reporting Fahrenheit ambient temperatures across the switch. Status
+// decoding is therefore unaffected by this setting.
+const TEMPERATURE_UNIT_INDEX = 9
+const TEMPERATURE_UNITS = ['°F', '°C'] as const
+type TemperatureUnit = (typeof TEMPERATURE_UNITS)[number]
+const TEMPERATURE_UNIT_VALUES: Record<TemperatureUnit, number> = { '°F': 0x00, '°C': 0x01 }
+
+// Captured Off then On on 2026-08-29. This is almost certainly the appliance behaviour already seen
+// in status: a convection start reports a setpoint 25°F below what was commanded (300°F Convection
+// Bake reported 275°F, 350°F Convection Roast reported 325°F). That link is untested, so nothing in
+// status decoding depends on this setting.
+const AUTO_CONVERSION_INDEX = 3
+const AUTO_CONVERSION_OFF = 0x00
+const AUTO_CONVERSION_ON = 0x01
+
+// Captured on 2026-08-29 as one Save carrying Upper -2°F and Lower Off: index 4 went to 0x00, the
+// same °F code the display unit at index 9 uses, index 5 to 0xFE and index 6 to 0x00. The trims are
+// therefore signed bytes in the unit named at index 4, and the app's "Off" is simply an offset of
+// zero. The handler always names °F at index 4 so the trims it writes need no conversion.
+//
+// The app's own picker allows ±35°F, or ±19°C for the same span. Since the handler always writes °F
+// these are the exact bounds the LG app enforces, not an assumed range.
+const TEMPERATURE_ADJUSTMENT_UNIT_INDEX = 4
+const TEMPERATURE_ADJUSTMENT_INDEXES: Record<CavityId, number> = { upper: 5, lower: 6 }
+const MIN_TEMPERATURE_ADJUSTMENT = -35
+const MAX_TEMPERATURE_ADJUSTMENT = 35
+
+// The cavity blocks are 18 bytes apart. An app command explicitly labelled Upper populated only the
+// first block, confirming the order. The three-minute run then counted 00:03:00 -> 00:02:59 at these
+// offsets. Set temperatures are unsigned 16-bit big-endian values at 5-6 and 23-24; this was proven
+// when Lower Convection Roast requested 350°F (01 5E) and reported an auto-converted 325°F (01 45).
+const UPPER_CAVITY_OFFSET = 0
+const LOWER_CAVITY_OFFSET = 18
+const CAVITY_STATE_OFFSET = 0
+const CAVITY_MODE_OFFSET = 1
+const CAVITY_COOK_SECONDS_OFFSET = 2
+const CAVITY_COOK_MINUTES_OFFSET = 3
+const CAVITY_COOK_HOURS_OFFSET = 4
+const CAVITY_SET_TEMPERATURE_OFFSET = 5
+const CAVITY_CURRENT_TEMPERATURE_OFFSET = 7
+const CAVITY_REMOTE_START_OFFSET = 15
+// Captures show this byte taking several values that don't decompose into independent bits:
+// 0x0E idle, 0x08 while being armed, 0x01 once armed, 0x02 while the other cavity is active, and
+// 0x06 after the completion alarm is cleared. It reads as a small status enum rather than a
+// bitfield, and 0x01 is the only value ever observed while Start was actually accepted.
+const REMOTE_START_READY = 0x01
+const UPPER_BAKE_OPERATION = 0x01
+const LOWER_REMOTE_MODES = ['Bake', 'Convection Bake', 'Convection Roast'] as const
+type LowerRemoteMode = (typeof LOWER_REMOTE_MODES)[number]
+const LOWER_REMOTE_OPERATIONS: Record<LowerRemoteMode, number> = {
+    Bake: 0x15,
+    'Convection Bake': 0x17,
+    'Convection Roast': 0x18,
+}
+const OVEN_STATE_NAMES: Record<number, string> = {
+    0x00: 'Idle',
+    0x01: 'Preheating',
+    0x02: 'Active',
+    0x03: 'Complete',
+}
+// Every captured remote start reports mode = operation | 0x80 (0x01 -> 0x81, 0x15 -> 0x95,
+// 0x17 -> 0x97, 0x18 -> 0x98), while the one captured panel-started cook (Broil) reported a bare
+// 0x07 — consistent with 0x80 flagging a remotely started cook. The flag is masked off before the
+// lookup so panel-started cooks decode too; a panel-started Bake capture would confirm the theory.
+const OVEN_MODE_NAMES: Record<number, string> = {
+    0x00: 'None',
+    [UPPER_BAKE_OPERATION]: 'Bake',
+    0x07: 'Broil',
+    [LOWER_REMOTE_OPERATIONS.Bake]: 'Bake',
+    [LOWER_REMOTE_OPERATIONS['Convection Bake']]: 'Convection Bake',
+    [LOWER_REMOTE_OPERATIONS['Convection Roast']]: 'Convection Roast',
+}
+// HA rejects any enum value outside its options list, so both lists are derived from the decode
+// tables above rather than restated. 'unknown' is accepted unconditionally and is not listed.
+const OVEN_STATE_OPTIONS = [...new Set(Object.values(OVEN_STATE_NAMES))]
+const OVEN_MODE_OPTIONS = [...new Set(Object.values(OVEN_MODE_NAMES))]
+
+// Home Assistant bounds the user-facing inputs to the appliance's normal Fahrenheit range. The
+// command itself carries an unsigned 16-bit value; 170°F and 350°F were confirmed on the wire.
+const MIN_REMOTE_TEMPERATURE = 170
+const MAX_REMOTE_TEMPERATURE = 550
+const REMOTE_TEMPERATURE_STEP = 5
+const MAX_REMOTE_COOK_TIME_MINUTES = 24 * 60
+
+type CavityId = 'upper' | 'lower'
+const CAVITY_IDS: CavityId[] = ['upper', 'lower']
+const CAVITY_TITLES: Record<CavityId, string> = { upper: 'Upper', lower: 'Lower' }
+const CAVITY_OFFSETS: Record<CavityId, number> = { upper: UPPER_CAVITY_OFFSET, lower: LOWER_CAVITY_OFFSET }
+// The app cancel command explicitly labelled Upper carried selector 0x00; Lower carried 0x01.
+const CAVITY_CANCEL_SELECTORS: Record<CavityId, number> = { upper: 0x00, lower: 0x01 }
+
+type CavityRemoteParams = { temperature: number; cookTime: number }
+type RemoteParams = {
+    upper: CavityRemoteParams
+    lower: CavityRemoteParams
+    lowerMode: LowerRemoteMode
+}
+
+// OBSERVED from LG's cloud, not inferred. The complete packet on the wire is:
+//   aa28f0ed114101000000181a0207080c14191a1e262b30353a00000000000000000000000000f3bb
+const STATUS_QUERY = 'f0ed114101000000181a0207080c14191a1e262b30353a00000000000000000000000000'
+
+function cavitySensorComponents(cavity: CavityId) {
+    const oven = `${cavity}_oven`
+    const title = CAVITY_TITLES[cavity]
+    return {
+        [`${oven}_temperature`]: {
+            platform: 'sensor',
+            device_class: 'temperature',
+            icon: 'mdi:thermometer',
+            unique_id: `$deviceid-${oven}_temperature`,
+            state_topic: `$this/${oven}_temperature`,
+            name: `${title} Oven Current Temperature`,
+            unit_of_measurement: '°F',
+        },
+        [`${oven}_state`]: {
+            platform: 'sensor',
+            device_class: 'enum',
+            icon: 'mdi:stove',
+            unique_id: `$deviceid-${oven}_state`,
+            state_topic: `$this/${oven}_state`,
+            name: `${title} Oven State`,
+            options: OVEN_STATE_OPTIONS,
+        },
+        [`${oven}_mode`]: {
+            platform: 'sensor',
+            device_class: 'enum',
+            icon: 'mdi:chef-hat',
+            unique_id: `$deviceid-${oven}_mode`,
+            state_topic: `$this/${oven}_mode`,
+            name: `${title} Oven Mode`,
+            options: OVEN_MODE_OPTIONS,
+        },
+        [`${oven}_set_temperature`]: {
+            platform: 'sensor',
+            device_class: 'temperature',
+            icon: 'mdi:thermometer-chevron-up',
+            unique_id: `$deviceid-${oven}_set_temperature`,
+            state_topic: `$this/${oven}_set_temperature`,
+            name: `${title} Oven Set Temperature`,
+            unit_of_measurement: '°F',
+        },
+        [`${oven}_cook_time`]: {
+            platform: 'sensor',
+            device_class: 'duration',
+            icon: 'mdi:timer-outline',
+            unique_id: `$deviceid-${oven}_cook_time`,
+            state_topic: `$this/${oven}_cook_time`,
+            name: `${title} Oven Cook Time`,
+            // The record counts down once a second, so seconds is the unit that loses nothing.
+            unit_of_measurement: 's',
+        },
+        [`${oven}_remote_start`]: {
+            platform: 'binary_sensor',
+            icon: 'mdi:remote',
+            unique_id: `$deviceid-${oven}_remote_start`,
+            state_topic: `$this/${oven}_remote_start`,
+            name: `${title} Oven Remote Start Ready`,
+            payload_on: 'ON',
+            payload_off: 'OFF',
+        },
+    }
+}
+
+// Write-only, like every other Preference row: the oven reports no trim and the LG app cannot read
+// one back, so Home Assistant tracks the value itself.
+function cavityTemperatureAdjustmentComponents(cavity: CavityId) {
+    const title = CAVITY_TITLES[cavity]
+    return {
+        [`${cavity}_temperature_adjustment`]: {
+            platform: 'number',
+            device_class: 'temperature',
+            icon: 'mdi:thermometer-plus',
+            unique_id: `$deviceid-${cavity}_temperature_adjustment`,
+            command_topic: `$this/${cavity}_temperature_adjustment/set`,
+            unit_of_measurement: '°F',
+            min: MIN_TEMPERATURE_ADJUSTMENT,
+            max: MAX_TEMPERATURE_ADJUSTMENT,
+            step: 1,
+            mode: 'box',
+            optimistic: true,
+            name: `${title} Temperature Adjustment`,
+        },
+    }
+}
+
+function cavityRemoteComponents(cavity: CavityId) {
+    const title = CAVITY_TITLES[cavity]
+    return {
+        [`${cavity}_remote_temperature`]: {
+            platform: 'number',
+            device_class: 'temperature',
+            icon: 'mdi:thermometer-chevron-up',
+            unique_id: `$deviceid-${cavity}_remote_temperature`,
+            state_topic: `$this/${cavity}_remote_temperature`,
+            command_topic: `$this/${cavity}_remote_temperature/set`,
+            unit_of_measurement: '°F',
+            min: MIN_REMOTE_TEMPERATURE,
+            max: MAX_REMOTE_TEMPERATURE,
+            step: REMOTE_TEMPERATURE_STEP,
+            mode: 'box',
+            name: `${title} Remote Temperature`,
+        },
+        [`${cavity}_remote_cook_time`]: {
+            platform: 'number',
+            device_class: 'duration',
+            icon: 'mdi:timer-outline',
+            unique_id: `$deviceid-${cavity}_remote_cook_time`,
+            state_topic: `$this/${cavity}_remote_cook_time`,
+            command_topic: `$this/${cavity}_remote_cook_time/set`,
+            unit_of_measurement: 'min',
+            min: 0,
+            max: MAX_REMOTE_COOK_TIME_MINUTES,
+            step: 1,
+            mode: 'box',
+            name: `${title} Remote Cook Time`,
+        },
+        [`${cavity}_start`]: {
+            platform: 'button',
+            icon: 'mdi:play-circle-outline',
+            unique_id: `$deviceid-${cavity}_start`,
+            command_topic: `$this/${cavity}_start/set`,
+            payload_press: 'PRESS',
+            name: cavity === 'upper' ? 'Start Upper Bake' : 'Start Lower',
+            availability: [
+                { topic: '$this/availability' },
+                { topic: '$rethink/availability' },
+                {
+                    topic: `$this/${cavity}_oven_remote_start`,
+                    payload_available: 'ON',
+                    payload_not_available: 'OFF',
+                },
+            ],
+            availability_mode: 'all',
+        },
+        [`${cavity}_cancel`]: {
+            platform: 'button',
+            icon: 'mdi:stop-circle-outline',
+            unique_id: `$deviceid-${cavity}_cancel`,
+            command_topic: `$this/${cavity}_cancel/set`,
+            payload_press: 'PRESS',
+            name: `Cancel ${title}`,
+        },
+    }
+}
+
+export default class Device extends AABBDevice {
+    remote: RemoteParams = {
+        upper: { temperature: 350, cookTime: 10 },
+        lower: { temperature: 350, cookTime: 10 },
+        lowerMode: 'Bake',
+    }
+
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: 'LG Oven' }),
+                components: {
+                    cooktop_status: {
+                        platform: 'binary_sensor',
+                        icon: 'mdi:stove',
+                        unique_id: '$deviceid-cooktop_status',
+                        state_topic: '$this/cooktop_status',
+                        name: 'Cooktop',
+                        payload_on: 'ON',
+                        payload_off: 'OFF',
+                    },
+                    ...cavitySensorComponents('upper'),
+                    ...cavitySensorComponents('lower'),
+                    timer: {
+                        platform: 'text',
+                        icon: 'mdi:timer',
+                        unique_id: '$deviceid-timer',
+                        state_topic: '$this/timer',
+                        command_topic: '$this/timer/set',
+                        pattern: '^\\d{2}:[0-5]\\d:[0-5]\\d$',
+                        name: 'Timer',
+                    },
+                    timer_stop: {
+                        platform: 'button',
+                        icon: 'mdi:timer-stop-outline',
+                        unique_id: '$deviceid-timer_stop',
+                        command_topic: '$this/timer_stop/set',
+                        payload_press: 'PRESS',
+                        name: 'Stop / Acknowledge Timer',
+                    },
+                    clock_sync: {
+                        platform: 'button',
+                        icon: 'mdi:clock-check-outline',
+                        unique_id: '$deviceid-clock_sync',
+                        command_topic: '$this/clock_sync/set',
+                        payload_press: 'PRESS',
+                        name: 'Sync Clock',
+                    },
+                    // The appliance never reports its beeper volume and the LG app cannot read it
+                    // back either, so there is no state to publish: HA tracks the selection itself.
+                    beeper_volume: {
+                        platform: 'select',
+                        icon: 'mdi:volume-high',
+                        unique_id: '$deviceid-beeper_volume',
+                        command_topic: '$this/beeper_volume/set',
+                        options: [...BEEPER_VOLUMES],
+                        optimistic: true,
+                        name: 'Beeper Volume',
+                    },
+                    // Write-only for the same reason as the beeper volume above.
+                    preheat_alarm_light: {
+                        platform: 'switch',
+                        icon: 'mdi:lightbulb-on-outline',
+                        unique_id: '$deviceid-preheat_alarm_light',
+                        command_topic: '$this/preheat_alarm_light/set',
+                        payload_on: 'ON',
+                        payload_off: 'OFF',
+                        optimistic: true,
+                        name: 'Preheating Alarm Light',
+                    },
+                    // Display-only, and write-only like its neighbours. Home Assistant keeps
+                    // reporting this device's temperatures in °F whatever is selected here.
+                    temperature_unit: {
+                        platform: 'select',
+                        icon: 'mdi:thermometer',
+                        unique_id: '$deviceid-temperature_unit',
+                        command_topic: '$this/temperature_unit/set',
+                        options: [...TEMPERATURE_UNITS],
+                        optimistic: true,
+                        name: 'Temperature Unit',
+                    },
+                    // Write-only like its neighbours.
+                    auto_conversion: {
+                        platform: 'switch',
+                        icon: 'mdi:thermometer-auto',
+                        unique_id: '$deviceid-auto_conversion',
+                        command_topic: '$this/auto_conversion/set',
+                        payload_on: 'ON',
+                        payload_off: 'OFF',
+                        optimistic: true,
+                        name: 'Auto Conversion',
+                    },
+                    ...cavityTemperatureAdjustmentComponents('upper'),
+                    ...cavityTemperatureAdjustmentComponents('lower'),
+                    ...cavityRemoteComponents('upper'),
+                    ...cavityRemoteComponents('lower'),
+                    lower_remote_mode: {
+                        platform: 'select',
+                        icon: 'mdi:chef-hat',
+                        unique_id: '$deviceid-lower_remote_mode',
+                        state_topic: '$this/lower_remote_mode',
+                        command_topic: '$this/lower_remote_mode/set',
+                        options: [...LOWER_REMOTE_MODES],
+                        name: 'Lower Remote Mode',
+                    },
+                },
+            }),
+        )
+        for (const cavity of CAVITY_IDS) {
+            this.publishProperty(`${cavity}_remote_temperature`, this.remote[cavity].temperature)
+            this.publishProperty(`${cavity}_remote_cook_time`, this.remote[cavity].cookTime)
+            // Readiness is trusted only from live status. Force the retained topic to OFF so a
+            // stale retained ON from a previous run cannot enable the Start button before the first
+            // status reply arrives.
+            this.publishProperty(`${cavity}_oven_remote_start`, 'OFF')
+        }
+        this.publishProperty('lower_remote_mode', this.remote.lowerMode)
+    }
+
+    start() {
+        this.send(Buffer.from(STATUS_QUERY, 'hex'))
+    }
+
+    processAABB(buf: Buffer) {
+        if (buf.length >= 2 && buf[0] === CLASS_BYTE) {
+            // Generic acknowledgements echo the app command family in byte 2 and a result in byte 3.
+            // Observed families are 0x43 for set/start and 0x44 for oven cancel. Result 0x00 is
+            // success; 0x40 came back from a remote start aimed at a cavity whose Remote Start was
+            // not armed, so a rejection is reported rather than silently dropped.
+            if (buf.length === 4 && buf[1] === 0x00 && (buf[2] === 0x43 || buf[2] === 0x44)) {
+                if (buf[3] !== 0x00) log('WFV474PGV', 'command rejected by the oven', buf.toString('hex'))
+                return
+            }
+
+            if (buf[1] === SINGLE_STATUS_FRAME_TYPE && buf.length === 2 + STATUS_RECORD_LENGTH) {
+                this.publishStatus(buf.subarray(2))
+                return
+            }
+
+            // EC carries equal-sized previous/current blocks. Only current state should be published.
+            if (buf[1] === STATUS_FRAME_TYPE && buf.length === 2 + STATUS_RECORD_LENGTH * 2) {
+                this.publishStatus(buf.subarray(2 + STATUS_RECORD_LENGTH))
+                return
+            }
+        }
+
+        // Everything else — unknown opcodes, foreign class bytes, unexpected record lengths. None of
+        // it is decoded, so it is logged for further reverse engineering rather than published.
+        log('WFV474PGV', 'undecoded frame', buf.toString('hex'))
+    }
+
+    publishStatus(current: Buffer) {
+        this.publishProperty(
+            'timer',
+            Device.formatTime(
+                current[TIMER_HOURS_OFFSET],
+                current[TIMER_MINUTES_OFFSET],
+                current[TIMER_SECONDS_OFFSET],
+            ),
+        )
+        this.publishCavity('upper', current)
+        this.publishCavity('lower', current)
+
+        const cooktopOn = COOKTOP_SLOT_STATE_OFFSETS.some((offset) => current[offset] !== 0)
+        this.publishProperty('cooktop_status', cooktopOn ? 'ON' : 'OFF')
+    }
+
+    publishCavity(cavity: CavityId, current: Buffer) {
+        const offset = CAVITY_OFFSETS[cavity]
+        const oven = `${cavity}_oven`
+        this.publishProperty(`${oven}_state`, Device.formatOvenState(current[offset + CAVITY_STATE_OFFSET]))
+        this.publishProperty(`${oven}_mode`, Device.formatOvenMode(current[offset + CAVITY_MODE_OFFSET]))
+        this.publishProperty(
+            `${oven}_temperature`,
+            Device.temperature(current.readUInt16BE(offset + CAVITY_CURRENT_TEMPERATURE_OFFSET)),
+        )
+        this.publishProperty(
+            `${oven}_set_temperature`,
+            Device.temperature(current.readUInt16BE(offset + CAVITY_SET_TEMPERATURE_OFFSET)),
+        )
+        this.publishProperty(
+            `${oven}_cook_time`,
+            Device.totalSeconds(
+                current[offset + CAVITY_COOK_HOURS_OFFSET],
+                current[offset + CAVITY_COOK_MINUTES_OFFSET],
+                current[offset + CAVITY_COOK_SECONDS_OFFSET],
+            ),
+        )
+        const remoteStartReady = current[offset + CAVITY_REMOTE_START_OFFSET] === REMOTE_START_READY
+        this.publishProperty(`${oven}_remote_start`, remoteStartReady ? 'ON' : 'OFF')
+    }
+
+    setProperty(prop: string, mqttValue: string) {
+        if (prop === 'timer') {
+            const time = Device.parseTime(mqttValue)
+            if (time) this.sendTimer(time)
+            return
+        }
+
+        if (prop === 'timer_stop' && mqttValue === 'PRESS') {
+            this.sendTimer({ hours: 0, minutes: 0, seconds: 0 })
+            return
+        }
+
+        if (prop === 'clock_sync' && mqttValue === 'PRESS') {
+            const now = new Date()
+            this.sendClock(now.getHours(), now.getMinutes())
+            return
+        }
+
+        if (prop === 'beeper_volume') {
+            // The membership test keeps the BEEPER_VOLUME_VALUES lookup total; HA only ever sends
+            // one of the declared options.
+            if (Device.isBeeperVolume(mqttValue)) this.sendBeeperVolume(mqttValue)
+            return
+        }
+
+        if (prop === 'preheat_alarm_light') {
+            if (mqttValue === 'ON' || mqttValue === 'OFF') this.sendPreheatAlarmLight(mqttValue === 'ON')
+            return
+        }
+
+        if (prop === 'temperature_unit') {
+            if (Device.isTemperatureUnit(mqttValue)) this.sendTemperatureUnit(mqttValue)
+            return
+        }
+
+        if (prop === 'auto_conversion') {
+            if (mqttValue === 'ON' || mqttValue === 'OFF') this.sendAutoConversion(mqttValue === 'ON')
+            return
+        }
+
+        const adjustment = /^(upper|lower)_temperature_adjustment$/.exec(prop)
+        if (adjustment) {
+            const degrees = Device.parseTemperatureAdjustment(mqttValue)
+            if (degrees !== undefined) this.sendTemperatureAdjustment({ [adjustment[1] as CavityId]: degrees })
+            return
+        }
+
+        if (prop === 'lower_remote_mode') {
+            // The membership test is what makes the LOWER_REMOTE_OPERATIONS lookup below total; HA
+            // only ever sends one of the declared options.
+            if (Device.isLowerRemoteMode(mqttValue)) {
+                this.remote.lowerMode = mqttValue
+                this.publishProperty(prop, mqttValue)
+            }
+            return
+        }
+
+        const match = /^(upper|lower)_(remote_temperature|remote_cook_time|start|cancel)$/.exec(prop)
+        if (!match) return
+        const cavity = match[1] as CavityId
+        const action = match[2]
+
+        if (action === 'remote_temperature') {
+            this.remote[cavity].temperature = this.stageNumber(prop, mqttValue, this.remote[cavity].temperature)
+            return
+        }
+
+        if (action === 'remote_cook_time') {
+            this.remote[cavity].cookTime = this.stageNumber(prop, mqttValue, this.remote[cavity].cookTime)
+            return
+        }
+
+        if (mqttValue !== 'PRESS') return
+
+        if (action === 'cancel') {
+            this.send(Buffer.from([0xf0, 0x44, CAVITY_CANCEL_SELECTORS[cavity]]))
+            return
+        }
+
+        // action === 'start'
+        const operation = cavity === 'upper' ? UPPER_BAKE_OPERATION : LOWER_REMOTE_OPERATIONS[this.remote.lowerMode]
+        this.sendRemoteStart(operation, this.remote[cavity].temperature, this.remote[cavity].cookTime)
+    }
+
+    sendTimer(time: { hours: number; minutes: number; seconds: number }) {
+        this.send(Buffer.from([0xf0, 0x43, 0x23, 0x06, 0x80, 0x80, 0x80, time.seconds, time.minutes, time.hours]))
+    }
+
+    // The app writes the whole Preference screen in one frame, marking every row the user did not
+    // touch. Each write here starts from an all-sentinel payload for the same reason: anything left
+    // alone must go out as "no change" rather than as a value we would only be guessing at.
+    static preferencePayload() {
+        const payload = Buffer.alloc(PREFERENCE_PAYLOAD_LENGTH, PREFERENCE_NO_CHANGE)
+        payload[PREFERENCE_FF_INDEX] = PREFERENCE_FF_NO_CHANGE
+        return payload
+    }
+
+    sendPreference(payload: Buffer) {
+        this.send(Buffer.concat([Buffer.from(PREFERENCE_COMMAND_PREFIX), payload]))
+    }
+
+    // No status record carries a clock field, so this is write-only: the button is stateless and
+    // nothing is published back, matching the app's one-shot "Sync with smartphone".
+    sendClock(hours: number, minutes: number) {
+        const payload = Device.preferencePayload()
+        payload[CLOCK_HOURS_INDEX] = hours
+        payload[CLOCK_MINUTES_INDEX] = minutes
+        payload[CLOCK_HOUR_FORMAT_INDEX] = CLOCK_HOUR_FORMAT_24H
+        this.sendPreference(payload)
+    }
+
+    sendBeeperVolume(volume: BeeperVolume) {
+        const payload = Device.preferencePayload()
+        payload[BEEPER_VOLUME_INDEX] = BEEPER_VOLUME_VALUES[volume]
+        this.sendPreference(payload)
+    }
+
+    sendPreheatAlarmLight(on: boolean) {
+        const payload = Device.preferencePayload()
+        payload[PREHEAT_ALARM_LIGHT_INDEX] = on ? PREHEAT_ALARM_LIGHT_ON : PREHEAT_ALARM_LIGHT_OFF
+        this.sendPreference(payload)
+    }
+
+    sendTemperatureUnit(unit: TemperatureUnit) {
+        const payload = Device.preferencePayload()
+        payload[TEMPERATURE_UNIT_INDEX] = TEMPERATURE_UNIT_VALUES[unit]
+        this.sendPreference(payload)
+    }
+
+    sendAutoConversion(on: boolean) {
+        const payload = Device.preferencePayload()
+        payload[AUTO_CONVERSION_INDEX] = on ? AUTO_CONVERSION_ON : AUTO_CONVERSION_OFF
+        this.sendPreference(payload)
+    }
+
+    // Takes both cavities so that the captured frame, which carried Upper and Lower together, can be
+    // reproduced exactly. Home Assistant writes one cavity at a time and leaves the other unchanged.
+    sendTemperatureAdjustment(adjustments: Partial<Record<CavityId, number>>) {
+        const payload = Device.preferencePayload()
+        payload[TEMPERATURE_ADJUSTMENT_UNIT_INDEX] = TEMPERATURE_UNIT_VALUES['°F']
+        for (const cavity of CAVITY_IDS) {
+            const degrees = adjustments[cavity]
+            if (degrees !== undefined) payload[TEMPERATURE_ADJUSTMENT_INDEXES[cavity]] = degrees & 0xff
+        }
+        this.sendPreference(payload)
+    }
+
+    sendRemoteStart(operation: number, temperature: number, cookTimeMinutes: number) {
+        const hours = Math.floor(cookTimeMinutes / 60)
+        const minutes = cookTimeMinutes % 60
+        // Unlike status records (seconds/minutes/hours), the command carries hours/minutes/seconds.
+        // The 01:03:00 Bake capture is the first non-symmetric value that proves this ordering.
+        this.send(
+            Buffer.from([
+                0xf0,
+                0x43,
+                0x20,
+                0x0b,
+                operation,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                temperature >> 8,
+                temperature & 0xff,
+                hours,
+                minutes,
+                0x00,
+                0x00,
+            ]),
+        )
+    }
+
+    // The number components declare min/max/step, so HA already constrains what it sends; range is
+    // not re-checked here. The digit test only keeps a non-numeric payload off the wire, since
+    // Number('') is 0 and a cook time of 0 means "no time limit" on this oven.
+    stageNumber(prop: string, mqttValue: string, previous: number) {
+        if (!/^\d+$/.test(mqttValue.trim())) return previous
+
+        const value = Number(mqttValue.trim())
+        this.publishProperty(prop, value)
+        return value
+    }
+
+    // Zero is the oven declining to report, not a reading: the current-temperature field reads 0
+    // for the whole of an active cycle even though it reports ambient and residual heat outside
+    // one, and the setpoint reads 0 whenever no cook is programmed.
+    static temperature(value: number) {
+        return value === 0 ? 'unknown' : value
+    }
+
+    static totalSeconds(hours: number, minutes: number, seconds: number) {
+        return hours * 3600 + minutes * 60 + seconds
+    }
+
+    static formatTime(hours: number, minutes: number, seconds: number) {
+        return [hours, minutes, seconds].map((value) => value.toString().padStart(2, '0')).join(':')
+    }
+
+    static parseTime(value: string) {
+        const match = /^(\d{2}):([0-5]\d):([0-5]\d)$/.exec(value)
+        if (!match) return undefined
+
+        const hours = Number(match[1])
+        if (hours > 0xff) return undefined
+        return { hours, minutes: Number(match[2]), seconds: Number(match[3]) }
+    }
+
+    static isLowerRemoteMode(value: string): value is LowerRemoteMode {
+        return (LOWER_REMOTE_MODES as readonly string[]).includes(value)
+    }
+
+    static isBeeperVolume(value: string): value is BeeperVolume {
+        return (BEEPER_VOLUMES as readonly string[]).includes(value)
+    }
+
+    static isTemperatureUnit(value: string): value is TemperatureUnit {
+        return (TEMPERATURE_UNITS as readonly string[]).includes(value)
+    }
+
+    // Unlike the staged remote-start numbers, this one is signed, so it needs its own parse. The
+    // range check keeps a payload that bypassed the HA component's own bounds off the wire.
+    static parseTemperatureAdjustment(value: string) {
+        const trimmed = value.trim()
+        if (!/^-?\d+$/.test(trimmed)) return undefined
+
+        const degrees = Number(trimmed)
+        if (degrees < MIN_TEMPERATURE_ADJUSTMENT || degrees > MAX_TEMPERATURE_ADJUSTMENT) return undefined
+        return degrees
+    }
+
+    static formatOvenState(value: number) {
+        const state = OVEN_STATE_NAMES[value]
+        if (state === undefined) log('WFV474PGV', 'undecoded oven state', value.toString(16))
+        return state ?? 'unknown'
+    }
+
+    static formatOvenMode(value: number) {
+        const mode = OVEN_MODE_NAMES[value & 0x7f]
+        if (mode === undefined) log('WFV474PGV', 'undecoded oven mode', value.toString(16))
+        return mode ?? 'unknown'
+    }
+}

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -23,6 +23,7 @@ import RV13B6ES_D_US_WIFI from './devices/RV13B6ES_D_US_WIFI'
 import WTL_FXU_BDV_NA_01 from './devices/WTL_FXU_BDV_NA_01'
 import DHUM_056905_WW from './devices/DHUM_056905_WW'
 import ST_B_E4H01Y_APL from './devices/ST_B_E4H01Y_APL'
+import WFV474PGV from './devices/WFV474PGV'
 import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
 import { type Connection } from './homeassistant'
@@ -69,6 +70,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     WTL_FXU_BDV_NA_01, // LG WashTower
     DHUM_056905_WW,
     ST_B_E4H01Y_APL,
+    WFV474PGV, // LG double oven/range
 }
 
 class Bridge {

--- a/tests/cloud/devices/WFV474PGV.test.ts
+++ b/tests/cloud/devices/WFV474PGV.test.ts
@@ -1,0 +1,1083 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/WFV474PGV'
+import Bridge from '@/cloud/ha_bridge'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, hex } from '@/tests/helpers/mocks'
+import { encodePacket } from '@/util/packet-codec'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'WFV474PGV'
+const META: Metadata = { modelId: MODEL_ID, modelName: MODEL_ID, swVersion: '0.0.0' }
+
+// REAL frames from 2026-08-22. The first is an idle/off report at 16:58:18Z. The second is the exact
+// 17:02:22Z transition where the first 62-byte record is cooktop-off and the current record is on:
+// the five slot-state bytes at current-record offsets 36, 41, 46, 51 and 56 all move 00 -> 01.
+const COOKTOP_OFF = Buffer.from(
+    'AA8240EC00000000000000004E0000000000000E000000000000000000004D0000000000000E0000000000000000000000000000000000000000000000000000000000000000000000004D0000000000000E000000000000000000004D0000000000000E0000000000000000000000000000000000000000000000000000000090BB',
+    'hex',
+)
+const COOKTOP_OFF_TO_ON = Buffer.from(
+    'AA8240EC00000000000000004E0000000000000E000000000000000000004D0000000000000E0000000000000000000000000000000000000000000000000000000000000000000000004E00000000000006000000000000000000004D00000000000006000001000300000100030000010003000001000300000100030000009FBB',
+    'hex',
+)
+// REAL 17:16:48Z reverse transition: the previous block has all five slot flags at 01 and the
+// current block has all five at 00.
+const COOKTOP_ON_TO_OFF = Buffer.from(
+    'AA8240EC00000000000000004E0000000000000E000000000000000000004D0000000000000E00000100190E000100190E000100190E000100190E000100190E000000000000000000004E0000000000000E000000000000000000004C0000000000000E00000000000000000000000000000000000000000000000000000000D8BB',
+    'hex',
+)
+
+// REAL timer frames from 2026-08-22. The timer was set from the LG app to 09:01:13. Record offsets
+// 30/31/32 carry seconds/minutes/hours; the rollover fixture proves both byte order and ordinary
+// binary encoding by moving from 09:01:01 to 09:00:59.
+const TIMER_09_01_13 = Buffer.from(
+    'AA8240EC00000000000000004E0000000000000E000000000000000000004C0000000000000E0000000000000000000000000000000000000000000000000000000000000000000000004E00000000000006000000000000000000004C0000000D010906000000000000000000000000000000000000000000000000000000009EBB',
+    'hex',
+)
+const TIMER_ROLLOVER_09_00_59 = Buffer.from(
+    'AA8240EC00000000000000004E00000000000006000000000000000000004C000000010109060000000000000000000000000000000000000000000000000000000000000000000000004E00000000000006000000000000000000004C0000003B00090600000000000000000000000000000000000000000000000000000000A6BB',
+    'hex',
+)
+const TIMER_STOPPED = Buffer.from(
+    'AA8240EC00000000000000004E00000000000006000000000000000000004C0000001A3A08060000000000000000000000000000000000000000000000000000000000000000000000004E0000000000000E000000000000000000004D0000000000000E0000000000000000000000000000000000000000000000000000000044BB',
+    'hex',
+)
+// REAL acknowledgements to the 0x43 set/start family. The first answered an accepted command; the
+// second answered an Upper Bake start aimed at a cavity whose Remote Start was not armed, sent
+// deliberately to establish what the oven does on its own. Byte 3 is the result: 0x00 versus 0x40.
+const START_ACCEPTED_ACK = Buffer.from('AA084000430060BB', 'hex')
+const START_REJECTED_ACK = Buffer.from('AA084000434020BB', 'hex')
+
+// REAL one-shot event emitted when a five-second timer expired naturally. Explicit Stop did not emit
+// this opcode. Alarm-clear behavior is still unknown, so it remains a diagnostic rather than a
+// stateful binary sensor.
+const TIMER_EXPIRED_ALARM = Buffer.from('AA13407203F50A0000000000000000000024BB', 'hex')
+
+// REAL status frames from the app-labelled Upper Oven remote-start experiment. Before starting,
+// both cavity readiness bytes are 01. The start frame populates only the first block with 170°F
+// (0xAA) and 00:03:00; the next frame rolls it to 00:02:59, proving the time offsets and block order.
+const BOTH_OVENS_REMOTE_START_READY = Buffer.from(
+    'AA8240EC00000000000000004E00000000000006000000000000000000004D000008000000060000000000000000000000000000000000000000000000000000000000000000000000004E00000000000001000000000000000000004C0000000000000100000000000000000000000000000000000000000000000000000000F6BB',
+    'hex',
+)
+// REAL Lower-only readiness transition. The previous record has both cavity bytes at 0E; the
+// current record has Upper offset 15 at 00 and only Lower offset 33 at 01.
+const LOWER_ONLY_REMOTE_START_READY = Buffer.from(
+    'AA8240EC0000000000000000850000000000000E000000000000000000004E0000000000000E0000000000000000000000000000000000000000000000000000000000000000000000008500000000000000000000000000000000004E00000000000001000000000000000000000000000000000000000000000000000000004EBB',
+    'hex',
+)
+// REAL Lower Convection Roast start after the app requested 350°F with cook time disabled. Only
+// the Lower block is active. Its mode is 98, time is zero, and setpoint 01 45 is 325°F after the
+// appliance's 25°F convection auto-conversion.
+const LOWER_CONVECTION_ROAST_350F_TIME_OFF = Buffer.from(
+    'AA8240EC00000000000000008300000000000000000000000000000000004E00000000000001000000000000000000000000000000000000000000000000000000000000000000000000830000000000000200000198000000014500000000000000000200000000000000000000000000000000000000000000000000000000C5BB',
+    'hex',
+)
+// REAL app-labelled Lower Bake start at 285°C for five minutes. Lower mode is 95, and the status
+// normalizes the requested setpoint to 0221 (545°F). The rollover confirms the countdown.
+const LOWER_BAKE_285C_FIVE_MINUTES = Buffer.from(
+    'AA8240EC0000000000000000FE0000000000000000000000000000000000AF00000000000001000000000000000000000000000000000000000000000000000000000000000000000000FE000000000000020000019500050002210000000000000000020000000000000000000000000000000000000000000000000000000093BB',
+    'hex',
+)
+const LOWER_BAKE_285C_FOUR_MINUTES_59 = Buffer.from(
+    'AA8240EC0000000000000000FE00000000000002000001950005000221000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000FE00000000000002000001953B040002210000000000000000020000000000000000000000000000000000000000000000000000000047BB',
+    'hex',
+)
+// REAL cancellation of the remotely started Lower Bake. The current record clears Lower state,
+// mode, time, and setpoint, then exposes current temperature 00FC (252°F).
+const LOWER_BAKE_CANCELLED_AT_252F = Buffer.from(
+    'AA8240EC0000000000000000F400000000000002000001952702000221000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000F40000000000000600000000000000000000FC00000000000006000000000000000000000000000000000000000000000000000000007BBB',
+    'hex',
+)
+// REAL app-labelled Lower Convection Bake start at 300°F for ten minutes. Lower mode is 97, and
+// the appliance's convection auto-conversion reports a 0113 (275°F) setpoint.
+const LOWER_CONVECTION_BAKE_300F_TEN_MINUTES = Buffer.from(
+    'AA8240EC0000000000000000EC0000000000000000000000000000000000F200000000000001000000000000000000000000000000000000000000000000000000000000000000000000EC0000000000000200000197000A0001130000000000000000020000000000000000000000000000000000000000000000000000000088BB',
+    'hex',
+)
+const LOWER_CONVECTION_BAKE_300F_NINE_MINUTES_59 = Buffer.from(
+    'AA8240EC0000000000000000EC0000000000000200000197000A000113000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000EC00000000000002000001973B09000113000000000000000002000000000000000000000000000000000000000000000000000000008BBB',
+    'hex',
+)
+const LOWER_CONVECTION_BAKE_PREHEAT_COMPLETE = Buffer.from(
+    'AA8240EC0000000000000000EB00000000000002000001973009000113000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000E9000000000000020000029705090001130000000000000000020000000000000000000000000000000000000000000000000000000081BB',
+    'hex',
+)
+// REAL manual Upper Broil High start while Lower Convection Roast remained in Preheating. Upper
+// state/mode/setpoint are 02/07/0190 (400°F); Lower remains 01/98/0145 (325°F).
+const UPPER_BROIL_HIGH_WITH_LOWER_PREHEATING = Buffer.from(
+    'AA8240EC00000000000000007F0000000000000000000198000000014500000000000000000000000000000000000000000000000000000000000000000000000000020700000001900000000000000000020000019800000001450000000000000000020000000000000000000000000000000000000000000000000000000066BB',
+    'hex',
+)
+// REAL Lower preheat-complete event and following transition while Upper Broil remained active.
+// Lower state changes 01 -> 02; mode 98, converted 325°F setpoint, and zero current temp persist.
+const LOWER_PREHEAT_COMPLETE_EVENT = Buffer.from('AA13407203E90A0000000000000000000030BB', 'hex')
+const LOWER_PREHEAT_COMPLETE_WITH_UPPER_BROIL = Buffer.from(
+    'AA8240EC0207000000019000000000000000000200000198000000014500000000000000000200000000000000000000000000000000000000000000000000000000020700000001900000000000000000020000029800000001450000000000000000020000000000000000000000000000000000000000000000000000000006BB',
+    'hex',
+)
+// REAL app cancel transition for Upper only. The prior record has both cavities active; the current
+// record clears Upper state/mode/setpoint, exposes its 206°F temperature, and leaves Lower unchanged.
+const UPPER_CANCELLED_WITH_LOWER_ACTIVE = Buffer.from(
+    'AA8240EC02070000000190000000000000000002000002980000000145000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000CE0000000000000200000298000000014500000000000000000200000000000000000000000000000000000000000000000000000000DDBB',
+    'hex',
+)
+// REAL Lower cancel transition. The current record clears Lower and exposes its 16-bit current
+// temperature as 01 64 (356°F), while Upper remains idle at 00 CC (204°F).
+const LOWER_CANCELLED = Buffer.from(
+    'AA8240EC0000000000000000CC00000000000002000002980000000145000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000CC000000000000060000000000000000000164000000000000060000000000000000000000000000000000000000000000000000000010BB',
+    'hex',
+)
+const UPPER_OVEN_170F_THREE_MINUTES = Buffer.from(
+    'AA8240EC00000000000000004E00000000000001000000000000000000004D0000000000000100000000000000000000000000000000000000000000000000000000018100030000AA000000000000000002000000000000000000004D000000000000020000000000000000000000000000000000000000000000000000000020BB',
+    'hex',
+)
+const UPPER_OVEN_170F_TWO_MINUTES_59 = Buffer.from(
+    'AA8240EC018100030000AA000000000000000002000000000000000000004D000000000000020000000000000000000000000000000000000000000000000000000001813B020000AA000000000000000002000000000000000000004D0000000000000200000000000000000000000000000000000000000000000000000000C7BB',
+    'hex',
+)
+// REAL app-labelled Upper Bake start at 125°C with a 01:03:00 cook time. The status normalizes
+// the setpoint to 257°F (01 01). The rollover proves that status time remains seconds/minutes/hours.
+const UPPER_BAKE_125C_ONE_HOUR_THREE_MINUTES = Buffer.from(
+    'AA8240EC00000000000000009F0000000000000100000000000000000000D100000000000000000000000000000000000000000000000000000000000000000000000181000301010100000000000000000200000000000000000000D0000000000000020000000000000000000000000000000000000000000000000000000070BB',
+    'hex',
+)
+const UPPER_BAKE_125C_ONE_HOUR_TWO_MINUTES_59 = Buffer.from(
+    'AA8240EC0181000301010100000000000000000200000000000000000000D0000000000000020000000000000000000000000000000000000000000000000000000001813B0201010100000000000000000200000000000000000000D100000000000002000000000000000000000000000000000000000000000000000000001EBB',
+    'hex',
+)
+// REAL Upper Bake preheat-complete event and its following transition. Upper state changes
+// Preheating 01 -> Active 02 while mode 81, setpoint 0101 (257°F), and the running timer persist.
+const UPPER_BAKE_PREHEAT_COMPLETE_EVENT = Buffer.from('AA13407200010A000000000000000000002FBB', 'hex')
+const UPPER_BAKE_PREHEAT_COMPLETE = Buffer.from(
+    'AA8240EC01813B3A00010100000000000000000200000000000000000000C4000000000000020000000000000000000000000000000000000000000000000000000002811F3A00010100000000000000000200000000000000000000C30000000000000200000000000000000000000000000000000000000000000000000000EBBB',
+    'hex',
+)
+// REAL cancellation of the remotely started Upper Bake. The current record is Idle, clears mode,
+// time, and setpoint, and exposes the post-cancel Upper current temperature as 010A (266°F).
+const UPPER_BAKE_CANCELLED_AT_266F = Buffer.from(
+    'AA8240EC02813A3500010100000000000000000200000000000000000000B9000000000000020000000000000000000000000000000000000000000000000000000000000000000000010A0000000000000600000000000000000000B6000000000000060000000000000000000000000000000000000000000000000000000083BB',
+    'hex',
+)
+// REAL end-of-cycle transition. Upper current temperature is 124°F (0x7C) at offset 8 while
+// the setpoint and cook time clear. The following 40 72 frame is the dedicated completion event.
+const UPPER_OVEN_FINISHED_AT_124F = Buffer.from(
+    'AA8240EC018102000000AA000000000000000002000000000000000000004C000000000000020000000000000000000000000000000000000000000000000000000003000000000000007C00000000000000000000000000000000004C0000000000000200000000000000000000000000000000000000000000000000000000F6BB',
+    'hex',
+)
+const UPPER_OVEN_FINISHED_EVENT = Buffer.from('AA13407200040A0000000000000000000028BB', 'hex')
+// REAL Clear Upper transition after the completion alarm. There was no outgoing command or new
+// event; the appliance reported Upper state 03 -> 00 while retaining its 149°F current temperature.
+const UPPER_OVEN_CLEARED_AT_149F = Buffer.from(
+    'AA8240EC03000000000000009500000000000000000000000000000000004D000000000000020000000000000000000000000000000000000000000000000000000000000000000000009500000000000006000000000000000000004D000000000000060000000000000000000000000000000000000000000000000000000078BB',
+    'hex',
+)
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+// Synthetic frames exercise the known oven shapes while keeping the unknown 62-byte record
+// contents conspicuous.
+function frame(inner: Buffer) {
+    return encodePacket({ protocol: 'aabb', body: inner.toString('hex') }).buffer
+}
+
+// Frames the handler does not decode must not reach Home Assistant at all, so the oracle for
+// "ignored" is that no published property moves.
+function snapshot(ha: MockHAConnection) {
+    return JSON.stringify(ha.devices[DEVICE_ID].properties)
+}
+
+// A 62-byte status record carrying only the Upper cavity fields named here, enough to tell the two
+// blocks of an EC frame apart and to drive the undecoded state/mode paths.
+function record({ temperature = 0, state = 0, mode = 0 } = {}) {
+    const out = Buffer.alloc(62)
+    out.writeUInt16BE(temperature, 7)
+    out[0] = state
+    out[1] = mode
+    return out
+}
+
+// Every real frame above, for assertions that must hold across the whole capture set.
+const ALL_CAPTURES = [
+    COOKTOP_OFF,
+    COOKTOP_OFF_TO_ON,
+    COOKTOP_ON_TO_OFF,
+    TIMER_09_01_13,
+    TIMER_ROLLOVER_09_00_59,
+    TIMER_STOPPED,
+    TIMER_EXPIRED_ALARM,
+    BOTH_OVENS_REMOTE_START_READY,
+    LOWER_ONLY_REMOTE_START_READY,
+    LOWER_CONVECTION_ROAST_350F_TIME_OFF,
+    LOWER_BAKE_285C_FIVE_MINUTES,
+    LOWER_BAKE_285C_FOUR_MINUTES_59,
+    LOWER_BAKE_CANCELLED_AT_252F,
+    LOWER_CONVECTION_BAKE_300F_TEN_MINUTES,
+    LOWER_CONVECTION_BAKE_300F_NINE_MINUTES_59,
+    LOWER_CONVECTION_BAKE_PREHEAT_COMPLETE,
+    UPPER_BROIL_HIGH_WITH_LOWER_PREHEATING,
+    LOWER_PREHEAT_COMPLETE_EVENT,
+    LOWER_PREHEAT_COMPLETE_WITH_UPPER_BROIL,
+    UPPER_CANCELLED_WITH_LOWER_ACTIVE,
+    LOWER_CANCELLED,
+    UPPER_OVEN_170F_THREE_MINUTES,
+    UPPER_OVEN_170F_TWO_MINUTES_59,
+    UPPER_BAKE_125C_ONE_HOUR_THREE_MINUTES,
+    UPPER_BAKE_125C_ONE_HOUR_TWO_MINUTES_59,
+    UPPER_BAKE_PREHEAT_COMPLETE_EVENT,
+    UPPER_BAKE_PREHEAT_COMPLETE,
+    UPPER_BAKE_CANCELLED_AT_266F,
+    UPPER_OVEN_FINISHED_AT_124F,
+    UPPER_OVEN_FINISHED_EVENT,
+    UPPER_OVEN_CLEARED_AT_149F,
+]
+
+describe(MODEL_ID, () => {
+    test('is selected by the Home Assistant bridge and queried on connect', () => {
+        const ha = new MockHAConnection()
+        const thinq = new MockThinq2Device(DEVICE_ID, META)
+        const bridge = new Bridge(ha.asConnection())
+
+        bridge.newDevice(thinq)
+
+        assert.ok(bridge.haDevices.has(DEVICE_ID))
+        assert.ok(ha.devices[DEVICE_ID].config)
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(
+            hex(thinq.outbox[0]),
+            'AA28F0ED114101000000181A0207080C14191A1E262B30353A00000000000000000000000000F3BB',
+        )
+    })
+
+    test('publishes status, confirmed write controls, and diagnostics', () => {
+        const { ha } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        const properties = ha.devices[DEVICE_ID].properties
+
+        assert.equal(components.cooktop_status.platform, 'binary_sensor')
+        assert.equal(components.cooktop_status.payload_on, 'ON')
+        assert.equal(components.cooktop_status.payload_off, 'OFF')
+        assert.equal(components.cooktop_status.command_topic, undefined)
+        assert.equal(components.upper_oven_temperature.command_topic, undefined)
+        assert.equal(components.upper_oven_temperature.unit_of_measurement, '°F')
+        assert.equal(components.upper_oven_state.command_topic, undefined)
+        assert.equal(components.upper_oven_mode.command_topic, undefined)
+        assert.equal(components.upper_oven_set_temperature.command_topic, undefined)
+        assert.equal(components.upper_oven_set_temperature.unit_of_measurement, '°F')
+        assert.equal(components.upper_oven_cook_time.command_topic, undefined)
+        assert.equal(components.lower_oven_temperature.command_topic, undefined)
+        assert.equal(components.lower_oven_temperature.unit_of_measurement, '°F')
+        assert.equal(components.lower_oven_state.command_topic, undefined)
+        assert.equal(components.lower_oven_mode.command_topic, undefined)
+        assert.equal(components.lower_oven_set_temperature.command_topic, undefined)
+        assert.equal(components.lower_oven_set_temperature.unit_of_measurement, '°F')
+        assert.equal(components.lower_oven_cook_time.command_topic, undefined)
+        assert.equal(components.upper_oven_remote_start.command_topic, undefined)
+        assert.equal(components.lower_oven_remote_start.command_topic, undefined)
+        assert.equal(components.timer.platform, 'text')
+        assert.equal(components.timer.command_topic, '$this/timer/set')
+        assert.equal(components.timer_stop.platform, 'button')
+        assert.equal(components.timer_stop.command_topic, '$this/timer_stop/set')
+        assert.equal(components.clock_sync.platform, 'button')
+        assert.equal(components.clock_sync.command_topic, '$this/clock_sync/set')
+        assert.equal(components.clock_sync.state_topic, undefined)
+        assert.equal(components.beeper_volume.platform, 'select')
+        assert.equal(components.beeper_volume.command_topic, '$this/beeper_volume/set')
+        assert.deepEqual(components.beeper_volume.options, ['High', 'Low', 'Mute'])
+        // Write-only: the oven never reports it, so HA must track the selection optimistically.
+        assert.equal(components.beeper_volume.optimistic, true)
+        assert.equal(components.beeper_volume.state_topic, undefined)
+        assert.equal(components.preheat_alarm_light.platform, 'switch')
+        assert.equal(components.preheat_alarm_light.command_topic, '$this/preheat_alarm_light/set')
+        assert.equal(components.preheat_alarm_light.optimistic, true)
+        assert.equal(components.preheat_alarm_light.state_topic, undefined)
+        assert.equal(components.temperature_unit.platform, 'select')
+        assert.equal(components.temperature_unit.command_topic, '$this/temperature_unit/set')
+        assert.deepEqual(components.temperature_unit.options, ['°F', '°C'])
+        assert.equal(components.temperature_unit.optimistic, true)
+        assert.equal(components.temperature_unit.state_topic, undefined)
+        assert.equal(components.auto_conversion.platform, 'switch')
+        assert.equal(components.auto_conversion.command_topic, '$this/auto_conversion/set')
+        assert.equal(components.auto_conversion.optimistic, true)
+        assert.equal(components.auto_conversion.state_topic, undefined)
+        assert.equal(components.upper_temperature_adjustment.platform, 'number')
+        assert.equal(components.upper_temperature_adjustment.min, -35)
+        assert.equal(components.upper_temperature_adjustment.max, 35)
+        assert.equal(components.upper_temperature_adjustment.unit_of_measurement, '°F')
+        assert.equal(components.upper_temperature_adjustment.optimistic, true)
+        assert.equal(components.upper_temperature_adjustment.state_topic, undefined)
+        assert.equal(components.lower_temperature_adjustment.platform, 'number')
+        assert.equal(components.lower_temperature_adjustment.state_topic, undefined)
+        assert.equal(components.upper_remote_temperature.platform, 'number')
+        assert.equal(components.upper_remote_temperature.min, 170)
+        assert.equal(components.upper_remote_temperature.max, 550)
+        assert.equal(components.upper_remote_cook_time.platform, 'number')
+        assert.equal(components.upper_start.platform, 'button')
+        assert.equal(components.upper_start.name, 'Start Upper Bake')
+        assert.equal(components.upper_cancel.platform, 'button')
+        assert.equal(components.lower_remote_temperature.platform, 'number')
+        assert.equal(components.lower_remote_temperature.min, 170)
+        assert.equal(components.lower_remote_temperature.max, 550)
+        assert.equal(components.lower_remote_cook_time.platform, 'number')
+        assert.equal(components.lower_remote_mode.platform, 'select')
+        assert.deepEqual(components.lower_remote_mode.options, ['Bake', 'Convection Bake', 'Convection Roast'])
+        assert.equal(components.lower_start.platform, 'button')
+        assert.equal(components.lower_start.name, 'Start Lower')
+        assert.equal(components.lower_cancel.platform, 'button')
+        assert.equal(properties.upper_remote_temperature, 350)
+        assert.equal(properties.upper_remote_cook_time, 10)
+        assert.equal(properties.lower_remote_temperature, 350)
+        assert.equal(properties.lower_remote_cook_time, 10)
+        assert.equal(properties.lower_remote_mode, 'Bake')
+        // Construction forces readiness OFF so a stale retained ON from a previous run cannot
+        // enable the Start buttons before the first status reply.
+        assert.equal(properties.upper_oven_remote_start, 'OFF')
+        assert.equal(properties.lower_oven_remote_start, 'OFF')
+        assert.equal(components.upper_oven_state.device_class, 'enum')
+        assert.deepEqual(components.upper_oven_state.options, ['Idle', 'Preheating', 'Active', 'Complete'])
+        assert.equal(components.upper_oven_mode.device_class, 'enum')
+        assert.deepEqual(components.upper_oven_mode.options, [
+            'None',
+            'Bake',
+            'Broil',
+            'Convection Bake',
+            'Convection Roast',
+        ])
+        // Undecoded bytes and frames are logged rather than published, so the discovery payload
+        // must carry no diagnostic dump entity.
+        assert.equal(components.raw_status, undefined)
+        assert.equal(components.undecoded_frame, undefined)
+    })
+
+    test('start sends the exact status query observed from LG cloud', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+
+        dev.start()
+
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(
+            hex(thinq.outbox[0]),
+            'AA28F0ED114101000000181A0207080C14191A1E262B30353A00000000000000000000000000F3BB',
+        )
+    })
+
+    // Publishing a value outside the declared options is an error in HA, and only 'unknown' is
+    // exempt. Replay every captured frame and check both enum sensors against the discovery config.
+    test('no captured frame publishes an oven state or mode outside the declared options', () => {
+        const { ha, thinq } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, { options?: string[] }>
+        const properties = ha.devices[DEVICE_ID].properties
+
+        for (const capture of ALL_CAPTURES) {
+            thinq.emit('data', capture)
+            for (const entity of ['upper_oven_state', 'lower_oven_state', 'upper_oven_mode', 'lower_oven_mode']) {
+                const allowed = [...components[entity].options!, 'unknown']
+                assert.ok(
+                    allowed.includes(properties[entity] as string),
+                    `${entity} published ${properties[entity]} for ${hex(capture)}`,
+                )
+            }
+        }
+    })
+
+    // Every captured status arrived as EC, so the EB shape is the one place a synthetic record is
+    // unavoidable. Only the framing is synthetic; the field offsets come from the real captures.
+    test('40 EB decodes its single status block', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', frame(Buffer.concat([Buffer.from([0x40, 0xeb]), record({ temperature: 350 })])))
+
+        assert.equal(ha.devices[DEVICE_ID].properties.upper_oven_temperature, 350)
+    })
+
+    test('40 EC decodes the second (current) block, not the first', () => {
+        const { ha, thinq } = makeDevice()
+        const inner = Buffer.concat([
+            Buffer.from([0x40, 0xec]),
+            record({ temperature: 100 }),
+            record({ temperature: 350 }),
+        ])
+
+        thinq.emit('data', frame(inner))
+
+        assert.equal(ha.devices[DEVICE_ID].properties.upper_oven_temperature, 350)
+    })
+
+    // HA rejects values outside a declared option list; 'unknown' is the one accepted fallback, so
+    // undecoded state/mode bytes must never leak out as a raw byte value.
+    test('undecoded state and mode bytes publish unknown', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', frame(Buffer.concat([Buffer.from([0x40, 0xeb]), record({ state: 0x7f, mode: 0x7e })])))
+
+        const properties = ha.devices[DEVICE_ID].properties
+        assert.equal(properties.upper_oven_state, 'unknown')
+        assert.equal(properties.upper_oven_mode, 'unknown')
+    })
+
+    test('real cooktop transitions publish OFF, ON, then OFF from the five slot flags', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', COOKTOP_OFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.cooktop_status, 'OFF')
+
+        thinq.emit('data', COOKTOP_OFF_TO_ON)
+        assert.equal(ha.devices[DEVICE_ID].properties.cooktop_status, 'ON')
+
+        thinq.emit('data', COOKTOP_ON_TO_OFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.cooktop_status, 'OFF')
+    })
+
+    test('real timer frames decode set, rollover, and stop states', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', TIMER_09_01_13)
+        assert.equal(ha.devices[DEVICE_ID].properties.timer, '09:01:13')
+
+        thinq.emit('data', TIMER_ROLLOVER_09_00_59)
+        assert.equal(ha.devices[DEVICE_ID].properties.timer, '09:00:59')
+
+        thinq.emit('data', TIMER_STOPPED)
+        assert.equal(ha.devices[DEVICE_ID].properties.timer, '00:00:00')
+    })
+
+    test('real timer-expiry alarm event publishes nothing', () => {
+        const { ha, thinq } = makeDevice()
+        const before = snapshot(ha)
+
+        thinq.emit('data', TIMER_EXPIRED_ALARM)
+
+        assert.equal(snapshot(ha), before)
+    })
+
+    test('real set/start, cancel, and rejection acknowledgements publish nothing', () => {
+        const { ha, thinq } = makeDevice()
+        const before = snapshot(ha)
+
+        thinq.emit('data', START_ACCEPTED_ACK)
+        thinq.emit('data', Buffer.from('AA084000440063BB', 'hex'))
+        thinq.emit('data', START_REJECTED_ACK)
+
+        assert.equal(snapshot(ha), before)
+    })
+
+    test('timer set and stop send the exact captured commands', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.setProperty('timer', '09:01:13')
+        assert.equal(hex(thinq.outbox[0]), 'AA0EF04323068080800D0109FEBB')
+
+        thinq.resetRecorder()
+        dev.setProperty('timer_stop', 'PRESS')
+        assert.equal(hex(thinq.outbox[0]), 'AA0EF0432306808080000000C1BB')
+    })
+
+    // Both frames were captured from the LG app's Clock Settings -> "Sync with smartphone" on
+    // 2026-08-29, at 23:12 and 23:15 local time. They differ only in byte 2 of the payload and in
+    // how the hour is expressed, which is what leaves that byte's meaning open.
+    test('clock sync reproduces the captured 24-hour preference command', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.sendClock(23, 15)
+
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(hex(thinq.outbox[0]), 'AA15F043210E170F008080808080808080FF8093BB')
+    })
+
+    // The 12-hour capture is not a shape the handler emits, but it is the other half of the
+    // evidence for byte 2, so it is pinned here to keep the payload layout honest.
+    test('the captured 12-hour clock frame differs only in the hour and byte 2', () => {
+        const twelveHour = Buffer.from('AA15F043210E0B0C018080808080808080FF80EDBB', 'hex')
+        const twentyFourHour = Buffer.from('AA15F043210E170F008080808080808080FF8093BB', 'hex')
+
+        // Payload sits after AA <len> F0 43 21 0E and before <checksum> BB.
+        const payload = (frame: Buffer) => [...frame.subarray(6, frame.length - 2)]
+        assert.deepEqual(payload(twelveHour), [0x0b, 0x0c, 0x01, ...Array(8).fill(0x80), 0xff, 0x80])
+        assert.deepEqual(payload(twentyFourHour), [0x17, 0x0f, 0x00, ...Array(8).fill(0x80), 0xff, 0x80])
+    })
+
+    test('clock sync sends the host time and leaves every other preference unchanged', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.setProperty('clock_sync', 'PRESS')
+
+        assert.equal(thinq.outbox.length, 1)
+        const frame = thinq.outbox[0]
+        const payload = frame.subarray(6, frame.length - 2)
+        assert.equal(hex(frame.subarray(0, 6)), 'AA15F043210E')
+        assert.ok(payload[0] < 24)
+        assert.ok(payload[1] < 60)
+        assert.equal(payload[2], 0x00)
+        // Every field the user did not touch must go out as the no-change sentinel.
+        assert.deepEqual([...payload.subarray(3)], [...Array(8).fill(0x80), 0xff, 0x80])
+    })
+
+    // One Save per value, captured 2026-08-29 at 05:23:17Z, 05:24:43Z and 05:25:01Z. Each frame
+    // changed only payload index 8, which is what identifies that slot as Beeper Volume.
+    test('beeper volume reproduces all three captured commands', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.setProperty('beeper_volume', 'Mute')
+        dev.setProperty('beeper_volume', 'High')
+        dev.setProperty('beeper_volume', 'Low')
+
+        assert.equal(thinq.outbox.length, 3)
+        assert.equal(hex(thinq.outbox[0]), 'AA15F043210E8080808080808080008080FF80F5BB')
+        assert.equal(hex(thinq.outbox[1]), 'AA15F043210E8080808080808080028080FF80F7BB')
+        assert.equal(hex(thinq.outbox[2]), 'AA15F043210E8080808080808080018080FF80F4BB')
+    })
+
+    test('a preference write leaves every field it does not set at its no-change sentinel', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.setProperty('beeper_volume', 'Mute')
+
+        const frame = thinq.outbox[0]
+        const payload = frame.subarray(6, frame.length - 2)
+        // Everything but index 8 (beeper) and index 11 (its own FF sentinel) stays 0x80.
+        payload.forEach((value, index) => {
+            if (index === 8) return assert.equal(value, 0x00)
+            if (index === 11) return assert.equal(value, 0xff)
+            assert.equal(value, 0x80, `payload index ${index}`)
+        })
+    })
+
+    // Captured 2026-08-29 at 05:27:54Z and 05:28:27Z; each changed only payload index 7.
+    test('preheating alarm light reproduces both captured commands', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.setProperty('preheat_alarm_light', 'OFF')
+        dev.setProperty('preheat_alarm_light', 'ON')
+
+        assert.equal(thinq.outbox.length, 2)
+        assert.equal(hex(thinq.outbox[0]), 'AA15F043210E8080808080808000808080FF80F5BB')
+        assert.equal(hex(thinq.outbox[1]), 'AA15F043210E8080808080808001808080FF80F4BB')
+    })
+
+    // Captured 2026-08-29 at 05:29:33Z (°C) and 05:34:50Z (°F); each changed only payload index 9.
+    test('temperature unit reproduces both captured commands', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.setProperty('temperature_unit', '°C')
+        dev.setProperty('temperature_unit', '°F')
+
+        assert.equal(thinq.outbox.length, 2)
+        assert.equal(hex(thinq.outbox[0]), 'AA15F043210E8080808080808080800180FF80F4BB')
+        assert.equal(hex(thinq.outbox[1]), 'AA15F043210E8080808080808080800080FF80F5BB')
+    })
+
+    // The EC frames captured either side of the °C switch kept reporting Fahrenheit ambient
+    // temperatures, so the display unit must not reach status decoding.
+    test('the display temperature unit does not change how status temperatures decode', () => {
+        const { ha, thinq, dev } = makeDevice()
+
+        dev.setProperty('temperature_unit', '°C')
+        thinq.emit('data', LOWER_CANCELLED)
+
+        assert.equal(ha.devices[DEVICE_ID].properties.lower_oven_temperature, 356)
+    })
+
+    // Captured 2026-08-29 at 05:44:31Z and 05:45:02Z; each changed only payload index 3.
+    test('auto conversion reproduces both captured commands', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.setProperty('auto_conversion', 'OFF')
+        dev.setProperty('auto_conversion', 'ON')
+
+        assert.equal(thinq.outbox.length, 2)
+        assert.equal(hex(thinq.outbox[0]), 'AA15F043210E8080800080808080808080FF80F5BB')
+        assert.equal(hex(thinq.outbox[1]), 'AA15F043210E8080800180808080808080FF80F4BB')
+    })
+
+    // REAL frame, 2026-08-29 05:48:41Z: one Save carrying Upper -2°F and Lower Off. Index 4 named
+    // °F, index 5 held the signed -2 and index 6 the zero that the app labels Off.
+    test('temperature adjustment reproduces the captured Upper -2°F, Lower Off command', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.sendTemperatureAdjustment({ upper: -2, lower: 0 })
+
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(hex(thinq.outbox[0]), 'AA15F043210E8080808000FE0080808080FF80CBBB')
+    })
+
+    // REAL frame, 2026-08-29 05:51:06Z: Upper +2°F and Lower -1°F in one Save. The pair with the
+    // capture above covers a positive, a negative and a zero, pinning the two's-complement encoding.
+    test('temperature adjustment reproduces the captured Upper +2°F, Lower -1°F command', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.sendTemperatureAdjustment({ upper: 2, lower: -1 })
+
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(hex(thinq.outbox[0]), 'AA15F043210E808080800002FF80808080FF80F4BB')
+    })
+
+    // REAL frame, 2026-08-29 05:53:22Z: Upper Off and Lower -1°C. The handler always names °F at
+    // index 4, so it does not emit this shape; it is pinned here because it is the evidence that
+    // index 4 is the unit for the trims and shares index 9's encoding.
+    test('the captured Celsius trim frame names °C at the temperature adjustment unit index', () => {
+        const frame = Buffer.from('AA15F043210E808080800100FF80808080FF80F5BB', 'hex')
+
+        const payload = frame.subarray(6, frame.length - 2)
+        assert.equal(payload[4], 0x01)
+        assert.equal(payload[5], 0x00)
+        assert.equal(payload[6], 0xff)
+    })
+
+    test('temperature adjustment writes one cavity and leaves the other unchanged', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.setProperty('upper_temperature_adjustment', '-2')
+        dev.setProperty('lower_temperature_adjustment', '15')
+
+        const payload = (frame: Buffer) => [...frame.subarray(6, frame.length - 2)]
+        // Upper write: index 5 carries the trim, index 6 stays at the no-change sentinel.
+        assert.deepEqual(payload(thinq.outbox[0]).slice(4, 7), [0x00, 0xfe, 0x80])
+        // Lower write: the reverse.
+        assert.deepEqual(payload(thinq.outbox[1]).slice(4, 7), [0x00, 0x80, 0x0f])
+    })
+
+    test('out-of-range and non-numeric temperature adjustments send nothing', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.setProperty('upper_temperature_adjustment', '-36')
+        dev.setProperty('upper_temperature_adjustment', '36')
+        dev.setProperty('upper_temperature_adjustment', 'hot')
+        dev.setProperty('lower_temperature_adjustment', '')
+
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('an unknown auto conversion payload sends nothing', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.setProperty('auto_conversion', 'AUTO')
+
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('an unknown temperature unit option sends nothing', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.setProperty('temperature_unit', 'kelvin')
+
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('an unknown preheating alarm light payload sends nothing', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.setProperty('preheat_alarm_light', 'MAYBE')
+
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('an unknown beeper volume option sends nothing', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.setProperty('beeper_volume', 'Deafening')
+
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('a non-press clock sync payload sends nothing', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.setProperty('clock_sync', 'not-a-press')
+
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('invalid timer values and non-press button payloads send nothing', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.setProperty('timer', '9:01:13')
+        dev.setProperty('timer', '09:61:13')
+        dev.setProperty('timer_stop', 'not-a-press')
+
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('Upper and Lower cancel send the exact captured selector commands', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.setProperty('upper_cancel', 'PRESS')
+        dev.setProperty('lower_cancel', 'PRESS')
+
+        assert.equal(hex(thinq.outbox[0]), 'AA07F04400B0BB')
+        assert.equal(hex(thinq.outbox[1]), 'AA07F04401B3BB')
+    })
+
+    test('remote start reproduces both captured start commands', () => {
+        const { thinq, dev } = makeDevice()
+
+        // Stage the parameters the captured commands actually carried, so the frames stay pinned to
+        // the captures rather than to whatever the constructor defaults happen to be.
+        dev.setProperty('upper_remote_temperature', '170')
+        dev.setProperty('upper_remote_cook_time', '3')
+        dev.setProperty('lower_remote_temperature', '350')
+        dev.setProperty('lower_remote_cook_time', '0')
+        dev.setProperty('lower_remote_mode', 'Convection Roast')
+
+        dev.setProperty('upper_start', 'PRESS')
+        dev.setProperty('lower_start', 'PRESS')
+
+        assert.equal(thinq.outbox.length, 2)
+        assert.equal(hex(thinq.outbox[0]), 'AA13F043200B010000000000AA000300009CBB')
+        assert.equal(hex(thinq.outbox[1]), 'AA13F043200B1800000000015E00000000C7BB')
+    })
+
+    // The oven arms Remote Start on its own front panel and answers an unarmed start with
+    // START_REJECTED_ACK, so the handler adds no lockout of its own on top of that.
+    test('remote start is sent without a readiness check of our own', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.setProperty('upper_start', 'PRESS')
+
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(hex(thinq.outbox[0]), 'AA13F043200B0100000000015E000A0000D0BB')
+    })
+
+    test('remote-start inputs publish and encode temperature and cook time', () => {
+        const { ha, thinq, dev } = makeDevice()
+
+        dev.setProperty('upper_remote_temperature', '400')
+        dev.setProperty('upper_remote_cook_time', '90')
+
+        assert.equal(ha.devices[DEVICE_ID].properties.upper_remote_temperature, 400)
+        assert.equal(ha.devices[DEVICE_ID].properties.upper_remote_cook_time, 90)
+        // Staging a value must not put anything on the wire; only the Start button does that.
+        assert.equal(thinq.outbox.length, 0)
+
+        dev.setProperty('upper_start', 'PRESS')
+
+        const command = thinq.outbox[0]
+        assert.deepEqual(
+            [...command.subarray(2, command.length - 2)],
+            [0xf0, 0x43, 0x20, 0x0b, 0x01, 0x00, 0x00, 0x00, 0x00, 0x01, 0x90, 0x01, 0x1e, 0x00, 0x00],
+        )
+    })
+
+    test('Lower mode selection validates, publishes, and encodes every captured operation', () => {
+        const { ha, thinq, dev } = makeDevice()
+        const properties = ha.devices[DEVICE_ID].properties
+
+        dev.setProperty('lower_remote_mode', 'Convection Roast')
+        dev.setProperty('lower_remote_mode', 'Steam Bake')
+        assert.equal(properties.lower_remote_mode, 'Convection Roast')
+        assert.equal(thinq.outbox.length, 0)
+
+        dev.setProperty('lower_remote_temperature', '300')
+        dev.setProperty('lower_remote_cook_time', '10')
+        dev.setProperty('lower_remote_mode', 'Bake')
+        assert.equal(properties.lower_remote_mode, 'Bake')
+        thinq.emit('data', LOWER_ONLY_REMOTE_START_READY)
+        dev.setProperty('lower_start', 'PRESS')
+        assert.equal(hex(thinq.outbox[0]), 'AA13F043200B1500000000012C000A000032BB')
+
+        dev.setProperty('lower_remote_mode', 'Convection Bake')
+        assert.equal(properties.lower_remote_mode, 'Convection Bake')
+        thinq.emit('data', LOWER_ONLY_REMOTE_START_READY)
+        dev.setProperty('lower_start', 'PRESS')
+        assert.equal(hex(thinq.outbox[1]), 'AA13F043200B1700000000012C000A00003CBB')
+
+        dev.setProperty('lower_remote_mode', 'Convection Roast')
+        assert.equal(properties.lower_remote_mode, 'Convection Roast')
+        thinq.emit('data', LOWER_ONLY_REMOTE_START_READY)
+        dev.setProperty('lower_start', 'PRESS')
+        assert.equal(hex(thinq.outbox[2]), 'AA13F043200B1800000000012C000A00003FBB')
+    })
+
+    test('real upper-oven remote start pins cavity order, temperature, cook time, and readiness', () => {
+        const { ha, thinq } = makeDevice()
+        const properties = ha.devices[DEVICE_ID].properties
+
+        thinq.emit('data', BOTH_OVENS_REMOTE_START_READY)
+        assert.equal(properties.upper_oven_remote_start, 'ON')
+        assert.equal(properties.lower_oven_remote_start, 'ON')
+
+        thinq.emit('data', UPPER_OVEN_170F_THREE_MINUTES)
+        assert.equal(properties.upper_oven_state, 'Preheating')
+        assert.equal(properties.upper_oven_mode, 'Bake')
+        assert.equal(properties.lower_oven_state, 'Idle')
+        assert.equal(properties.upper_oven_temperature, 'unknown')
+        assert.equal(properties.upper_oven_set_temperature, 170)
+        assert.equal(properties.upper_oven_cook_time, 180)
+        assert.equal(properties.lower_oven_temperature, 77)
+        assert.equal(properties.lower_oven_set_temperature, 'unknown')
+        assert.equal(properties.lower_oven_cook_time, 0)
+        assert.equal(properties.upper_oven_remote_start, 'OFF')
+        assert.equal(properties.lower_oven_remote_start, 'OFF')
+
+        thinq.emit('data', UPPER_OVEN_170F_TWO_MINUTES_59)
+        assert.equal(properties.upper_oven_cook_time, 179)
+
+        thinq.emit('data', UPPER_OVEN_FINISHED_AT_124F)
+        assert.equal(properties.upper_oven_state, 'Complete')
+        assert.equal(properties.upper_oven_temperature, 124)
+        assert.equal(properties.upper_oven_set_temperature, 'unknown')
+        assert.equal(properties.upper_oven_cook_time, 0)
+        assert.equal(properties.upper_oven_remote_start, 'OFF')
+
+        const beforeEvent = snapshot(ha)
+        thinq.emit('data', UPPER_OVEN_FINISHED_EVENT)
+        assert.equal(snapshot(ha), beforeEvent)
+
+        thinq.emit('data', UPPER_OVEN_CLEARED_AT_149F)
+        assert.equal(properties.upper_oven_state, 'Idle')
+        assert.equal(properties.upper_oven_temperature, 149)
+        assert.equal(properties.upper_oven_set_temperature, 'unknown')
+        assert.equal(properties.upper_oven_cook_time, 0)
+        assert.equal(properties.upper_oven_remote_start, 'OFF')
+        assert.equal(properties.lower_oven_remote_start, 'OFF')
+    })
+
+    test('real 125°C Upper Bake frame confirms mode, normalized setpoint, and 01:03:00 countdown', () => {
+        const { ha, thinq } = makeDevice()
+        const properties = ha.devices[DEVICE_ID].properties
+
+        thinq.emit('data', UPPER_BAKE_125C_ONE_HOUR_THREE_MINUTES)
+        assert.equal(properties.upper_oven_state, 'Preheating')
+        assert.equal(properties.upper_oven_mode, 'Bake')
+        assert.equal(properties.upper_oven_set_temperature, 257)
+        assert.equal(properties.upper_oven_cook_time, 3780)
+
+        thinq.emit('data', UPPER_BAKE_125C_ONE_HOUR_TWO_MINUTES_59)
+        assert.equal(properties.upper_oven_cook_time, 3779)
+
+        const beforeEvent = snapshot(ha)
+        thinq.emit('data', UPPER_BAKE_PREHEAT_COMPLETE_EVENT)
+        assert.equal(snapshot(ha), beforeEvent)
+
+        thinq.emit('data', UPPER_BAKE_PREHEAT_COMPLETE)
+        assert.equal(properties.upper_oven_state, 'Active')
+        assert.equal(properties.upper_oven_mode, 'Bake')
+        assert.equal(properties.upper_oven_set_temperature, 257)
+        assert.equal(properties.upper_oven_cook_time, 3511)
+
+        thinq.emit('data', UPPER_BAKE_CANCELLED_AT_266F)
+        assert.equal(properties.upper_oven_state, 'Idle')
+        assert.equal(properties.upper_oven_mode, 'None')
+        assert.equal(properties.upper_oven_temperature, 266)
+        assert.equal(properties.upper_oven_set_temperature, 'unknown')
+        assert.equal(properties.upper_oven_cook_time, 0)
+    })
+
+    test('real Lower-only remote-start frame publishes only Lower as ready', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', LOWER_ONLY_REMOTE_START_READY)
+
+        assert.equal(ha.devices[DEVICE_ID].properties.upper_oven_remote_start, 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties.lower_oven_remote_start, 'ON')
+    })
+
+    test('real 285°C Lower Bake frame confirms mode, normalized setpoint, and countdown', () => {
+        const { ha, thinq } = makeDevice()
+        const properties = ha.devices[DEVICE_ID].properties
+
+        thinq.emit('data', LOWER_BAKE_285C_FIVE_MINUTES)
+        assert.equal(properties.upper_oven_state, 'Idle')
+        assert.equal(properties.lower_oven_state, 'Preheating')
+        assert.equal(properties.lower_oven_mode, 'Bake')
+        assert.equal(properties.lower_oven_set_temperature, 545)
+        assert.equal(properties.lower_oven_cook_time, 300)
+
+        thinq.emit('data', LOWER_BAKE_285C_FOUR_MINUTES_59)
+        assert.equal(properties.lower_oven_cook_time, 299)
+
+        thinq.emit('data', LOWER_BAKE_CANCELLED_AT_252F)
+        assert.equal(properties.upper_oven_state, 'Idle')
+        assert.equal(properties.lower_oven_state, 'Idle')
+        assert.equal(properties.lower_oven_mode, 'None')
+        assert.equal(properties.lower_oven_temperature, 252)
+        assert.equal(properties.lower_oven_set_temperature, 'unknown')
+        assert.equal(properties.lower_oven_cook_time, 0)
+    })
+
+    test('real 300°F Lower Convection Bake confirms mode, auto-converted setpoint, and countdown', () => {
+        const { ha, thinq } = makeDevice()
+        const properties = ha.devices[DEVICE_ID].properties
+
+        thinq.emit('data', LOWER_CONVECTION_BAKE_300F_TEN_MINUTES)
+        assert.equal(properties.upper_oven_state, 'Idle')
+        assert.equal(properties.lower_oven_state, 'Preheating')
+        assert.equal(properties.lower_oven_mode, 'Convection Bake')
+        assert.equal(properties.lower_oven_set_temperature, 275)
+        assert.equal(properties.lower_oven_cook_time, 600)
+
+        thinq.emit('data', LOWER_CONVECTION_BAKE_300F_NINE_MINUTES_59)
+        assert.equal(properties.lower_oven_cook_time, 599)
+
+        const beforeEvent = snapshot(ha)
+        thinq.emit('data', LOWER_PREHEAT_COMPLETE_EVENT)
+        assert.equal(snapshot(ha), beforeEvent)
+
+        thinq.emit('data', LOWER_CONVECTION_BAKE_PREHEAT_COMPLETE)
+        assert.equal(properties.lower_oven_state, 'Active')
+        assert.equal(properties.lower_oven_mode, 'Convection Bake')
+        assert.equal(properties.lower_oven_set_temperature, 275)
+        assert.equal(properties.lower_oven_cook_time, 545)
+    })
+
+    test('real Lower Convection Roast frame decodes 16-bit auto-converted setpoint and time off', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', LOWER_CONVECTION_ROAST_350F_TIME_OFF)
+
+        const properties = ha.devices[DEVICE_ID].properties
+        assert.equal(properties.upper_oven_set_temperature, 'unknown')
+        assert.equal(properties.upper_oven_cook_time, 0)
+        assert.equal(properties.lower_oven_set_temperature, 325)
+        assert.equal(properties.lower_oven_state, 'Preheating')
+        assert.equal(properties.lower_oven_mode, 'Convection Roast')
+        assert.equal(properties.lower_oven_cook_time, 0)
+        assert.equal(properties.upper_oven_remote_start, 'OFF')
+        assert.equal(properties.lower_oven_remote_start, 'OFF')
+    })
+
+    test('real manual Upper Broil High frame decodes both simultaneously active cavities', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', UPPER_BROIL_HIGH_WITH_LOWER_PREHEATING)
+
+        const properties = ha.devices[DEVICE_ID].properties
+        assert.equal(properties.upper_oven_state, 'Active')
+        assert.equal(properties.upper_oven_mode, 'Broil')
+        assert.equal(properties.upper_oven_set_temperature, 400)
+        assert.equal(properties.upper_oven_cook_time, 0)
+        assert.equal(properties.lower_oven_state, 'Preheating')
+        assert.equal(properties.lower_oven_mode, 'Convection Roast')
+        assert.equal(properties.lower_oven_set_temperature, 325)
+        assert.equal(properties.lower_oven_cook_time, 0)
+    })
+
+    test('real Lower preheat-complete event and transition publish Lower Active', () => {
+        const { ha, thinq } = makeDevice()
+
+        const beforeEvent = snapshot(ha)
+        thinq.emit('data', LOWER_PREHEAT_COMPLETE_EVENT)
+        assert.equal(snapshot(ha), beforeEvent)
+
+        thinq.emit('data', LOWER_PREHEAT_COMPLETE_WITH_UPPER_BROIL)
+
+        const properties = ha.devices[DEVICE_ID].properties
+        assert.equal(properties.upper_oven_state, 'Active')
+        assert.equal(properties.upper_oven_mode, 'Broil')
+        assert.equal(properties.upper_oven_set_temperature, 400)
+        assert.equal(properties.lower_oven_state, 'Active')
+        assert.equal(properties.lower_oven_mode, 'Convection Roast')
+        assert.equal(properties.lower_oven_set_temperature, 325)
+        assert.equal(properties.lower_oven_temperature, 'unknown')
+    })
+
+    test('real Upper cancel transition clears only Upper and preserves active Lower', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', UPPER_CANCELLED_WITH_LOWER_ACTIVE)
+
+        const properties = ha.devices[DEVICE_ID].properties
+        assert.equal(properties.upper_oven_state, 'Idle')
+        assert.equal(properties.upper_oven_mode, 'None')
+        assert.equal(properties.upper_oven_set_temperature, 'unknown')
+        assert.equal(properties.upper_oven_temperature, 206)
+        assert.equal(properties.lower_oven_state, 'Active')
+        assert.equal(properties.lower_oven_mode, 'Convection Roast')
+        assert.equal(properties.lower_oven_set_temperature, 325)
+        assert.equal(properties.lower_oven_temperature, 'unknown')
+    })
+
+    test('real Lower cancel transition clears Lower and decodes 16-bit current temperatures', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', LOWER_CANCELLED)
+
+        const properties = ha.devices[DEVICE_ID].properties
+        assert.equal(properties.upper_oven_state, 'Idle')
+        assert.equal(properties.upper_oven_temperature, 204)
+        assert.equal(properties.lower_oven_state, 'Idle')
+        assert.equal(properties.lower_oven_mode, 'None')
+        assert.equal(properties.lower_oven_set_temperature, 'unknown')
+        assert.equal(properties.lower_oven_temperature, 356)
+        assert.equal(properties.upper_oven_remote_start, 'OFF')
+        assert.equal(properties.lower_oven_remote_start, 'OFF')
+    })
+
+    test('other oven opcodes are ignored', () => {
+        const { ha, thinq } = makeDevice()
+        const before = snapshot(ha)
+
+        thinq.emit('data', frame(Buffer.from([0x40, 0x31, 0x01, 0x02])))
+
+        assert.equal(snapshot(ha), before)
+    })
+
+    test('foreign class bytes and malformed status records are ignored, not decoded as status', () => {
+        const { ha, thinq } = makeDevice()
+        const before = snapshot(ha)
+
+        thinq.emit('data', frame(Buffer.from([0x32, 0xeb, 0x01])))
+        thinq.emit('data', frame(Buffer.from([0x40, 0xeb, 0x01])))
+        thinq.emit('data', frame(Buffer.from([0x40, 0xec, 0x01])))
+        // A 4-byte frame with an unknown command family is not a known acknowledgement.
+        thinq.emit('data', frame(Buffer.from([0x40, 0x00, 0x45, 0x00])))
+
+        assert.equal(snapshot(ha), before)
+    })
+
+    test('non-numeric and unknown-option payloads leave the staged value alone', () => {
+        const { ha, thinq, dev } = makeDevice()
+        const properties = ha.devices[DEVICE_ID].properties
+
+        dev.setProperty('upper_remote_temperature', '425')
+        dev.setProperty('lower_remote_mode', 'Convection Bake')
+        dev.setProperty('upper_remote_temperature', '')
+        dev.setProperty('upper_remote_temperature', 'hot')
+        dev.setProperty('lower_remote_mode', 'Steam Bake')
+
+        assert.equal(properties.upper_remote_temperature, 425)
+        assert.equal(properties.lower_remote_mode, 'Convection Bake')
+
+        // The staged values, not the discarded payloads, are what a start actually sends.
+        dev.setProperty('upper_start', 'PRESS')
+        dev.setProperty('lower_start', 'PRESS')
+        assert.equal(hex(thinq.outbox[0]), 'AA13F043200B010000000001A9000A000085BB')
+        assert.equal(hex(thinq.outbox[1]), 'AA13F043200B1700000000015E000A0000CEBB')
+    })
+
+    test('reconnect resets staged remote parameters and readiness to defaults', () => {
+        const { ha, thinq, dev } = makeDevice()
+        const properties = ha.devices[DEVICE_ID].properties
+
+        dev.setProperty('upper_remote_temperature', '425')
+        dev.setProperty('lower_remote_mode', 'Convection Bake')
+        thinq.emit('data', BOTH_OVENS_REMOTE_START_READY)
+        assert.equal(properties.upper_oven_remote_start, 'ON')
+
+        // The bridge constructs a fresh Device each time the appliance transport reopens.
+        new DUT(ha.asConnection(), new MockThinq2Device(DEVICE_ID, META), META)
+
+        assert.equal(properties.upper_remote_temperature, 350)
+        assert.equal(properties.lower_remote_mode, 'Bake')
+        assert.equal(properties.upper_oven_remote_start, 'OFF')
+        assert.equal(properties.lower_oven_remote_start, 'OFF')
+    })
+
+    test('unflagged panel-started mode codes decode via the remote-start flag mask', () => {
+        const { ha, thinq } = makeDevice()
+        const current = Buffer.alloc(62)
+        current[1] = 0x01 // panel Bake: remote-start flag 0x80 clear
+        current[19] = 0x17 // panel Convection Bake in the Lower block
+
+        thinq.emit('data', frame(Buffer.concat([Buffer.from([0x40, 0xeb]), current])))
+
+        assert.equal(ha.devices[DEVICE_ID].properties.upper_oven_mode, 'Bake')
+        assert.equal(ha.devices[DEVICE_ID].properties.lower_oven_mode, 'Convection Bake')
+    })
+})


### PR DESCRIPTION
Adds a driver for the LG WFV474PGV double oven (deviceType 301) and wires it
into the Home Assistant bridge.

Everything was derived from live captures against a real appliance, and writes
are limited to command shapes actually observed on the wire. Fields we don't
yet understand stay visible through a diagnostic sensor rather than being
guessed at.

**Exposes:** cooktop status; per-cavity current/set temperature, state, mode,
and cook time; a settable timer; staged temperature, cook time, and Lower mode
selection; and Start and Cancel buttons per cavity.

Remote start is gated on the appliance reporting that cavity ready — both in
HA (the button goes unavailable) and again in the driver before sending.

31 tests, most built on captured frames, including both remote-start commands
reproduced byte-for-byte.
