### PR TITLE
Add LG WM3500CW (F3L2CNV4W_WIFI) front-load washer support (ThinQ1)

### DIFF
--- a/cloud/devices/F3L2CNV4W_WIFI.ts
+++ b/cloud/devices/F3L2CNV4W_WIFI.ts
@@ -387,6 +387,11 @@ export default class Device extends HADevice {
             }),
         )
 
+        // The washer reports APCourse=0 while idle/no course actively dialed — that's not
+        // in COURSE_DEFAULTS, so the sync-on-data logic below never fires for it. Publish
+        // our own default up front so the select entity doesn't sit at "unknown" forever.
+        this.publishProperty('course_selection', AP_COURSE[this.pendingCourseId])
+
         thinq.on('data', (buf) => {
             if (buf.length < 24) return
 

--- a/cloud/devices/F3L2CNV4W_WIFI.ts
+++ b/cloud/devices/F3L2CNV4W_WIFI.ts
@@ -378,6 +378,10 @@ export default class Device extends HADevice {
         })
     }
 
+    start() {
+        this.thinq.send({ Cmd: 'Mon', CmdOpt: 'Start' })
+    }
+
     publishCache: Record<string, string | number> = {}
 
     publishProperty(prop: string, value: string | number) {

--- a/cloud/devices/F3L2CNV4W_WIFI.ts
+++ b/cloud/devices/F3L2CNV4W_WIFI.ts
@@ -27,11 +27,15 @@ import { Metadata } from '../thinq'
 // entirely: HTTP diagmon reports (cloud/thinq1/http.ts), not the persistent :47878 status
 // socket this class otherwise reads from. See the thinq.on('diagmon', ...) handler below.
 //
-// course_selection also offers the 16 app-downloadable SMART_COURSE_DEFAULTS entries
-// alongside the 9 physical-dial ones — same OperationStart command, same confirmed encoding,
-// just APCourse fixed at DOWNLOAD_COURSE_AP_ID with the real SmartCourse id populated instead
-// of 0. Every SmartCourse entry has controlEnable/downloadEnable:true in the modelJson, but
-// this path itself isn't yet confirmed against a real captured SmartCourse start.
+// course_selection only offers the 9 physical-dial AP courses, not the 16 SmartCourse ones.
+// Confirmed live (2026-08-22): starting "Small Load" (id 51) via OperationStart applied our
+// requested Soil/SpinSpeed/WaterTemp, but the machine kept reporting SmartCourse/OPCourse
+// identity for whatever was actually resident (a previously app-downloaded course), not id 51.
+// So OperationStart's SmartCourse field isn't a live selector - the machine only ever runs the
+// one SmartCourse actually downloaded onto it, and offering the other 15 as if they were
+// startable was misleading. Real download appears to be a separate, still-unimplemented
+// command (modelJson's ControlWifi.action.CourseDownload). SMART_COURSE below stays as a
+// read-only reflection of whatever's actually resident.
 
 const STATES: Record<number, string> = {
     0: 'Off',
@@ -143,9 +147,9 @@ const AP_COURSE: Record<number, string> = {
 // Remote-start defaults per course, straight from modelJson's APCourse[id].function[]
 // (Soil/WaterTemp/SpinSpeed) and APCourse[id].OPCourse. id 11 (Spin Only, hidden —
 // "visibility":"gone" in the modelJson) is deliberately excluded: not offered by the
-// physical dial or the official app either. id 10 (Download Course) is handled separately
-// below, via SMART_COURSE_DEFAULTS — it's not a fixed course, it's the "a SmartCourse is
-// loaded" slot.
+// physical dial or the official app either. id 10 (Download Course) is also excluded - it's
+// not a fixed course, it's "whatever SmartCourse is actually resident on the machine", and we
+// have no way to control that (see the header comment).
 const COURSE_DEFAULTS: Record<number, { soil: number; spinSpeed: number; waterTemp: number; opCourse: number }> = {
     1: { soil: 0, spinSpeed: 3, waterTemp: 0, opCourse: 13 }, // Tub Clean
     2: { soil: 3, spinSpeed: 5, waterTemp: 6, opCourse: 8 }, // Bright Whites
@@ -157,34 +161,6 @@ const COURSE_DEFAULTS: Record<number, { soil: number; spinSpeed: number; waterTe
     8: { soil: 3, spinSpeed: 5, waterTemp: 4, opCourse: 14 }, // Towels
     9: { soil: 1, spinSpeed: 5, waterTemp: 6, opCourse: 12 }, // Speed Wash
 }
-
-// App-downloadable "smart" courses, straight from modelJson's SmartCourse[id].function[] and
-// .OPCourse — same shape as COURSE_DEFAULTS above. Every entry has controlEnable:true and
-// downloadEnable:true in the spec. Starting one is the same OperationStart command as an
-// AP_COURSE start, just with APCourse fixed at 10 ("Download Course") and SmartCourse set to
-// the real id instead of 0 — no new/guessed command needed, only different template values.
-// Not yet confirmed against a real captured command (unlike the AP_COURSE path).
-const SMART_COURSE_DEFAULTS: Record<number, { soil: number; spinSpeed: number; waterTemp: number; opCourse: number }> =
-    {
-        51: { soil: 3, spinSpeed: 5, waterTemp: 4, opCourse: 15 }, // Small Load
-        52: { soil: 3, spinSpeed: 3, waterTemp: 2, opCourse: 6 }, // Color Care
-        53: { soil: 1, spinSpeed: 3, waterTemp: 2, opCourse: 10 }, // Beachwear
-        54: { soil: 1, spinSpeed: 2, waterTemp: 2, opCourse: 6 }, // New Clothes
-        55: { soil: 3, spinSpeed: 3, waterTemp: 2, opCourse: 6 }, // Denim
-        59: { soil: 1, spinSpeed: 2, waterTemp: 2, opCourse: 10 }, // Swimwear
-        60: { soil: 3, spinSpeed: 5, waterTemp: 4, opCourse: 6 }, // Rainy Day
-        61: { soil: 1, spinSpeed: 3, waterTemp: 4, opCourse: 21 }, // Gym Clothes
-        63: { soil: 1, spinSpeed: 5, waterTemp: 4, opCourse: 6 }, // Sweat Stains
-        64: { soil: 1, spinSpeed: 5, waterTemp: 6, opCourse: 12 }, // Single Garments
-        100: { soil: 3, spinSpeed: 5, waterTemp: 6, opCourse: 6 }, // Baby Clothes
-        105: { soil: 3, spinSpeed: 2, waterTemp: 4, opCourse: 6 }, // Overnight Wash
-        106: { soil: 3, spinSpeed: 5, waterTemp: 2, opCourse: 6 }, // Econo Wash
-        107: { soil: 1, spinSpeed: 2, waterTemp: 2, opCourse: 10 }, // Delicate Dresses
-        108: { soil: 3, spinSpeed: 5, waterTemp: 4, opCourse: 6 }, // Half Load Wash
-        109: { soil: 5, spinSpeed: 5, waterTemp: 4, opCourse: 6 }, // Full Load Wash
-    }
-
-const DOWNLOAD_COURSE_AP_ID = 10
 
 const DEFAULT_COURSE_ID = 5 // Normal
 
@@ -221,7 +197,9 @@ const OP_COURSE: Record<number, string> = {
 // SmartCourse (byte 20): a course downloaded from the app's "smart course" picker, distinct
 // from AP_COURSE's physical-dial courses. modelJson's SmartCourse table has exactly these 16
 // entries (not ~90 — corrected after actually counting); ids outside this table (or 0,
-// meaning none downloaded) fall back to their raw number. Keys match SMART_COURSE_DEFAULTS.
+// meaning none downloaded) fall back to their raw number. Read-only: this is a label for
+// whatever the machine reports as resident, not something course_selection can set (see the
+// header comment) — there's no defaults table to pair it with any more.
 const SMART_COURSE: Record<number, string> = {
     51: 'Small Load',
     52: 'Color Care',
@@ -264,29 +242,20 @@ function encodeCourse(
     return Buffer.from(bytes).toString('base64')
 }
 
-// courseId is either an AP_COURSE dial position (1-9) or a SMART_COURSE id (51+) - the two
-// id ranges never overlap, so a single numeric selection can be resolved against either
-// table. A SmartCourse start is encoded with APCourse fixed at DOWNLOAD_COURSE_AP_ID (10,
-// "a course is loaded") and the real SmartCourse id in the SmartCourse slot instead of 0 -
-// same command, same confirmed encoding, just different template values. Not yet confirmed
-// against a real captured SmartCourse start (unlike the AP_COURSE path).
+// courseId is an AP_COURSE dial position (1-9). SmartCourse ids are deliberately not
+// resolvable here — see the header comment for why offering them as startable was wrong.
 function encodeCourseStart(courseId: number): string | undefined {
     const ap = COURSE_DEFAULTS[courseId]
     if (ap) return encodeCourse(courseId, 0, ap)
 
-    const smart = SMART_COURSE_DEFAULTS[courseId]
-    if (smart) return encodeCourse(DOWNLOAD_COURSE_AP_ID, courseId, smart)
-
     return undefined
 }
 
-// Every id that's actually startable (AP_COURSE dial positions + SMART_COURSE ids), for the
-// course_selection select's option list and its name -> id reverse lookup. The two id ranges
-// don't overlap, so this can be a single flat map.
-const SELECTABLE_COURSE_NAMES: Record<number, string> = {
-    ...Object.fromEntries(Object.keys(COURSE_DEFAULTS).map((id) => [id, AP_COURSE[Number(id)]])),
-    ...Object.fromEntries(Object.keys(SMART_COURSE_DEFAULTS).map((id) => [id, SMART_COURSE[Number(id)]])),
-}
+// Every id that's actually startable, for the course_selection select's option list and its
+// name -> id reverse lookup.
+const SELECTABLE_COURSE_NAMES: Record<number, string> = Object.fromEntries(
+    Object.keys(COURSE_DEFAULTS).map((id) => [id, AP_COURSE[Number(id)]]),
+)
 
 export default class Device extends HADevice {
     constructor(
@@ -686,18 +655,15 @@ export default class Device extends HADevice {
             this.publishProperty('initial_time', timeInitial)
             this.publishProperty('remaining_time', timeRemain)
 
-            // Keep the pending course-to-start in sync with whatever's actually dialed in
-            // on the machine, as long as nobody's picked a different one via HA yet. A loaded
-            // SmartCourse reports APCourse=DOWNLOAD_COURSE_AP_ID with the real course in the
-            // SmartCourse byte, so prefer that when present.
-            if (!this.courseSelectedByUser) {
-                if (apCourse === DOWNLOAD_COURSE_AP_ID && SMART_COURSE_DEFAULTS[smartCourse]) {
-                    this.pendingCourseId = smartCourse
-                    this.publishProperty('course_selection', SMART_COURSE[smartCourse])
-                } else if (COURSE_DEFAULTS[apCourse]) {
-                    this.pendingCourseId = apCourse
-                    this.publishProperty('course_selection', AP_COURSE[apCourse])
-                }
+            // Keep the pending course-to-start in sync with whatever's actually dialed in on
+            // the machine, as long as nobody's picked a different one via HA yet. A resident
+            // SmartCourse reports APCourse=10, which isn't in COURSE_DEFAULTS - deliberately
+            // left unhandled here, since SmartCourse names aren't selectable options any more
+            // (see the header comment); course_selection just keeps showing its last valid
+            // value in that case rather than publishing something HA would reject.
+            if (!this.courseSelectedByUser && COURSE_DEFAULTS[apCourse]) {
+                this.pendingCourseId = apCourse
+                this.publishProperty('course_selection', AP_COURSE[apCourse])
             }
         })
 

--- a/cloud/devices/F3L2CNV4W_WIFI.ts
+++ b/cloud/devices/F3L2CNV4W_WIFI.ts
@@ -480,11 +480,18 @@ export default class Device extends HADevice {
                         platform: 'sensor',
                         unique_id: '$deviceid-last-cycle-energy',
                         state_topic: '$this/last_cycle_energy',
-                        // No unit_of_measurement/device_class yet: the value (energyMonInfo's
-                        // "power" field) is very plausibly Wh, but that's not confirmed against
-                        // the app's own displayed number yet. Labeling it "energy"/Wh prematurely
-                        // would let HA's Energy Dashboard ingest a value we haven't verified.
-                        name: 'Last cycle energy usage (raw, unconfirmed unit)',
+                        // Wh: TA2k/ioBroker.lg-thinq's docs document the same field name
+                        // ("power") on LG's ThinQ2 statistics API with an explicit "divide by
+                        // 1000 for kWh" comment - a different endpoint than our ThinQ1 diagmon
+                        // energyMonInfo, but the same LG-ecosystem naming convention, and 154 Wh
+                        // is a physically plausible total for a ~77 min Normal cycle. state_class
+                        // is deliberately "measurement", not "total_increasing": this is a
+                        // per-cycle snapshot that resets/changes each time, not a running counter,
+                        // so it won't be offered as an Energy Dashboard source by mistake.
+                        device_class: 'energy',
+                        state_class: 'measurement',
+                        unit_of_measurement: 'Wh',
+                        name: 'Last cycle energy usage',
                         icon: 'mdi:lightning-bolt-outline',
                     },
                     last_cycle_course: {

--- a/cloud/devices/F3L2CNV4W_WIFI.ts
+++ b/cloud/devices/F3L2CNV4W_WIFI.ts
@@ -333,7 +333,13 @@ export default class Device extends HADevice {
                         platform: 'button',
                         unique_id: '$deviceid-remote-start-button',
                         command_topic: '$this/remote_start_button/set',
-                        availability: [{ topic: '$this/controls_available' }],
+                        // Separate from course_selection's controls_available: OperationStart is
+                        // also how you resume a paused cycle (modelJson has no distinct Resume
+                        // action - Off/Initial/Paused all send the same Start command), so this
+                        // button needs to stay available through Paused too. course_selection
+                        // does not: we have no evidence for what the machine does if you swap
+                        // courses while paused and hit Start, so it stays locked to Off/Initial.
+                        availability: [{ topic: '$this/remote_start_available' }],
                         payload_press: '',
                         name: 'Remote Start',
                         icon: 'mdi:play-circle-outline',
@@ -609,6 +615,7 @@ export default class Device extends HADevice {
         // stale prior-process value; the data handler corrects it the moment a real frame
         // arrives.
         this.publishProperty('controls_available', 'offline')
+        this.publishProperty('remote_start_available', 'offline')
 
         thinq.on('data', (buf) => {
             if (buf.length < 24) return
@@ -641,10 +648,18 @@ export default class Device extends HADevice {
             this.publishProperty('error_message', ERRORS[error] ?? String(error))
             this.publishProperty('error', error ? 'ON' : 'OFF')
             this.publishProperty('status', STATES[state] ?? String(state))
-            // Course selection / Remote Start only make sense when the machine is actually
-            // idle — mid-cycle they'd let you fire a second OperationStart the machine has
-            // no defined behavior for. Off/Initial are the only states nothing is running.
+            // Course selection only makes sense when the machine is actually idle — mid-cycle
+            // it'd let you fire an OperationStart with different course params than what's
+            // running, which we have no evidence is safe. Off/Initial are the only states
+            // nothing is running.
             this.publishProperty('controls_available', state === 0 || state === 5 ? 'online' : 'offline')
+            // Remote Start also needs to stay available while Paused: modelJson has no distinct
+            // Resume action, OperationStart is how you resume a paused cycle too (same as
+            // pressing Start on the physical panel while paused).
+            this.publishProperty(
+                'remote_start_available',
+                state === 0 || state === 5 || state === 6 ? 'online' : 'offline',
+            )
             this.publishProperty('pre_state', STATES[preState] ?? String(preState))
             this.publishProperty('course', AP_COURSE[apCourse] ?? String(apCourse))
             this.publishProperty('op_course', OP_COURSE[opCourse] ?? String(opCourse))

--- a/cloud/devices/F3L2CNV4W_WIFI.ts
+++ b/cloud/devices/F3L2CNV4W_WIFI.ts
@@ -503,6 +503,22 @@ export default class Device extends HADevice {
                         icon: 'mdi:clock-check-outline',
                         entity_category: 'diagnostic',
                     },
+                    initial_bit: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-initial-bit',
+                        state_topic: '$this/initial_bit',
+                        name: 'Initial bit',
+                        icon: 'mdi:flag-outline',
+                        entity_category: 'diagnostic',
+                    },
+                    option3_raw: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-option3-raw',
+                        state_topic: '$this/option3_raw',
+                        name: 'Option3 (raw)',
+                        icon: 'mdi:code-braces',
+                        entity_category: 'diagnostic',
+                    },
                 },
             }),
         )
@@ -529,6 +545,7 @@ export default class Device extends HADevice {
             const reserveM = buf[13]
             const option1 = buf[14]
             const option2 = buf[15]
+            const option3 = buf[16]
             const preState = buf[19]
             const smartCourse = buf[20]
             const tclCount = buf[21]
@@ -564,6 +581,8 @@ export default class Device extends HADevice {
             this.publishProperty('fresh_care', option2 & 0x01 ? 'ON' : 'OFF')
             this.publishProperty('coldwash', option2 & 0x10 ? 'ON' : 'OFF')
             this.publishProperty('remote_start', option2 & 0x80 ? 'ON' : 'OFF')
+            this.publishProperty('initial_bit', option3 & 0x20 ? 'ON' : 'OFF')
+            this.publishProperty('option3_raw', option3)
             this.publishProperty('tub_clean_count', tclCount)
             this.publishProperty('load_level', loadLevel)
             this.publishProperty('reserve_time', reserveH * 60 + reserveM)

--- a/cloud/devices/F3L2CNV4W_WIFI.ts
+++ b/cloud/devices/F3L2CNV4W_WIFI.ts
@@ -148,21 +148,76 @@ const COURSE_DEFAULTS: Record<number, { soil: number; spinSpeed: number; waterTe
 
 const DEFAULT_COURSE_ID = 5 // Normal
 
+// OPCourse (byte 22): the machine's internal course code, which AP_COURSE's dial position
+// maps onto (Normal -> OPCourse 6, etc. — see COURSE_DEFAULTS). Published separately as a
+// diagnostic since it's a richer catalog than AP_COURSE (includes codes no physical dial
+// position selects directly, e.g. Small Load, Rugged, Sportswear).
+const OP_COURSE: Record<number, string> = {
+    0: '-',
+    1: 'Refresh',
+    2: 'Sanitary',
+    3: 'Allergiene',
+    4: 'Bedding',
+    5: 'Perm Press',
+    6: 'Normal',
+    7: 'Heavy Duty',
+    8: 'Bright Whites',
+    9: 'Cold Care',
+    10: 'Delicates',
+    11: 'Hand Wash',
+    12: 'Speed Wash',
+    13: 'Tub Clean',
+    14: 'Towels',
+    15: 'Small Load',
+    16: 'Rinse+Spin',
+    17: 'Rugged',
+    18: 'KidsWears',
+    19: 'WorkOut Wear',
+    20: 'Drain+Spin',
+    21: 'Sportswear',
+    22: 'Jumbo Wash',
+}
+
+// SmartCourse (byte 20): a course downloaded from the app's "smart course" picker, distinct
+// from AP_COURSE's physical-dial courses. modelJson's SmartCourse table has ~90 entries;
+// only the ones actually reachable are worth naming here — ids outside this table (or 0,
+// meaning none downloaded) fall back to their raw number.
+const SMART_COURSE: Record<number, string> = {
+    51: 'Small Load',
+    52: 'Color Care',
+    53: 'Beachwear',
+    54: 'New Clothes',
+    55: 'Denim',
+    59: 'Swimwear',
+    60: 'Rainy Day',
+    61: 'Gym Clothes',
+    63: 'Sweat Stains',
+    64: 'Single Garments',
+    100: 'Baby Clothes',
+    105: 'Overnight Wash',
+    106: 'Econo Wash',
+    107: 'Delicate Dresses',
+    108: 'Half Load Wash',
+    109: 'Full Load Wash',
+}
+
 // modelJson ControlWifi.action.OperationStart.data, positionally:
 //   [APCourse, Soil, SpinSpeed, WaterTemp, RinseOption, Reserve_Time_H, Reserve_Time_M,
 //    Option1, Option2, Option3, OPCourse, SmartCourse, 0,0,0,0,0,0,0,0,0]
-// Encoding (each element = one raw byte, base64 of the resulting buffer) matches
-// ha-smartthinq-sensors' confirmed ThinQ1 v1 command builder — an independent, real-world
-// implementation already driving this exact model — cross-checked against the modelJson
-// template itself. Only the course-varying fields (Soil/SpinSpeed/WaterTemp/OPCourse) are
-// populated from COURSE_DEFAULTS; every other slot modelJson shows as 0 across all courses.
+// CONFIRMED against a real captured command (Normal course, 2026-08-22): courseId, Soil,
+// SpinSpeed, WaterTemp, RinseOption, Reserve_Time_H/M, Option1, Option2, OPCourse,
+// SmartCourse and all 9 trailing bytes matched this encoding exactly. The one gap this
+// capture caught: Option3 needs bit 5 (0x20) set — modelJson's "InitialBit" — which a
+// bare 0 does not produce; without it the machine never actually started.
 function encodeCourseStart(courseId: number): string | undefined {
     const d = COURSE_DEFAULTS[courseId]
     if (!d) return undefined
 
+    const INITIAL_BIT = 0x20 // Option3 bit 5
+
     // prettier-ignore
     const bytes = [
-        courseId, d.soil, d.spinSpeed, d.waterTemp, 0, 0, 0, 0, 0, 0, d.opCourse, 0,
+        courseId, d.soil, d.spinSpeed, d.waterTemp, 0, 0, 0, 0, 0, INITIAL_BIT, d.opCourse, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]
     return Buffer.from(bytes).toString('base64')
@@ -257,6 +312,22 @@ export default class Device extends HADevice {
                         name: 'Course',
                         icon: 'mdi:pin-outline',
                     },
+                    op_course: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-op-course',
+                        state_topic: '$this/op_course',
+                        name: 'Internal course code',
+                        icon: 'mdi:cog-outline',
+                        entity_category: 'diagnostic',
+                    },
+                    smart_course: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-smart-course',
+                        state_topic: '$this/smart_course',
+                        name: 'Downloaded course',
+                        icon: 'mdi:cloud-download-outline',
+                        entity_category: 'diagnostic',
+                    },
                     soil: {
                         platform: 'sensor',
                         unique_id: '$deviceid-soil',
@@ -330,6 +401,13 @@ export default class Device extends HADevice {
                         name: 'TurboWash',
                         icon: 'mdi:speedometer',
                     },
+                    extra_rinse: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-extra-rinse',
+                        state_topic: '$this/extra_rinse',
+                        name: 'Extra rinse',
+                        icon: 'mdi:water-plus-outline',
+                    },
                     coldwash: {
                         platform: 'binary_sensor',
                         unique_id: '$deviceid-coldwash',
@@ -357,6 +435,14 @@ export default class Device extends HADevice {
                         state_topic: '$this/tub_clean_count',
                         name: 'Cycles since tub clean',
                         icon: 'mdi:counter',
+                        entity_category: 'diagnostic',
+                    },
+                    load_level: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-load-level',
+                        state_topic: '$this/load_level',
+                        name: 'Load level (raw)',
+                        icon: 'mdi:scale-bathroom',
                         entity_category: 'diagnostic',
                     },
                     reserve_time: {
@@ -410,7 +496,10 @@ export default class Device extends HADevice {
             const option1 = buf[14]
             const option2 = buf[15]
             const preState = buf[19]
+            const smartCourse = buf[20]
             const tclCount = buf[21]
+            const opCourse = buf[22]
+            const loadLevel = buf[23]
 
             const rinseCount = rinseOption & 0x0f
             const extraRinseCount = (rinseOption >> 4) & 0x0f
@@ -421,6 +510,8 @@ export default class Device extends HADevice {
             this.publishProperty('status', STATES[state] ?? 'unknown')
             this.publishProperty('pre_state', STATES[preState] ?? 'unknown')
             this.publishProperty('course', AP_COURSE[apCourse] ?? String(apCourse))
+            this.publishProperty('op_course', OP_COURSE[opCourse] ?? String(opCourse))
+            this.publishProperty('smart_course', SMART_COURSE[smartCourse] ?? String(smartCourse))
             this.publishProperty('soil', SOIL[soil] ?? 'unknown')
             this.publishProperty('spin', SPIN[spin] ?? 'unknown')
             this.publishProperty('temp', TEMP[temp] ?? 'unknown')
@@ -431,10 +522,12 @@ export default class Device extends HADevice {
             this.publishProperty('steam', option1 & 0x04 ? 'ON' : 'OFF')
             this.publishProperty('prewash', option1 & 0x08 ? 'ON' : 'OFF')
             this.publishProperty('turbowash', option1 & 0x80 ? 'ON' : 'OFF')
+            this.publishProperty('extra_rinse', option1 & 0x40 ? 'ON' : 'OFF')
             this.publishProperty('fresh_care', option2 & 0x01 ? 'ON' : 'OFF')
             this.publishProperty('coldwash', option2 & 0x10 ? 'ON' : 'OFF')
             this.publishProperty('remote_start', option2 & 0x80 ? 'ON' : 'OFF')
             this.publishProperty('tub_clean_count', tclCount)
+            this.publishProperty('load_level', loadLevel)
             this.publishProperty('reserve_time', reserveH * 60 + reserveM)
             this.publishProperty('initial_time', timeInitial)
             this.publishProperty('remaining_time', timeRemain)

--- a/cloud/devices/F3L2CNV4W_WIFI.ts
+++ b/cloud/devices/F3L2CNV4W_WIFI.ts
@@ -320,7 +320,11 @@ export default class Device extends HADevice {
                         unique_id: '$deviceid-course-selection',
                         state_topic: '$this/course_selection',
                         command_topic: '$this/course_selection/set',
-                        availability_topic: '$this/controls_available',
+                        // Singular availability_topic collides with the device-level `availability`
+                        // list (see HADevice.config) in HA's schema - both forms set the same
+                        // exclusion group, and HA rejects the whole component if both are present.
+                        // The list form doesn't conflict, so use it here too.
+                        availability: [{ topic: '$this/controls_available' }],
                         name: 'Course selection',
                         icon: 'mdi:tune-vertical-variant',
                         options: Object.values(SELECTABLE_COURSE_NAMES),
@@ -329,7 +333,7 @@ export default class Device extends HADevice {
                         platform: 'button',
                         unique_id: '$deviceid-remote-start-button',
                         command_topic: '$this/remote_start_button/set',
-                        availability_topic: '$this/controls_available',
+                        availability: [{ topic: '$this/controls_available' }],
                         payload_press: '',
                         name: 'Remote Start',
                         icon: 'mdi:play-circle-outline',
@@ -634,21 +638,21 @@ export default class Device extends HADevice {
             const extraRinseCount = (rinseOption >> 4) & 0x0f
 
             this.publishProperty('power', state > 0 ? 'ON' : 'OFF')
-            this.publishProperty('error_message', ERRORS[error] ?? 'unknown')
+            this.publishProperty('error_message', ERRORS[error] ?? String(error))
             this.publishProperty('error', error ? 'ON' : 'OFF')
-            this.publishProperty('status', STATES[state] ?? 'unknown')
+            this.publishProperty('status', STATES[state] ?? String(state))
             // Course selection / Remote Start only make sense when the machine is actually
             // idle — mid-cycle they'd let you fire a second OperationStart the machine has
             // no defined behavior for. Off/Initial are the only states nothing is running.
             this.publishProperty('controls_available', state === 0 || state === 5 ? 'online' : 'offline')
-            this.publishProperty('pre_state', STATES[preState] ?? 'unknown')
+            this.publishProperty('pre_state', STATES[preState] ?? String(preState))
             this.publishProperty('course', AP_COURSE[apCourse] ?? String(apCourse))
             this.publishProperty('op_course', OP_COURSE[opCourse] ?? String(opCourse))
             this.publishProperty('smart_course', SMART_COURSE[smartCourse] ?? String(smartCourse))
-            this.publishProperty('soil', SOIL[soil] ?? 'unknown')
-            this.publishProperty('spin', SPIN[spin] ?? 'unknown')
-            this.publishProperty('temp', TEMP[temp] ?? 'unknown')
-            this.publishProperty('dry_level', DRY_LEVEL[dryLevel] ?? 'unknown')
+            this.publishProperty('soil', SOIL[soil] ?? String(soil))
+            this.publishProperty('spin', SPIN[spin] ?? String(spin))
+            this.publishProperty('temp', TEMP[temp] ?? String(temp))
+            this.publishProperty('dry_level', DRY_LEVEL[dryLevel] ?? String(dryLevel))
             this.publishProperty('rinse_count', RINSE_COUNT[rinseCount] ?? String(rinseCount))
             this.publishProperty('extra_rinse_count', RINSE_COUNT[extraRinseCount] ?? String(extraRinseCount))
             this.publishProperty('child_lock', option1 & 0x01 ? 'ON' : 'OFF')

--- a/cloud/devices/F3L2CNV4W_WIFI.ts
+++ b/cloud/devices/F3L2CNV4W_WIFI.ts
@@ -255,6 +255,7 @@ export default class Device extends HADevice {
                         unique_id: '$deviceid-course-selection',
                         state_topic: '$this/course_selection',
                         command_topic: '$this/course_selection/set',
+                        availability_topic: '$this/controls_available',
                         name: 'Course selection',
                         icon: 'mdi:tune-vertical-variant',
                         options: Object.keys(COURSE_DEFAULTS).map((id) => AP_COURSE[Number(id)]),
@@ -263,6 +264,7 @@ export default class Device extends HADevice {
                         platform: 'button',
                         unique_id: '$deviceid-remote-start-button',
                         command_topic: '$this/remote_start_button/set',
+                        availability_topic: '$this/controls_available',
                         payload_press: '',
                         name: 'Remote Start',
                         icon: 'mdi:play-circle-outline',
@@ -508,6 +510,10 @@ export default class Device extends HADevice {
             this.publishProperty('error_message', ERRORS[error] ?? 'unknown')
             this.publishProperty('error', error ? 'ON' : 'OFF')
             this.publishProperty('status', STATES[state] ?? 'unknown')
+            // Course selection / Remote Start only make sense when the machine is actually
+            // idle — mid-cycle they'd let you fire a second OperationStart the machine has
+            // no defined behavior for. Off/Initial are the only states nothing is running.
+            this.publishProperty('controls_available', state === 0 || state === 5 ? 'online' : 'offline')
             this.publishProperty('pre_state', STATES[preState] ?? 'unknown')
             this.publishProperty('course', AP_COURSE[apCourse] ?? String(apCourse))
             this.publishProperty('op_course', OP_COURSE[opCourse] ?? String(opCourse))

--- a/cloud/devices/F3L2CNV4W_WIFI.ts
+++ b/cloud/devices/F3L2CNV4W_WIFI.ts
@@ -26,6 +26,12 @@ import { Metadata } from '../thinq'
 // Per-cycle energy usage (last_cycle_energy/course/completed) comes from a second channel
 // entirely: HTTP diagmon reports (cloud/thinq1/http.ts), not the persistent :47878 status
 // socket this class otherwise reads from. See the thinq.on('diagmon', ...) handler below.
+//
+// course_selection also offers the 16 app-downloadable SMART_COURSE_DEFAULTS entries
+// alongside the 9 physical-dial ones — same OperationStart command, same confirmed encoding,
+// just APCourse fixed at DOWNLOAD_COURSE_AP_ID with the real SmartCourse id populated instead
+// of 0. Every SmartCourse entry has controlEnable/downloadEnable:true in the modelJson, but
+// this path itself isn't yet confirmed against a real captured SmartCourse start.
 
 const STATES: Record<number, string> = {
     0: 'Off',
@@ -135,10 +141,11 @@ const AP_COURSE: Record<number, string> = {
 }
 
 // Remote-start defaults per course, straight from modelJson's APCourse[id].function[]
-// (Soil/WaterTemp/SpinSpeed) and APCourse[id].OPCourse. ids 10 (Download Course) and 11
-// (Spin Only, hidden — "visibility":"gone" in the modelJson) are deliberately excluded:
-// 10 needs a downloaded SmartCourse payload we don't have tabled, and 11 isn't offered
-// by the physical dial or the official app either.
+// (Soil/WaterTemp/SpinSpeed) and APCourse[id].OPCourse. id 11 (Spin Only, hidden —
+// "visibility":"gone" in the modelJson) is deliberately excluded: not offered by the
+// physical dial or the official app either. id 10 (Download Course) is handled separately
+// below, via SMART_COURSE_DEFAULTS — it's not a fixed course, it's the "a SmartCourse is
+// loaded" slot.
 const COURSE_DEFAULTS: Record<number, { soil: number; spinSpeed: number; waterTemp: number; opCourse: number }> = {
     1: { soil: 0, spinSpeed: 3, waterTemp: 0, opCourse: 13 }, // Tub Clean
     2: { soil: 3, spinSpeed: 5, waterTemp: 6, opCourse: 8 }, // Bright Whites
@@ -150,6 +157,34 @@ const COURSE_DEFAULTS: Record<number, { soil: number; spinSpeed: number; waterTe
     8: { soil: 3, spinSpeed: 5, waterTemp: 4, opCourse: 14 }, // Towels
     9: { soil: 1, spinSpeed: 5, waterTemp: 6, opCourse: 12 }, // Speed Wash
 }
+
+// App-downloadable "smart" courses, straight from modelJson's SmartCourse[id].function[] and
+// .OPCourse — same shape as COURSE_DEFAULTS above. Every entry has controlEnable:true and
+// downloadEnable:true in the spec. Starting one is the same OperationStart command as an
+// AP_COURSE start, just with APCourse fixed at 10 ("Download Course") and SmartCourse set to
+// the real id instead of 0 — no new/guessed command needed, only different template values.
+// Not yet confirmed against a real captured command (unlike the AP_COURSE path).
+const SMART_COURSE_DEFAULTS: Record<number, { soil: number; spinSpeed: number; waterTemp: number; opCourse: number }> =
+    {
+        51: { soil: 3, spinSpeed: 5, waterTemp: 4, opCourse: 15 }, // Small Load
+        52: { soil: 3, spinSpeed: 3, waterTemp: 2, opCourse: 6 }, // Color Care
+        53: { soil: 1, spinSpeed: 3, waterTemp: 2, opCourse: 10 }, // Beachwear
+        54: { soil: 1, spinSpeed: 2, waterTemp: 2, opCourse: 6 }, // New Clothes
+        55: { soil: 3, spinSpeed: 3, waterTemp: 2, opCourse: 6 }, // Denim
+        59: { soil: 1, spinSpeed: 2, waterTemp: 2, opCourse: 10 }, // Swimwear
+        60: { soil: 3, spinSpeed: 5, waterTemp: 4, opCourse: 6 }, // Rainy Day
+        61: { soil: 1, spinSpeed: 3, waterTemp: 4, opCourse: 21 }, // Gym Clothes
+        63: { soil: 1, spinSpeed: 5, waterTemp: 4, opCourse: 6 }, // Sweat Stains
+        64: { soil: 1, spinSpeed: 5, waterTemp: 6, opCourse: 12 }, // Single Garments
+        100: { soil: 3, spinSpeed: 5, waterTemp: 6, opCourse: 6 }, // Baby Clothes
+        105: { soil: 3, spinSpeed: 2, waterTemp: 4, opCourse: 6 }, // Overnight Wash
+        106: { soil: 3, spinSpeed: 5, waterTemp: 2, opCourse: 6 }, // Econo Wash
+        107: { soil: 1, spinSpeed: 2, waterTemp: 2, opCourse: 10 }, // Delicate Dresses
+        108: { soil: 3, spinSpeed: 5, waterTemp: 4, opCourse: 6 }, // Half Load Wash
+        109: { soil: 5, spinSpeed: 5, waterTemp: 4, opCourse: 6 }, // Full Load Wash
+    }
+
+const DOWNLOAD_COURSE_AP_ID = 10
 
 const DEFAULT_COURSE_ID = 5 // Normal
 
@@ -184,9 +219,9 @@ const OP_COURSE: Record<number, string> = {
 }
 
 // SmartCourse (byte 20): a course downloaded from the app's "smart course" picker, distinct
-// from AP_COURSE's physical-dial courses. modelJson's SmartCourse table has ~90 entries;
-// only the ones actually reachable are worth naming here — ids outside this table (or 0,
-// meaning none downloaded) fall back to their raw number.
+// from AP_COURSE's physical-dial courses. modelJson's SmartCourse table has exactly these 16
+// entries (not ~90 — corrected after actually counting); ids outside this table (or 0,
+// meaning none downloaded) fall back to their raw number. Keys match SMART_COURSE_DEFAULTS.
 const SMART_COURSE: Record<number, string> = {
     51: 'Small Load',
     52: 'Color Care',
@@ -214,18 +249,43 @@ const SMART_COURSE: Record<number, string> = {
 // SmartCourse and all 9 trailing bytes matched this encoding exactly. The one gap this
 // capture caught: Option3 needs bit 5 (0x20) set — modelJson's "InitialBit" — which a
 // bare 0 does not produce; without it the machine never actually started.
-function encodeCourseStart(courseId: number): string | undefined {
-    const d = COURSE_DEFAULTS[courseId]
-    if (!d) return undefined
+const INITIAL_BIT = 0x20 // Option3 bit 5
 
-    const INITIAL_BIT = 0x20 // Option3 bit 5
-
+function encodeCourse(
+    apCourse: number,
+    smartCourse: number,
+    d: { soil: number; spinSpeed: number; waterTemp: number; opCourse: number },
+): string {
     // prettier-ignore
     const bytes = [
-        courseId, d.soil, d.spinSpeed, d.waterTemp, 0, 0, 0, 0, 0, INITIAL_BIT, d.opCourse, 0,
+        apCourse, d.soil, d.spinSpeed, d.waterTemp, 0, 0, 0, 0, 0, INITIAL_BIT, d.opCourse, smartCourse,
         0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]
     return Buffer.from(bytes).toString('base64')
+}
+
+// courseId is either an AP_COURSE dial position (1-9) or a SMART_COURSE id (51+) - the two
+// id ranges never overlap, so a single numeric selection can be resolved against either
+// table. A SmartCourse start is encoded with APCourse fixed at DOWNLOAD_COURSE_AP_ID (10,
+// "a course is loaded") and the real SmartCourse id in the SmartCourse slot instead of 0 -
+// same command, same confirmed encoding, just different template values. Not yet confirmed
+// against a real captured SmartCourse start (unlike the AP_COURSE path).
+function encodeCourseStart(courseId: number): string | undefined {
+    const ap = COURSE_DEFAULTS[courseId]
+    if (ap) return encodeCourse(courseId, 0, ap)
+
+    const smart = SMART_COURSE_DEFAULTS[courseId]
+    if (smart) return encodeCourse(DOWNLOAD_COURSE_AP_ID, courseId, smart)
+
+    return undefined
+}
+
+// Every id that's actually startable (AP_COURSE dial positions + SMART_COURSE ids), for the
+// course_selection select's option list and its name -> id reverse lookup. The two id ranges
+// don't overlap, so this can be a single flat map.
+const SELECTABLE_COURSE_NAMES: Record<number, string> = {
+    ...Object.fromEntries(Object.keys(COURSE_DEFAULTS).map((id) => [id, AP_COURSE[Number(id)]])),
+    ...Object.fromEntries(Object.keys(SMART_COURSE_DEFAULTS).map((id) => [id, SMART_COURSE[Number(id)]])),
 }
 
 export default class Device extends HADevice {
@@ -263,7 +323,7 @@ export default class Device extends HADevice {
                         availability_topic: '$this/controls_available',
                         name: 'Course selection',
                         icon: 'mdi:tune-vertical-variant',
-                        options: Object.keys(COURSE_DEFAULTS).map((id) => AP_COURSE[Number(id)]),
+                        options: Object.values(SELECTABLE_COURSE_NAMES),
                     },
                     remote_start_button: {
                         platform: 'button',
@@ -533,7 +593,7 @@ export default class Device extends HADevice {
         // The washer reports APCourse=0 while idle/no course actively dialed — that's not
         // in COURSE_DEFAULTS, so the sync-on-data logic below never fires for it. Publish
         // our own default up front so the select entity doesn't sit at "unknown" forever.
-        this.publishProperty('course_selection', AP_COURSE[this.pendingCourseId])
+        this.publishProperty('course_selection', SELECTABLE_COURSE_NAMES[this.pendingCourseId])
 
         thinq.on('data', (buf) => {
             if (buf.length < 24) return
@@ -597,10 +657,17 @@ export default class Device extends HADevice {
             this.publishProperty('remaining_time', timeRemain)
 
             // Keep the pending course-to-start in sync with whatever's actually dialed in
-            // on the machine, as long as nobody's picked a different one via HA yet.
-            if (!this.courseSelectedByUser && COURSE_DEFAULTS[apCourse]) {
-                this.pendingCourseId = apCourse
-                this.publishProperty('course_selection', AP_COURSE[apCourse])
+            // on the machine, as long as nobody's picked a different one via HA yet. A loaded
+            // SmartCourse reports APCourse=DOWNLOAD_COURSE_AP_ID with the real course in the
+            // SmartCourse byte, so prefer that when present.
+            if (!this.courseSelectedByUser) {
+                if (apCourse === DOWNLOAD_COURSE_AP_ID && SMART_COURSE_DEFAULTS[smartCourse]) {
+                    this.pendingCourseId = smartCourse
+                    this.publishProperty('course_selection', SMART_COURSE[smartCourse])
+                } else if (COURSE_DEFAULTS[apCourse]) {
+                    this.pendingCourseId = apCourse
+                    this.publishProperty('course_selection', AP_COURSE[apCourse])
+                }
             }
         })
 
@@ -651,8 +718,10 @@ export default class Device extends HADevice {
             this.thinq.send({ Cmd: 'Control', CmdOpt: 'Operation', Value: 'Stop', Format: 'B64', Data: '' })
         }
         if (prop === 'course_selection') {
-            const id = Number(Object.keys(COURSE_DEFAULTS).find((key) => AP_COURSE[Number(key)] === mqttValue))
-            if (COURSE_DEFAULTS[id]) {
+            const id = Number(
+                Object.keys(SELECTABLE_COURSE_NAMES).find((key) => SELECTABLE_COURSE_NAMES[Number(key)] === mqttValue),
+            )
+            if (SELECTABLE_COURSE_NAMES[id]) {
                 this.pendingCourseId = id
                 this.courseSelectedByUser = true
                 this.publishProperty('course_selection', mqttValue)

--- a/cloud/devices/F3L2CNV4W_WIFI.ts
+++ b/cloud/devices/F3L2CNV4W_WIFI.ts
@@ -12,13 +12,15 @@ import { Metadata } from '../thinq'
 // class. The 24-byte Monitoring.protocol block maps 1:1 to the buffer `thinq.on('data')`
 // delivers here (each field is exactly one byte, at the startByte given below).
 //
-// PowerOff and the pause/stop command are implemented — their wire shape
-// ({Cmd:'Control', CmdOpt:..., Value:...}) matches WTDN3.ts's already-verified pattern
-// exactly, cross-confirmed by the modelJson's ControlWifi.action entries. Remote power-ON
-// and starting a cycle (OperationStart) are deliberately NOT implemented yet: the
-// modelJson defines no PowerOn action at all (this model's physical dial is presumably
-// the only way to arm remote start), and OperationStart's course-parameter array encoding
-// isn't confirmed against a real captured command yet — see tools/rethink-capture.ts.
+// PowerOff, pause/stop, and starting a cycle (OperationStart) are all implemented — their
+// wire shape ({Cmd:'Control', CmdOpt:..., Value:...}) matches WTDN3.ts's already-verified
+// pattern, cross-confirmed by the modelJson's ControlWifi.action entries.
+// OperationStart's course-parameter array encoding (courseId/Soil/SpinSpeed/WaterTemp/../
+// OPCourse as one byte each, base64) is cross-confirmed against ha-smartthinq-sensors'
+// independent ThinQ1 v1 command builder, which already drives this exact model — but not
+// yet against a real captured command from this device (see tools/rethink-capture.ts).
+// Remote power-ON is NOT implemented: the modelJson defines no PowerOn action at all for
+// this model (the physical dial is presumably the only way to arm remote start).
 
 const STATES: Record<number, string> = {
     0: 'Off',
@@ -127,6 +129,45 @@ const AP_COURSE: Record<number, string> = {
     11: 'Spin Only',
 }
 
+// Remote-start defaults per course, straight from modelJson's APCourse[id].function[]
+// (Soil/WaterTemp/SpinSpeed) and APCourse[id].OPCourse. ids 10 (Download Course) and 11
+// (Spin Only, hidden — "visibility":"gone" in the modelJson) are deliberately excluded:
+// 10 needs a downloaded SmartCourse payload we don't have tabled, and 11 isn't offered
+// by the physical dial or the official app either.
+const COURSE_DEFAULTS: Record<number, { soil: number; spinSpeed: number; waterTemp: number; opCourse: number }> = {
+    1: { soil: 0, spinSpeed: 3, waterTemp: 0, opCourse: 13 }, // Tub Clean
+    2: { soil: 3, spinSpeed: 5, waterTemp: 6, opCourse: 8 }, // Bright Whites
+    3: { soil: 3, spinSpeed: 3, waterTemp: 4, opCourse: 4 }, // Bedding
+    4: { soil: 5, spinSpeed: 5, waterTemp: 4, opCourse: 7 }, // Heavy Duty
+    5: { soil: 3, spinSpeed: 5, waterTemp: 4, opCourse: 6 }, // Normal
+    6: { soil: 3, spinSpeed: 3, waterTemp: 4, opCourse: 5 }, // Perm Press
+    7: { soil: 3, spinSpeed: 3, waterTemp: 2, opCourse: 10 }, // Delicates
+    8: { soil: 3, spinSpeed: 5, waterTemp: 4, opCourse: 14 }, // Towels
+    9: { soil: 1, spinSpeed: 5, waterTemp: 6, opCourse: 12 }, // Speed Wash
+}
+
+const DEFAULT_COURSE_ID = 5 // Normal
+
+// modelJson ControlWifi.action.OperationStart.data, positionally:
+//   [APCourse, Soil, SpinSpeed, WaterTemp, RinseOption, Reserve_Time_H, Reserve_Time_M,
+//    Option1, Option2, Option3, OPCourse, SmartCourse, 0,0,0,0,0,0,0,0,0]
+// Encoding (each element = one raw byte, base64 of the resulting buffer) matches
+// ha-smartthinq-sensors' confirmed ThinQ1 v1 command builder — an independent, real-world
+// implementation already driving this exact model — cross-checked against the modelJson
+// template itself. Only the course-varying fields (Soil/SpinSpeed/WaterTemp/OPCourse) are
+// populated from COURSE_DEFAULTS; every other slot modelJson shows as 0 across all courses.
+function encodeCourseStart(courseId: number): string | undefined {
+    const d = COURSE_DEFAULTS[courseId]
+    if (!d) return undefined
+
+    // prettier-ignore
+    const bytes = [
+        courseId, d.soil, d.spinSpeed, d.waterTemp, 0, 0, 0, 0, 0, 0, d.opCourse, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]
+    return Buffer.from(bytes).toString('base64')
+}
+
 export default class Device extends HADevice {
     constructor(
         HA: Connection,
@@ -153,6 +194,23 @@ export default class Device extends HADevice {
                         payload_press: '',
                         name: 'Pause',
                         icon: 'mdi:pause-circle-outline',
+                    },
+                    course_selection: {
+                        platform: 'select',
+                        unique_id: '$deviceid-course-selection',
+                        state_topic: '$this/course_selection',
+                        command_topic: '$this/course_selection/set',
+                        name: 'Course selection',
+                        icon: 'mdi:tune-vertical-variant',
+                        options: Object.keys(COURSE_DEFAULTS).map((id) => AP_COURSE[Number(id)]),
+                    },
+                    remote_start_button: {
+                        platform: 'button',
+                        unique_id: '$deviceid-remote-start-button',
+                        command_topic: '$this/remote_start_button/set',
+                        payload_press: '',
+                        name: 'Remote Start',
+                        icon: 'mdi:play-circle-outline',
                     },
                     status: {
                         platform: 'sensor',
@@ -375,12 +433,22 @@ export default class Device extends HADevice {
             this.publishProperty('reserve_time', reserveH * 60 + reserveM)
             this.publishProperty('initial_time', timeInitial)
             this.publishProperty('remaining_time', timeRemain)
+
+            // Keep the pending course-to-start in sync with whatever's actually dialed in
+            // on the machine, as long as nobody's picked a different one via HA yet.
+            if (!this.courseSelectedByUser && COURSE_DEFAULTS[apCourse]) {
+                this.pendingCourseId = apCourse
+                this.publishProperty('course_selection', AP_COURSE[apCourse])
+            }
         })
     }
 
     start() {
         this.thinq.send({ Cmd: 'Mon', CmdOpt: 'Start' })
     }
+
+    pendingCourseId = DEFAULT_COURSE_ID
+    courseSelectedByUser = false
 
     publishCache: Record<string, string | number> = {}
 
@@ -400,8 +468,18 @@ export default class Device extends HADevice {
         if (prop === 'pause') {
             this.thinq.send({ Cmd: 'Control', CmdOpt: 'Operation', Value: 'Stop', Format: 'B64', Data: '' })
         }
-        // Starting a cycle (OperationStart) needs a base64-encoded 21-byte course-parameter
-        // array per the modelJson's ControlWifi.action.OperationStart — not implemented
-        // until the exact byte encoding is confirmed against a real captured command.
+        if (prop === 'course_selection') {
+            const id = Number(Object.keys(COURSE_DEFAULTS).find((key) => AP_COURSE[Number(key)] === mqttValue))
+            if (COURSE_DEFAULTS[id]) {
+                this.pendingCourseId = id
+                this.courseSelectedByUser = true
+                this.publishProperty('course_selection', mqttValue)
+            }
+        }
+        if (prop === 'remote_start_button') {
+            const data = encodeCourseStart(this.pendingCourseId)
+            if (data)
+                this.thinq.send({ Cmd: 'Control', CmdOpt: 'Operation', Value: 'Start', Format: 'B64', Data: data })
+        }
     }
 }

--- a/cloud/devices/F3L2CNV4W_WIFI.ts
+++ b/cloud/devices/F3L2CNV4W_WIFI.ts
@@ -595,6 +595,17 @@ export default class Device extends HADevice {
         // our own default up front so the select entity doesn't sit at "unknown" forever.
         this.publishProperty('course_selection', SELECTABLE_COURSE_NAMES[this.pendingCourseId])
 
+        // Same class of bug as course_selection above, and it's the one that actually bit us:
+        // controls_available was ONLY ever published reactively, inside thinq.on('data', ...)
+        // below. If this process's lifetime hasn't seen a fresh frame yet (e.g. the washer
+        // hasn't reconnected since a restart), that topic had never been republished, so HA
+        // was just showing whatever was last retained from a PREVIOUS process — stuck
+        // "offline" indefinitely if that process's last frame happened to be mid-cycle.
+        // Publish a real default immediately so a fresh process is never silently stuck on a
+        // stale prior-process value; the data handler corrects it the moment a real frame
+        // arrives.
+        this.publishProperty('controls_available', 'offline')
+
         thinq.on('data', (buf) => {
             if (buf.length < 24) return
 

--- a/cloud/devices/F3L2CNV4W_WIFI.ts
+++ b/cloud/devices/F3L2CNV4W_WIFI.ts
@@ -1,0 +1,403 @@
+import HADevice from './base'
+import { Device as Thinq1Device } from '../thinq1/device'
+import { type Connection } from '../homeassistant'
+import { allowExtendedType } from '@/util/casting'
+import { Metadata } from '../thinq'
+
+// LG F3L2CNV4W_WIFI front-load washer (ThinQ1, deviceType 201).
+//
+// Field layout and enums below come directly from LG's own modelJson for this model
+// (fetched via the wideq library against a real account, not reverse-engineered from
+// captures) — see cloud/thinq1/http.ts for how a device's modelId is matched to this
+// class. The 24-byte Monitoring.protocol block maps 1:1 to the buffer `thinq.on('data')`
+// delivers here (each field is exactly one byte, at the startByte given below).
+//
+// PowerOff and the pause/stop command are implemented — their wire shape
+// ({Cmd:'Control', CmdOpt:..., Value:...}) matches WTDN3.ts's already-verified pattern
+// exactly, cross-confirmed by the modelJson's ControlWifi.action entries. Remote power-ON
+// and starting a cycle (OperationStart) are deliberately NOT implemented yet: the
+// modelJson defines no PowerOn action at all (this model's physical dial is presumably
+// the only way to arm remote start), and OperationStart's course-parameter array encoding
+// isn't confirmed against a real captured command yet — see tools/rethink-capture.ts.
+
+const STATES: Record<number, string> = {
+    0: 'Off',
+    5: 'Initial',
+    6: 'Paused',
+    7: 'Error auto-off',
+    10: 'Reserved',
+    20: 'Detecting',
+    21: 'Add drain',
+    22: 'Load display',
+    23: 'Running',
+    30: 'Rinsing',
+    31: 'Rinse hold',
+    40: 'Spinning',
+    50: 'Drying',
+    60: 'End',
+    61: 'Fresh care',
+    79: 'Smart diagnosis',
+    81: 'Tub clean count alarm',
+    101: 'Smart diagnosis data',
+}
+
+const ERRORS: Record<number, string> = {
+    0: 'OK',
+    1: 'Door lock error (DE2)',
+    2: 'No fill error (IE)',
+    3: 'Not draining error (OE)',
+    4: 'Out of balance error (UE)',
+    5: 'Overfill error (FE)',
+    6: 'Water sensor error (PE)',
+    7: 'Thermistor error (tE)',
+    8: 'Locked motor error (LE)',
+    9: 'CE error',
+    10: 'dHE error',
+    11: 'Power failure error (PF)',
+    12: 'Freeze error (FF)',
+    13: 'dCE error',
+    14: 'AE error',
+    15: 'EEPROM error (EE)',
+    16: 'Suds error (Sud)',
+    17: 'Door open error (DE1)',
+    18: 'Sliding lid open error (LOE)',
+    19: 'PS error',
+}
+
+const SOIL: Record<number, string> = {
+    0: '-',
+    1: 'Light',
+    2: 'Light-Normal',
+    3: 'Normal',
+    4: 'Normal-Heavy',
+    5: 'Heavy',
+}
+
+const SPIN: Record<number, string> = {
+    0: '-',
+    1: 'No spin',
+    2: 'Low',
+    3: 'Medium',
+    4: 'High',
+    5: 'Extra high',
+}
+
+const TEMP: Record<number, string> = {
+    0: '-',
+    1: 'Tap cold',
+    2: 'Cold',
+    3: 'Semi warm',
+    4: 'Warm',
+    5: 'Warm',
+    6: 'Hot',
+    7: 'Extra hot',
+}
+
+const DRY_LEVEL: Record<number, string> = {
+    0: '-',
+    5: 'Turbo',
+    6: 'Wind',
+    7: '30 min',
+    8: '60 min',
+    9: '90 min',
+    10: '120 min',
+    11: '150 min',
+}
+
+const RINSE_COUNT: Record<number, string> = {
+    0: '0',
+    1: '1',
+    2: '2',
+    3: '3',
+}
+
+// Physical-dial ("AP") courses; ids beyond this table (smart/downloaded courses) fall
+// back to their raw numeric id.
+const AP_COURSE: Record<number, string> = {
+    1: 'Tub Clean',
+    2: 'Bright Whites',
+    3: 'Bedding',
+    4: 'Heavy Duty',
+    5: 'Normal',
+    6: 'Perm Press',
+    7: 'Delicates',
+    8: 'Towels',
+    9: 'Speed Wash',
+    10: 'Download Course',
+    11: 'Spin Only',
+}
+
+export default class Device extends HADevice {
+    constructor(
+        HA: Connection,
+        readonly thinq: Thinq1Device,
+        meta: Metadata,
+    ) {
+        super(HA, thinq.id)
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: 'LG Washer' }),
+                components: {
+                    power: {
+                        platform: 'switch',
+                        unique_id: '$deviceid-power',
+                        state_topic: '$this/power',
+                        command_topic: '$this/power/set',
+                        name: '',
+                        icon: 'mdi:washing-machine',
+                    },
+                    pause: {
+                        platform: 'button',
+                        unique_id: '$deviceid-pause',
+                        command_topic: '$this/pause/set',
+                        payload_press: '',
+                        name: 'Pause',
+                        icon: 'mdi:pause-circle-outline',
+                    },
+                    status: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-status',
+                        state_topic: '$this/status',
+                        name: 'Status',
+                        icon: 'mdi:state-machine',
+                        device_class: 'enum',
+                        options: Object.values(STATES),
+                    },
+                    pre_state: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-pre-state',
+                        state_topic: '$this/pre_state',
+                        name: 'Previous status',
+                        icon: 'mdi:history',
+                        entity_category: 'diagnostic',
+                        device_class: 'enum',
+                        options: Object.values(STATES),
+                    },
+                    error: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-error',
+                        state_topic: '$this/error',
+                        name: 'Error',
+                        icon: 'mdi:check-circle',
+                        device_class: 'problem',
+                        entity_category: 'diagnostic',
+                    },
+                    error_message: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-error-message',
+                        state_topic: '$this/error_message',
+                        name: 'Error message',
+                        icon: 'mdi:alert-circle-outline',
+                        device_class: 'enum',
+                        entity_category: 'diagnostic',
+                        options: Object.values(ERRORS),
+                    },
+                    course: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-course',
+                        state_topic: '$this/course',
+                        name: 'Course',
+                        icon: 'mdi:pin-outline',
+                    },
+                    soil: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-soil',
+                        state_topic: '$this/soil',
+                        name: 'Soil level',
+                        icon: 'mdi:water-opacity',
+                    },
+                    spin: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-spin',
+                        state_topic: '$this/spin',
+                        name: 'Spin',
+                        icon: 'mdi:autorenew',
+                    },
+                    temp: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-temp',
+                        state_topic: '$this/temp',
+                        name: 'Water temperature',
+                        icon: 'mdi:thermometer',
+                    },
+                    dry_level: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-dry-level',
+                        state_topic: '$this/dry_level',
+                        name: 'Dry level',
+                        icon: 'mdi:tumble-dryer',
+                    },
+                    rinse_count: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-rinse-count',
+                        state_topic: '$this/rinse_count',
+                        name: 'Rinse count',
+                        icon: 'mdi:water-sync',
+                        entity_category: 'diagnostic',
+                    },
+                    extra_rinse_count: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-extra-rinse-count',
+                        state_topic: '$this/extra_rinse_count',
+                        name: 'Extra rinse count',
+                        icon: 'mdi:water-plus-outline',
+                        entity_category: 'diagnostic',
+                    },
+                    child_lock: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-child-lock',
+                        state_topic: '$this/child_lock',
+                        name: 'Child lock',
+                        device_class: 'lock',
+                        entity_category: 'diagnostic',
+                    },
+                    steam: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-steam',
+                        state_topic: '$this/steam',
+                        name: 'Steam',
+                        icon: 'mdi:kettle-steam',
+                    },
+                    prewash: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-prewash',
+                        state_topic: '$this/prewash',
+                        name: 'Prewash',
+                        icon: 'mdi:water-outline',
+                    },
+                    turbowash: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-turbowash',
+                        state_topic: '$this/turbowash',
+                        name: 'TurboWash',
+                        icon: 'mdi:speedometer',
+                    },
+                    coldwash: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-coldwash',
+                        state_topic: '$this/coldwash',
+                        name: 'Cold wash',
+                        icon: 'mdi:snowflake',
+                    },
+                    fresh_care: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-fresh-care',
+                        state_topic: '$this/fresh_care',
+                        name: 'Fresh care',
+                        icon: 'mdi:air-filter',
+                    },
+                    remote_start: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-remote_start',
+                        state_topic: '$this/remote_start',
+                        name: 'Remote start armed',
+                        icon: 'mdi:play-circle-outline',
+                    },
+                    tub_clean_count: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-tub-clean-count',
+                        state_topic: '$this/tub_clean_count',
+                        name: 'Cycles since tub clean',
+                        icon: 'mdi:counter',
+                        entity_category: 'diagnostic',
+                    },
+                    reserve_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-reserve-time',
+                        state_topic: '$this/reserve_time',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        name: 'Delay wash time',
+                    },
+                    initial_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-initial_time',
+                        state_topic: '$this/initial_time',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        name: 'Initial time',
+                    },
+                    remaining_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-remaining_time',
+                        state_topic: '$this/remaining_time',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        name: 'Remaining time',
+                    },
+                },
+            }),
+        )
+
+        thinq.on('data', (buf) => {
+            if (buf.length < 24) return
+
+            const state = buf[0]
+            const timeRemain = buf[1] * 60 + buf[2]
+            const timeInitial = buf[3] * 60 + buf[4]
+            const apCourse = buf[5]
+            const error = buf[6]
+            const soil = buf[7]
+            const spin = buf[8]
+            const temp = buf[9]
+            const rinseOption = buf[10]
+            const dryLevel = buf[11]
+            const reserveH = buf[12]
+            const reserveM = buf[13]
+            const option1 = buf[14]
+            const option2 = buf[15]
+            const preState = buf[19]
+            const tclCount = buf[21]
+
+            const rinseCount = rinseOption & 0x0f
+            const extraRinseCount = (rinseOption >> 4) & 0x0f
+
+            this.publishProperty('power', state > 0 ? 'ON' : 'OFF')
+            this.publishProperty('error_message', ERRORS[error] ?? 'unknown')
+            this.publishProperty('error', error ? 'ON' : 'OFF')
+            this.publishProperty('status', STATES[state] ?? 'unknown')
+            this.publishProperty('pre_state', STATES[preState] ?? 'unknown')
+            this.publishProperty('course', AP_COURSE[apCourse] ?? String(apCourse))
+            this.publishProperty('soil', SOIL[soil] ?? 'unknown')
+            this.publishProperty('spin', SPIN[spin] ?? 'unknown')
+            this.publishProperty('temp', TEMP[temp] ?? 'unknown')
+            this.publishProperty('dry_level', DRY_LEVEL[dryLevel] ?? 'unknown')
+            this.publishProperty('rinse_count', RINSE_COUNT[rinseCount] ?? String(rinseCount))
+            this.publishProperty('extra_rinse_count', RINSE_COUNT[extraRinseCount] ?? String(extraRinseCount))
+            this.publishProperty('child_lock', option1 & 0x01 ? 'ON' : 'OFF')
+            this.publishProperty('steam', option1 & 0x04 ? 'ON' : 'OFF')
+            this.publishProperty('prewash', option1 & 0x08 ? 'ON' : 'OFF')
+            this.publishProperty('turbowash', option1 & 0x80 ? 'ON' : 'OFF')
+            this.publishProperty('fresh_care', option2 & 0x01 ? 'ON' : 'OFF')
+            this.publishProperty('coldwash', option2 & 0x10 ? 'ON' : 'OFF')
+            this.publishProperty('remote_start', option2 & 0x80 ? 'ON' : 'OFF')
+            this.publishProperty('tub_clean_count', tclCount)
+            this.publishProperty('reserve_time', reserveH * 60 + reserveM)
+            this.publishProperty('initial_time', timeInitial)
+            this.publishProperty('remaining_time', timeRemain)
+        })
+    }
+
+    publishCache: Record<string, string | number> = {}
+
+    publishProperty(prop: string, value: string | number) {
+        if (this.publishCache[prop] === value) return
+
+        this.publishCache[prop] = value
+        this.HA.publishProperty(this.id, prop, value)
+    }
+
+    setProperty(prop: string, mqttValue: string) {
+        if (prop === 'power' && mqttValue === 'OFF') {
+            this.thinq.send({ Cmd: 'Control', CmdOpt: 'Power', Value: 'Off', Format: 'B64', Data: '' })
+        }
+        // power=ON is intentionally not implemented: the modelJson defines no PowerOn
+        // action for this model, only PowerOff/OperationStart/OperationStop.
+        if (prop === 'pause') {
+            this.thinq.send({ Cmd: 'Control', CmdOpt: 'Operation', Value: 'Stop', Format: 'B64', Data: '' })
+        }
+        // Starting a cycle (OperationStart) needs a base64-encoded 21-byte course-parameter
+        // array per the modelJson's ControlWifi.action.OperationStart — not implemented
+        // until the exact byte encoding is confirmed against a real captured command.
+    }
+}

--- a/cloud/devices/F3L2CNV4W_WIFI.ts
+++ b/cloud/devices/F3L2CNV4W_WIFI.ts
@@ -16,11 +16,16 @@ import { Metadata } from '../thinq'
 // wire shape ({Cmd:'Control', CmdOpt:..., Value:...}) matches WTDN3.ts's already-verified
 // pattern, cross-confirmed by the modelJson's ControlWifi.action entries.
 // OperationStart's course-parameter array encoding (courseId/Soil/SpinSpeed/WaterTemp/../
-// OPCourse as one byte each, base64) is cross-confirmed against ha-smartthinq-sensors'
-// independent ThinQ1 v1 command builder, which already drives this exact model — but not
-// yet against a real captured command from this device (see tools/rethink-capture.ts).
+// OPCourse as one byte each, base64) is confirmed against a real captured command from this
+// device (2026-08-22, Normal course) — see the test file — and independently cross-checked
+// against ha-smartthinq-sensors' ThinQ1 v1 command builder, which already drives this exact
+// model.
 // Remote power-ON is NOT implemented: the modelJson defines no PowerOn action at all for
 // this model (the physical dial is presumably the only way to arm remote start).
+//
+// Per-cycle energy usage (last_cycle_energy/course/completed) comes from a second channel
+// entirely: HTTP diagmon reports (cloud/thinq1/http.ts), not the persistent :47878 status
+// socket this class otherwise reads from. See the thinq.on('diagmon', ...) handler below.
 
 const STATES: Record<number, string> = {
     0: 'Off',
@@ -471,6 +476,33 @@ export default class Device extends HADevice {
                         unit_of_measurement: 'min',
                         name: 'Remaining time',
                     },
+                    last_cycle_energy: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-last-cycle-energy',
+                        state_topic: '$this/last_cycle_energy',
+                        // No unit_of_measurement/device_class yet: the value (energyMonInfo's
+                        // "power" field) is very plausibly Wh, but that's not confirmed against
+                        // the app's own displayed number yet. Labeling it "energy"/Wh prematurely
+                        // would let HA's Energy Dashboard ingest a value we haven't verified.
+                        name: 'Last cycle energy usage (raw, unconfirmed unit)',
+                        icon: 'mdi:lightning-bolt-outline',
+                    },
+                    last_cycle_course: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-last-cycle-course',
+                        state_topic: '$this/last_cycle_course',
+                        name: 'Last completed course',
+                        icon: 'mdi:pin-outline',
+                        entity_category: 'diagnostic',
+                    },
+                    last_cycle_completed: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-last-cycle-completed',
+                        state_topic: '$this/last_cycle_completed',
+                        name: 'Last cycle completed at',
+                        icon: 'mdi:clock-check-outline',
+                        entity_category: 'diagnostic',
+                    },
                 },
             }),
         )
@@ -544,6 +576,26 @@ export default class Device extends HADevice {
                 this.pendingCourseId = apCourse
                 this.publishProperty('course_selection', AP_COURSE[apCourse])
             }
+        })
+
+        // Confirmed against a real captured report (2026-08-22, Normal course): diagMonType
+        // "WasherMonitoring" wraps a base64'd XML blob with one of several inner elements —
+        // tubInfo (idle tub-clean counter, redundant with byte 21 above), courseInfo (a
+        // mid-cycle mirror of the same 24-byte Monitoring frame), and energyMonInfo (the one
+        // that matters: course/power/useDate for a just-completed cycle). Only energyMonInfo
+        // is handled here; the other two don't carry anything we don't already have.
+        thinq.on('diagmon', (diagMonType, decoded) => {
+            if (diagMonType !== 'WasherMonitoring') return
+
+            const info = (
+                decoded as { lgedmRoot?: { energyMonInfo?: { course?: number; power?: number; useDate?: string } } }
+            )?.lgedmRoot?.energyMonInfo
+            if (!info) return
+
+            if (typeof info.power === 'number') this.publishProperty('last_cycle_energy', info.power)
+            if (typeof info.course === 'number')
+                this.publishProperty('last_cycle_course', AP_COURSE[info.course] ?? String(info.course))
+            if (typeof info.useDate === 'string') this.publishProperty('last_cycle_completed', info.useDate)
         })
     }
 

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -22,6 +22,7 @@ import RV13B6BSD_D_US_WIFI from './devices/RV13B6BSD_D_US_WIFI'
 import RV13B6ES_D_US_WIFI from './devices/RV13B6ES_D_US_WIFI'
 import WTL_FXU_BDV_NA_01 from './devices/WTL_FXU_BDV_NA_01'
 import DHUM_056905_WW from './devices/DHUM_056905_WW'
+import F3L2CNV4W_WIFI from './devices/F3L2CNV4W_WIFI'
 import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
 import { type Connection } from './homeassistant'
@@ -34,6 +35,7 @@ type T2Factory = new (HA: Connection, thinq: T2Device, metadata: Metadata) => HA
 
 const t1deviceTypes: Record<string, T1Factory> = {
     WTDN3,
+    F3L2CNV4W_WIFI, // LG F3L2CNV4W front-load washer — decode from LG's own modelJson, cycle-start not yet implemented
 }
 
 const t2deviceTypes: Record<string, T2Factory> = {

--- a/cloud/thinq1/device.ts
+++ b/cloud/thinq1/device.ts
@@ -12,6 +12,7 @@ type ConWithExtra = Connection & {
 type DeviceEvents = {
     data: (packet: Buffer) => void
     sendData: (body: object) => void
+    diagmon: (diagMonType: string, decoded: unknown) => void
     close: () => void
 }
 

--- a/cloud/thinq1/http.ts
+++ b/cloud/thinq1/http.ts
@@ -112,5 +112,16 @@ export function routes(config: Config) {
         res.end()
     })
 
+    router.post('/api/product/sendPushMessage', (req, res) => {
+        // Not yet decoded — this is the device's own push-notification channel
+        // (messageCode/langCode), the likely source of "cycle complete"/error events that
+        // don't fit into the periodic Mon/Start status. Previously unhandled entirely (fell
+        // through to the generic {} JSON fallback instead of a real XML ack). Log the body
+        // so a real notification can be captured and turned into an HA event.
+        log('HTTPS', `sendPushMessage ${req.header('x-lgedm-deviceid')}: ${JSON.stringify(req.body)}`)
+        res.header('Content-type: text/xml;charset=utf-8')
+        res.end(XML_HEADER + new XMLBuilder().build({ lgedmRoot: { returnCd: '0000', returnMsg: 'OK' } }))
+    })
+
     return router
 }

--- a/cloud/thinq1/http.ts
+++ b/cloud/thinq1/http.ts
@@ -2,6 +2,7 @@ import { Request, Response, Router } from 'express'
 import { Config } from '@/util/config'
 import { XMLParser, XMLBuilder, XMLValidator } from 'fast-xml-parser'
 import { Metadata } from '../thinq'
+import log from '@/util/logging'
 
 const XML_HEADER = '<?xml version="1.0" encoding="utf-8" standalone="yes"?>'
 
@@ -103,6 +104,11 @@ export function routes(config: Config) {
     })
 
     router.post('/lgehadm/report/diagmon', (req, res) => {
+        // Not yet decoded — this is where per-cycle energy/water usage reports arrive
+        // (WasherMonitoring diagMonType, separate from the periodic Mon/Start status
+        // channel). Log the raw parsed body so a real report can be captured and a proper
+        // decoder written from it, the same way the rest of this device's fields were.
+        log('HTTPS', `diagmon ${req.header('x-lgedm-deviceid')}: ${JSON.stringify(req.body)}`)
         res.end()
     })
 

--- a/cloud/thinq1/http.ts
+++ b/cloud/thinq1/http.ts
@@ -11,6 +11,21 @@ export function getDeviceMetadata(id: string) {
     return deviceMeta[id]
 }
 
+// diagMonData is base64 of either a plain decimal string (e.g. ScomoCourse's course id) or
+// XML (WasherMonitoring's tubInfo/courseInfo/energyMonInfo) — try XML first, fall back to
+// the raw decoded string.
+function decodeDiagMonData(b64: string): unknown {
+    const raw = Buffer.from(b64, 'base64')
+    if (raw[0] === 0x3c /* '<' */) {
+        try {
+            return new XMLParser().parse(raw)
+        } catch {
+            // fall through to the raw string below
+        }
+    }
+    return raw.toString('utf-8')
+}
+
 function xmlParser(req: Request, res: Response, next: () => void) {
     const buffers: Buffer[] = []
     let length = 0
@@ -35,7 +50,7 @@ function xmlParser(req: Request, res: Response, next: () => void) {
     })
 }
 
-export function routes(config: Config) {
+export function routes(config: Config, onDiagmon?: (deviceId: string, diagMonType: string, decoded: unknown) => void) {
     const router = Router()
     router.use(xmlParser)
 
@@ -104,11 +119,22 @@ export function routes(config: Config) {
     })
 
     router.post('/lgehadm/report/diagmon', (req, res) => {
-        // Not yet decoded — this is where per-cycle energy/water usage reports arrive
-        // (WasherMonitoring diagMonType, separate from the periodic Mon/Start status
-        // channel). Log the raw parsed body so a real report can be captured and a proper
-        // decoder written from it, the same way the rest of this device's fields were.
-        log('HTTPS', `diagmon ${req.header('x-lgedm-deviceid')}: ${JSON.stringify(req.body)}`)
+        // Per-cycle energy/water usage and tub-clean-alert reports arrive here
+        // (WasherMonitoring diagMonType), separate from the periodic Mon/Start status
+        // channel. diagMonData is double-encoded (base64 of either a plain string or XML,
+        // which may itself contain further base64 fields) — decode what we can generically
+        // here and hand it to the matching device, which knows what its fields mean.
+        // Unlike every other lgehadm endpoint, this one doesn't send x-lgedm-deviceid —
+        // the device id only exists inside the body, as Report.devId.
+        const report = req.body?.Report
+        const deviceId = req.header('x-lgedm-deviceid') ?? report?.devId
+        if (deviceId && typeof report?.diagMonType === 'string' && typeof report?.diagMonData === 'string') {
+            const decoded = decodeDiagMonData(report.diagMonData)
+            log('HTTPS', `diagmon ${deviceId} ${report.diagMonType}: ${JSON.stringify(decoded)}`)
+            onDiagmon?.(deviceId, report.diagMonType, decoded)
+        } else {
+            log('HTTPS', `diagmon ${deviceId}: ${JSON.stringify(req.body)}`)
+        }
         res.end()
     })
 

--- a/cloud/thinq2/device.ts
+++ b/cloud/thinq2/device.ts
@@ -12,6 +12,10 @@ import { Metadata } from '../thinq'
 type DeviceEvents = {
     data: (packet: Buffer) => void
     sendData: (buf: Buffer) => void
+    // Never emitted on ThinQ2 (there's no diagmon-equivalent channel here) — present only
+    // so AnyDevice's union-typed .on()/.emit() calls elsewhere keep resolving; ThinQ1's
+    // Device is the only one that actually fires this.
+    diagmon: (diagMonType: string, decoded: unknown) => void
     close: () => void
 }
 

--- a/rethink-cloud.ts
+++ b/rethink-cloud.ts
@@ -10,7 +10,7 @@ import * as net from 'node:net'
 import { X509Certificate } from 'node:crypto'
 import { routes as thinq1Routes } from './cloud/thinq1/http'
 import { routes as thinq2Routes } from './cloud/thinq2/provisioning'
-import { DeviceAcceptor as T1Acceptor } from './cloud/thinq1/device'
+import { DeviceAcceptor as T1Acceptor, Device as T1Device } from './cloud/thinq1/device'
 import { DeviceAcceptor as T2Acceptor } from './cloud/thinq2/device'
 import { Connection as HA_connection } from './cloud/homeassistant'
 import HA_bridge from './cloud/ha_bridge'
@@ -83,7 +83,12 @@ function t1setup(manager: DeviceManager) {
         next()
     })
 
-    app.use(thinq1Routes(config))
+    app.use(
+        thinq1Routes(config, (deviceId, diagMonType, decoded) => {
+            const dev = manager.allDevices[deviceId]
+            if (dev instanceof T1Device) dev.emit('diagmon', diagMonType, decoded)
+        }),
+    )
 
     // fallback
     app.use((req, res) => {

--- a/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
+++ b/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
@@ -106,6 +106,18 @@ describe(MODEL_ID, () => {
         assert.equal(ha.devices[DEVICE_ID].properties.course_selection, 'Normal')
     })
 
+    test('course_selection/remote_start_button availability tracks Off/Initial vs a running cycle', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_STATE_OFF) // State=Off
+        assert.equal(ha.devices[DEVICE_ID].properties.controls_available, 'online')
+
+        thinq.emit('data', SAMPLE_STATE_RUNNING_NORMAL) // State=Running
+        assert.equal(ha.devices[DEVICE_ID].properties.controls_available, 'offline')
+
+        thinq.emit('data', SAMPLE_STATE_OFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.controls_available, 'online')
+    })
+
     test('OFF state publishes power=OFF and idle defaults', () => {
         const { ha, thinq } = makeDevice()
         thinq.emit('data', SAMPLE_STATE_OFF)

--- a/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
+++ b/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
@@ -156,6 +156,13 @@ describe(MODEL_ID, () => {
         assert.deepEqual(thinq.sent, [{ Cmd: 'Control', CmdOpt: 'Operation', Value: 'Stop', Format: 'B64', Data: '' }])
     })
 
+    test('start() sends a Mon/Start subscription on the wire', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.start()
+        assert.deepEqual(thinq.sent, [{ Cmd: 'Mon', CmdOpt: 'Start' }])
+    })
+
     // No test for starting a cycle (OperationStart) — not implemented yet, see the class
     // header comment: the course-parameter array encoding isn't confirmed against a real
     // captured command.

--- a/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
+++ b/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
@@ -135,8 +135,9 @@ describe(MODEL_ID, () => {
         const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
         for (const c of ['course_selection', 'remote_start_button']) {
             assert.equal(components[c].availability_topic, undefined, `${c} must not use availability_topic`)
-            assert.deepEqual(components[c].availability, [{ topic: '$this/controls_available' }])
         }
+        assert.deepEqual(components.course_selection.availability, [{ topic: '$this/controls_available' }])
+        assert.deepEqual(components.remote_start_button.availability, [{ topic: '$this/remote_start_available' }])
     })
 
     test('course_selection defaults to Normal on construction, before any data arrives', () => {
@@ -158,9 +159,10 @@ describe(MODEL_ID, () => {
         // "offline" (e.g. the washer was mid-cycle when that earlier process stopped).
         const { ha } = makeDevice()
         assert.equal(ha.devices[DEVICE_ID].properties.controls_available, 'offline')
+        assert.equal(ha.devices[DEVICE_ID].properties.remote_start_available, 'offline')
     })
 
-    test('course_selection/remote_start_button availability tracks Off/Initial vs a running cycle', () => {
+    test('course_selection availability tracks Off/Initial vs a running cycle', () => {
         const { ha, thinq } = makeDevice()
         thinq.emit('data', SAMPLE_STATE_OFF) // State=Off
         assert.equal(ha.devices[DEVICE_ID].properties.controls_available, 'online')
@@ -170,6 +172,22 @@ describe(MODEL_ID, () => {
 
         thinq.emit('data', SAMPLE_STATE_OFF)
         assert.equal(ha.devices[DEVICE_ID].properties.controls_available, 'online')
+    })
+
+    test('remote_start_button stays available through Paused too, unlike course_selection', () => {
+        // modelJson has no distinct Resume action - OperationStart is how you resume a paused
+        // cycle. course_selection has no such exception: we have no evidence it's safe to swap
+        // courses mid-pause, so it stays locked to Off/Initial only.
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_STATE_OFF) // State=Off
+        assert.equal(ha.devices[DEVICE_ID].properties.remote_start_available, 'online')
+
+        thinq.emit('data', SAMPLE_STATE_RUNNING_NORMAL) // State=Running
+        assert.equal(ha.devices[DEVICE_ID].properties.remote_start_available, 'offline')
+
+        thinq.emit('data', buf('06 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00')) // State=Paused
+        assert.equal(ha.devices[DEVICE_ID].properties.controls_available, 'offline')
+        assert.equal(ha.devices[DEVICE_ID].properties.remote_start_available, 'online')
     })
 
     test('OFF state publishes power=OFF and idle defaults', () => {
@@ -248,11 +266,13 @@ describe(MODEL_ID, () => {
     test('Frames shorter than the 24-byte layout are ignored', () => {
         const { ha, thinq } = makeDevice()
         thinq.emit('data', buf('AABBCC'))
-        // course_selection and controls_available are both published at construction time,
-        // independent of any frame; nothing else should appear from a too-short frame.
+        // course_selection, controls_available, and remote_start_available are all published
+        // at construction time, independent of any frame; nothing else should appear from a
+        // too-short frame.
         assert.deepEqual(ha.devices[DEVICE_ID].properties, {
             course_selection: 'Normal',
             controls_available: 'offline',
+            remote_start_available: 'offline',
         })
     })
 

--- a/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
+++ b/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
@@ -93,6 +93,7 @@ describe(MODEL_ID, () => {
         assert.ok((components.status.options as string[]).includes('Running'))
         assert.ok((components.status.options as string[]).includes('Error auto-off'))
 
+        // 9 physical-dial courses + 16 app-downloadable SmartCourse ones.
         assert.deepEqual(components.course_selection.options, [
             'Tub Clean',
             'Bright Whites',
@@ -103,6 +104,22 @@ describe(MODEL_ID, () => {
             'Delicates',
             'Towels',
             'Speed Wash',
+            'Small Load',
+            'Color Care',
+            'Beachwear',
+            'New Clothes',
+            'Denim',
+            'Swimwear',
+            'Rainy Day',
+            'Gym Clothes',
+            'Sweat Stains',
+            'Single Garments',
+            'Baby Clothes',
+            'Overnight Wash',
+            'Econo Wash',
+            'Delicate Dresses',
+            'Half Load Wash',
+            'Full Load Wash',
         ])
     })
 
@@ -253,6 +270,23 @@ describe(MODEL_ID, () => {
         assert.deepEqual(
             [...Buffer.from(sent.Data, 'base64')],
             [5, 3, 5, 4, 0, 0, 0, 0, 0, 0x20, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        )
+    })
+
+    test('selecting a SmartCourse and starting sends APCourse=10 with the real SmartCourse id', () => {
+        const { ha, thinq, dev } = makeDevice()
+        dev.setProperty('course_selection', 'Small Load')
+        assert.equal(ha.devices[DEVICE_ID].properties.course_selection, 'Small Load')
+
+        thinq.resetRecorder()
+        dev.setProperty('remote_start_button', '')
+        const sent = thinq.sent[0] as { Data: string }
+        // Small Load (SmartCourse id 51): Soil=3, SpinSpeed=5, WaterTemp=4, OPCourse=15.
+        // APCourse is fixed at 10 (Download Course) and the SmartCourse slot carries 51,
+        // instead of APCourse=<dial id> and SmartCourse=0 for a physical-dial course.
+        assert.deepEqual(
+            [...Buffer.from(sent.Data, 'base64')],
+            [10, 3, 5, 4, 0, 0, 0, 0, 0, 0x20, 15, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         )
     })
 

--- a/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
+++ b/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
@@ -31,6 +31,15 @@ const SAMPLE_STATE_ERROR_DE1 = buf(`
     07 00 00 00 00 05 11 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 `)
 
+// Real capture (2026-08-22), not synthetic: the courseInfo mirror bundled inside a
+// mid-cycle WasherMonitoring diagmon report, decoded from its base64 <data> field.
+// State=Detecting, Normal course, RemoteStart armed, tub-clean count 48. Option3=2 here —
+// a real, undocumented bit pattern (not InitialBit/0x20), useful for confirming option3_raw
+// surfaces it as-is rather than only recognizing the one named bit.
+const SAMPLE_STATE_REAL_MIDCYCLE_COURSEINFO = buf(`
+    14 01 11 01 11 05 00 03 05 04 02 00 00 00 00 80 02 00 00 05 6a 30 00 00
+`)
+
 function makeDevice() {
     const ha = new MockHAConnection()
     const thinq = new MockThinq1Device(DEVICE_ID, META)
@@ -70,6 +79,8 @@ describe(MODEL_ID, () => {
             'coldwash',
             'fresh_care',
             'remote_start',
+            'initial_bit',
+            'option3_raw',
             'tub_clean_count',
             'load_level',
             'reserve_time',
@@ -160,8 +171,25 @@ describe(MODEL_ID, () => {
         assert.equal(props.error, 'OFF')
         assert.equal(props.op_course, 'Normal')
         assert.equal(props.smart_course, '0')
+        assert.equal(props.initial_bit, 'OFF')
+        assert.equal(props.option3_raw, 0)
         assert.equal(props.extra_rinse, 'OFF')
         assert.equal(props.load_level, 0)
+    })
+
+    test('real mid-cycle capture decodes cleanly, including an undocumented Option3 bit', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_STATE_REAL_MIDCYCLE_COURSEINFO)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.status, 'Detecting')
+        assert.equal(props.course, 'Normal')
+        assert.equal(props.remote_start, 'ON')
+        assert.equal(props.tub_clean_count, 48)
+        assert.equal(props.smart_course, 'Econo Wash')
+        // Option3=2 here (bit 1) — not InitialBit (bit 5, 0x20) — so the named sensor stays
+        // off, but the raw byte still surfaces the undocumented bit for future investigation.
+        assert.equal(props.initial_bit, 'OFF')
+        assert.equal(props.option3_raw, 2)
     })
 
     test('Door-open error publishes error binary + descriptive message', () => {

--- a/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
+++ b/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
@@ -123,6 +123,22 @@ describe(MODEL_ID, () => {
         ])
     })
 
+    test('course_selection/remote_start_button use the list-form availability, not availability_topic', () => {
+        // Regression test: HA's MQTT discovery schema treats `availability_topic` (singular)
+        // and `availability`/`availability_mode` (list) as mutually exclusive within one
+        // entity. The device declares device-level `availability` (see HADevice.config), so
+        // any component here that also wants its own override must use the list form too -
+        // mixing forms makes HA reject the whole component with "two or more values in the
+        // same group of exclusion 'availability'", silently dropping the entity. Confirmed
+        // against real HA logs, not simulated - MockHAConnection has no schema of its own.
+        const { ha } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        for (const c of ['course_selection', 'remote_start_button']) {
+            assert.equal(components[c].availability_topic, undefined, `${c} must not use availability_topic`)
+            assert.deepEqual(components[c].availability, [{ topic: '$this/controls_available' }])
+        }
+    })
+
     test('course_selection defaults to Normal on construction, before any data arrives', () => {
         const { ha } = makeDevice()
         assert.equal(ha.devices[DEVICE_ID].properties.course_selection, 'Normal')

--- a/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
+++ b/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
@@ -134,6 +134,16 @@ describe(MODEL_ID, () => {
         assert.equal(ha.devices[DEVICE_ID].properties.course_selection, 'Normal')
     })
 
+    test('controls_available defaults to offline on construction, before any data arrives', () => {
+        // Regression test: this was previously only ever published reactively inside the
+        // data handler, so a process that hadn't yet seen a fresh frame (e.g. right after a
+        // restart, before the washer reconnects) left HA showing a stale value retained from
+        // whatever a PREVIOUS process last published - stuck indefinitely if that was
+        // "offline" (e.g. the washer was mid-cycle when that earlier process stopped).
+        const { ha } = makeDevice()
+        assert.equal(ha.devices[DEVICE_ID].properties.controls_available, 'offline')
+    })
+
     test('course_selection/remote_start_button availability tracks Off/Initial vs a running cycle', () => {
         const { ha, thinq } = makeDevice()
         thinq.emit('data', SAMPLE_STATE_OFF) // State=Off
@@ -222,9 +232,12 @@ describe(MODEL_ID, () => {
     test('Frames shorter than the 24-byte layout are ignored', () => {
         const { ha, thinq } = makeDevice()
         thinq.emit('data', buf('AABBCC'))
-        // course_selection is published at construction time, independent of any frame;
-        // nothing else should appear from a too-short frame.
-        assert.deepEqual(ha.devices[DEVICE_ID].properties, { course_selection: 'Normal' })
+        // course_selection and controls_available are both published at construction time,
+        // independent of any frame; nothing else should appear from a too-short frame.
+        assert.deepEqual(ha.devices[DEVICE_ID].properties, {
+            course_selection: 'Normal',
+            controls_available: 'offline',
+        })
     })
 
     test('HA write power=OFF sends the modelJson PowerOff envelope', () => {

--- a/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
+++ b/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
@@ -93,7 +93,9 @@ describe(MODEL_ID, () => {
         assert.ok((components.status.options as string[]).includes('Running'))
         assert.ok((components.status.options as string[]).includes('Error auto-off'))
 
-        // 9 physical-dial courses + 16 app-downloadable SmartCourse ones.
+        // Only the 9 physical-dial courses are selectable - see the class header comment for
+        // why SmartCourse ids were removed from here (confirmed live: OperationStart can't
+        // actually select which SmartCourse runs, only the physical-dial ones are real).
         assert.deepEqual(components.course_selection.options, [
             'Tub Clean',
             'Bright Whites',
@@ -104,22 +106,6 @@ describe(MODEL_ID, () => {
             'Delicates',
             'Towels',
             'Speed Wash',
-            'Small Load',
-            'Color Care',
-            'Beachwear',
-            'New Clothes',
-            'Denim',
-            'Swimwear',
-            'Rainy Day',
-            'Gym Clothes',
-            'Sweat Stains',
-            'Single Garments',
-            'Baby Clothes',
-            'Overnight Wash',
-            'Econo Wash',
-            'Delicate Dresses',
-            'Half Load Wash',
-            'Full Load Wash',
         ])
     })
 
@@ -322,20 +308,23 @@ describe(MODEL_ID, () => {
         )
     })
 
-    test('selecting a SmartCourse and starting sends APCourse=10 with the real SmartCourse id', () => {
+    test('selecting a SmartCourse by name is a no-op - only the 9 dial courses are selectable', () => {
+        // Regression test: confirmed live (2026-08-22) that OperationStart's SmartCourse field
+        // doesn't actually select which SmartCourse runs - the machine only ever runs whatever
+        // is actually resident. SmartCourse names were removed from SELECTABLE_COURSE_NAMES, so
+        // this HA write should be silently ignored rather than changing pendingCourseId.
         const { ha, thinq, dev } = makeDevice()
         dev.setProperty('course_selection', 'Small Load')
-        assert.equal(ha.devices[DEVICE_ID].properties.course_selection, 'Small Load')
+        assert.equal(ha.devices[DEVICE_ID].properties.course_selection, 'Normal') // unchanged default
 
         thinq.resetRecorder()
         dev.setProperty('remote_start_button', '')
         const sent = thinq.sent[0] as { Data: string }
-        // Small Load (SmartCourse id 51): Soil=3, SpinSpeed=5, WaterTemp=4, OPCourse=15.
-        // APCourse is fixed at 10 (Download Course) and the SmartCourse slot carries 51,
-        // instead of APCourse=<dial id> and SmartCourse=0 for a physical-dial course.
+        // Still starts the default (Normal, id 5) course - the rejected SmartCourse pick never
+        // touched pendingCourseId.
         assert.deepEqual(
             [...Buffer.from(sent.Data, 'base64')],
-            [10, 3, 5, 4, 0, 0, 0, 0, 0, 0x20, 15, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [5, 3, 5, 4, 0, 0, 0, 0, 0, 0x20, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         )
     })
 

--- a/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
+++ b/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
@@ -1,0 +1,162 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/F3L2CNV4W_WIFI'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq1Device, buf } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'F3L2CNV4W_WIFI'
+const META: Metadata = { modelId: MODEL_ID, modelName: MODEL_ID, swVersion: '1.8' }
+
+// Synthetic frames built from the confirmed field layout (LG's own modelJson for this
+// model — see the class header comment), not from a real capture yet. Byte offsets and
+// enum values match modelJson.Monitoring.protocol / modelJson.Value exactly; the frames
+// themselves are hand-assembled to exercise that mapping. Replace/extend with real
+// tools/rethink-capture.ts samples once available.
+
+// All-zero: power off, idle.
+const SAMPLE_STATE_OFF = buf(`
+    00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+`)
+
+// Running, Normal course (id 5): Soil=Normal, Spin=Extra High, Temp=Warm, one extra
+// rinse, Steam + TurboWash on, FreshCare + RemoteStart armed, PreState=Initial,
+// remaining/initial time 1h05/1h10, 12 cycles since last tub clean.
+const SAMPLE_STATE_RUNNING_NORMAL = buf(`
+    17 01 05 01 0a 05 00 03 05 04 10 00 00 00 84 81 00 00 00 05 00 0c 06 00
+`)
+
+// Door-open error (DE1, id 17) interrupting a cycle set to the Normal course.
+const SAMPLE_STATE_ERROR_DE1 = buf(`
+    07 00 00 00 00 05 11 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+`)
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq1Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('config exposes expected components', () => {
+        const { ha } = makeDevice()
+        const cfg = ha.devices[DEVICE_ID].config
+        assert.ok(cfg, 'config published on construction')
+        const components = cfg!.components as Record<string, Record<string, unknown>>
+        for (const c of [
+            'power',
+            'pause',
+            'status',
+            'pre_state',
+            'error',
+            'error_message',
+            'course',
+            'soil',
+            'spin',
+            'temp',
+            'dry_level',
+            'rinse_count',
+            'extra_rinse_count',
+            'child_lock',
+            'steam',
+            'prewash',
+            'turbowash',
+            'coldwash',
+            'fresh_care',
+            'remote_start',
+            'tub_clean_count',
+            'reserve_time',
+            'initial_time',
+            'remaining_time',
+        ]) {
+            assert.ok(components[c], `component ${c} present`)
+        }
+        assert.ok(Array.isArray(components.status.options))
+        assert.ok((components.status.options as string[]).includes('Running'))
+        assert.ok((components.status.options as string[]).includes('Error auto-off'))
+    })
+
+    test('OFF state publishes power=OFF and idle defaults', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_STATE_OFF)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.power, 'OFF')
+        assert.equal(props.status, 'Off')
+        assert.equal(props.error, 'OFF')
+        assert.equal(props.error_message, 'OK')
+        assert.equal(props.soil, '-')
+        assert.equal(props.spin, '-')
+        assert.equal(props.temp, '-')
+        assert.equal(props.remaining_time, 0)
+        assert.equal(props.initial_time, 0)
+        assert.equal(props.tub_clean_count, 0)
+    })
+
+    test('Running Normal course decodes course/soil/spin/temp/options/time', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_STATE_RUNNING_NORMAL)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.power, 'ON')
+        assert.equal(props.status, 'Running')
+        assert.equal(props.pre_state, 'Initial')
+        assert.equal(props.course, 'Normal')
+        assert.equal(props.soil, 'Normal')
+        assert.equal(props.spin, 'Extra high')
+        assert.equal(props.temp, 'Warm')
+        assert.equal(props.rinse_count, '0')
+        assert.equal(props.extra_rinse_count, '1')
+        assert.equal(props.steam, 'ON')
+        assert.equal(props.turbowash, 'ON')
+        assert.equal(props.prewash, 'OFF')
+        assert.equal(props.child_lock, 'OFF')
+        assert.equal(props.fresh_care, 'ON')
+        assert.equal(props.coldwash, 'OFF')
+        assert.equal(props.remote_start, 'ON')
+        assert.equal(props.tub_clean_count, 12)
+        assert.equal(props.initial_time, 70)
+        assert.equal(props.remaining_time, 65)
+        assert.equal(props.error, 'OFF')
+    })
+
+    test('Door-open error publishes error binary + descriptive message', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_STATE_ERROR_DE1)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.status, 'Error auto-off')
+        assert.equal(props.error, 'ON')
+        assert.equal(props.error_message, 'Door open error (DE1)')
+        assert.equal(props.course, 'Normal')
+    })
+
+    test('Frames shorter than the 24-byte layout are ignored', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', buf('AABBCC'))
+        assert.deepEqual(ha.devices[DEVICE_ID].properties, {})
+    })
+
+    test('HA write power=OFF sends the modelJson PowerOff envelope', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('power', 'OFF')
+        assert.deepEqual(thinq.sent, [{ Cmd: 'Control', CmdOpt: 'Power', Value: 'Off', Format: 'B64', Data: '' }])
+    })
+
+    test('HA write power=ON sends nothing (no PowerOn action in the modelJson)', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('power', 'ON')
+        assert.deepEqual(thinq.sent, [])
+    })
+
+    test('HA write pause sends the modelJson OperationStop envelope', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('pause', '')
+        assert.deepEqual(thinq.sent, [{ Cmd: 'Control', CmdOpt: 'Operation', Value: 'Stop', Format: 'B64', Data: '' }])
+    })
+
+    // No test for starting a cycle (OperationStart) — not implemented yet, see the class
+    // header comment: the course-parameter array encoding isn't confirmed against a real
+    // captured command.
+})

--- a/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
+++ b/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
@@ -250,7 +250,40 @@ describe(MODEL_ID, () => {
         )
     })
 
-    // OperationStart's encoding is cross-confirmed against ha-smartthinq-sensors' independent
-    // ThinQ1 command builder (see the class header comment), but not yet against a real
-    // captured command from this device.
+    test('diagmon energyMonInfo publishes last-cycle energy/course/completion time', () => {
+        const { ha, thinq } = makeDevice()
+        // Real captured report (2026-08-22, Normal course completing): diagMonType
+        // "WasherMonitoring", diagMonData base64-decodes to
+        // <lgedmRoot><energyMonInfo><event>2</event><course>5</course><power>154</power>
+        // <option>...</option><dlCourse>106</dlCourse>
+        // <useDate>20260822 23:48:24</useDate></energyMonInfo></lgedmRoot>
+        thinq.emit('diagmon', 'WasherMonitoring', {
+            lgedmRoot: {
+                energyMonInfo: {
+                    event: 2,
+                    course: 5,
+                    power: 154,
+                    option: 'FAERAREFAAMFBAIAAAAAgAIAAAVqMAAA',
+                    dlCourse: 106,
+                    useDate: '20260822 23:48:24',
+                },
+            },
+        })
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.last_cycle_energy, 154)
+        assert.equal(props.last_cycle_course, 'Normal')
+        assert.equal(props.last_cycle_completed, '20260822 23:48:24')
+    })
+
+    test('diagmon tubInfo/courseInfo are ignored (not energyMonInfo)', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('diagmon', 'WasherMonitoring', {
+            lgedmRoot: { tubInfo: { event: 2, count: 49, maxCount: 30 } },
+        })
+        assert.equal(ha.devices[DEVICE_ID].properties.last_cycle_energy, undefined)
+    })
+
+    // OperationStart's encoding is cross-confirmed against a real captured command from this
+    // device (see the class header comment and the test above) as well as
+    // ha-smartthinq-sensors' independent ThinQ1 command builder.
 })

--- a/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
+++ b/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
@@ -54,6 +54,8 @@ describe(MODEL_ID, () => {
             'error',
             'error_message',
             'course',
+            'op_course',
+            'smart_course',
             'soil',
             'spin',
             'temp',
@@ -64,10 +66,12 @@ describe(MODEL_ID, () => {
             'steam',
             'prewash',
             'turbowash',
+            'extra_rinse',
             'coldwash',
             'fresh_care',
             'remote_start',
             'tub_clean_count',
+            'load_level',
             'reserve_time',
             'initial_time',
             'remaining_time',
@@ -142,6 +146,10 @@ describe(MODEL_ID, () => {
         assert.equal(props.initial_time, 70)
         assert.equal(props.remaining_time, 65)
         assert.equal(props.error, 'OFF')
+        assert.equal(props.op_course, 'Normal')
+        assert.equal(props.smart_course, '0')
+        assert.equal(props.extra_rinse, 'OFF')
+        assert.equal(props.load_level, 0)
     })
 
     test('Door-open error publishes error binary + descriptive message', () => {
@@ -200,10 +208,11 @@ describe(MODEL_ID, () => {
         assert.equal(sent.CmdOpt, 'Operation')
         assert.equal(sent.Value, 'Start')
         assert.equal(sent.Format, 'B64')
-        // Normal (id 5): Soil=3, SpinSpeed=5, WaterTemp=4, OPCourse=6 — from modelJson
+        // Matches a real captured OperationStart command for the Normal course (2026-08-22),
+        // Data: "BQMFBAAAAAAAIAYAAAAAAAAAAAAA" — byte-for-byte, not just the modelJson-derived guess.
         assert.deepEqual(
             [...Buffer.from(sent.Data, 'base64')],
-            [5, 3, 5, 4, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [5, 3, 5, 4, 0, 0, 0, 0, 0, 0x20, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         )
     })
 
@@ -225,7 +234,7 @@ describe(MODEL_ID, () => {
         // Heavy Duty (id 4): Soil=5, SpinSpeed=5, WaterTemp=4, OPCourse=7
         assert.deepEqual(
             [...Buffer.from(sent.Data, 'base64')],
-            [4, 5, 5, 4, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            [4, 5, 5, 4, 0, 0, 0, 0, 0, 0x20, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         )
     })
 

--- a/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
+++ b/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
@@ -47,6 +47,8 @@ describe(MODEL_ID, () => {
         for (const c of [
             'power',
             'pause',
+            'course_selection',
+            'remote_start_button',
             'status',
             'pre_state',
             'error',
@@ -75,6 +77,18 @@ describe(MODEL_ID, () => {
         assert.ok(Array.isArray(components.status.options))
         assert.ok((components.status.options as string[]).includes('Running'))
         assert.ok((components.status.options as string[]).includes('Error auto-off'))
+
+        assert.deepEqual(components.course_selection.options, [
+            'Tub Clean',
+            'Bright Whites',
+            'Bedding',
+            'Heavy Duty',
+            'Normal',
+            'Perm Press',
+            'Delicates',
+            'Towels',
+            'Speed Wash',
+        ])
     })
 
     test('OFF state publishes power=OFF and idle defaults', () => {
@@ -163,7 +177,46 @@ describe(MODEL_ID, () => {
         assert.deepEqual(thinq.sent, [{ Cmd: 'Mon', CmdOpt: 'Start' }])
     })
 
-    // No test for starting a cycle (OperationStart) — not implemented yet, see the class
-    // header comment: the course-parameter array encoding isn't confirmed against a real
-    // captured command.
+    test('remote_start_button sends OperationStart with the default (Normal) course', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('remote_start_button', '')
+        assert.equal(thinq.sent.length, 1)
+        const sent = thinq.sent[0] as { Cmd: string; CmdOpt: string; Value: string; Format: string; Data: string }
+        assert.equal(sent.Cmd, 'Control')
+        assert.equal(sent.CmdOpt, 'Operation')
+        assert.equal(sent.Value, 'Start')
+        assert.equal(sent.Format, 'B64')
+        // Normal (id 5): Soil=3, SpinSpeed=5, WaterTemp=4, OPCourse=6 — from modelJson
+        assert.deepEqual(
+            [...Buffer.from(sent.Data, 'base64')],
+            [5, 3, 5, 4, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        )
+    })
+
+    test('course_selection tracks the live course until the user picks one', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', SAMPLE_STATE_RUNNING_NORMAL) // course id 5 -> Normal
+        assert.equal(ha.devices[DEVICE_ID].properties.course_selection, 'Normal')
+
+        dev.setProperty('course_selection', 'Heavy Duty')
+        assert.equal(ha.devices[DEVICE_ID].properties.course_selection, 'Heavy Duty')
+
+        // a later frame still reporting the Normal course shouldn't override the user's pick
+        thinq.emit('data', SAMPLE_STATE_RUNNING_NORMAL)
+        assert.equal(ha.devices[DEVICE_ID].properties.course_selection, 'Heavy Duty')
+
+        thinq.resetRecorder()
+        dev.setProperty('remote_start_button', '')
+        const sent = thinq.sent[0] as { Data: string }
+        // Heavy Duty (id 4): Soil=5, SpinSpeed=5, WaterTemp=4, OPCourse=7
+        assert.deepEqual(
+            [...Buffer.from(sent.Data, 'base64')],
+            [4, 5, 5, 4, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        )
+    })
+
+    // OperationStart's encoding is cross-confirmed against ha-smartthinq-sensors' independent
+    // ThinQ1 command builder (see the class header comment), but not yet against a real
+    // captured command from this device.
 })

--- a/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
+++ b/tests/cloud/devices/F3L2CNV4W_WIFI.test.ts
@@ -91,6 +91,17 @@ describe(MODEL_ID, () => {
         ])
     })
 
+    test('course_selection defaults to Normal on construction, before any data arrives', () => {
+        const { ha } = makeDevice()
+        assert.equal(ha.devices[DEVICE_ID].properties.course_selection, 'Normal')
+    })
+
+    test('course_selection stays at its default while idle (APCourse=0 is not a real course)', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_STATE_OFF) // APCourse byte is 0
+        assert.equal(ha.devices[DEVICE_ID].properties.course_selection, 'Normal')
+    })
+
     test('OFF state publishes power=OFF and idle defaults', () => {
         const { ha, thinq } = makeDevice()
         thinq.emit('data', SAMPLE_STATE_OFF)
@@ -146,7 +157,9 @@ describe(MODEL_ID, () => {
     test('Frames shorter than the 24-byte layout are ignored', () => {
         const { ha, thinq } = makeDevice()
         thinq.emit('data', buf('AABBCC'))
-        assert.deepEqual(ha.devices[DEVICE_ID].properties, {})
+        // course_selection is published at construction time, independent of any frame;
+        // nothing else should appear from a too-short frame.
+        assert.deepEqual(ha.devices[DEVICE_ID].properties, { course_selection: 'Normal' })
     })
 
     test('HA write power=OFF sends the modelJson PowerOff envelope', () => {


### PR DESCRIPTION
## Device

- Brand / model name: LG WM3500CW
- ThinQ Model ID: F3L2CNV4W_WIFI
- Platform: ThinQ1
- Related issue: none

## What's supported

Built directly from the model's own `modelJson` (fetched via `wideq`, not reverse-engineered
by hand) and confirmed against real captured commands from the physical device.

- Full read side: every field in `modelJson`'s 24-byte `Monitoring.protocol` block - status,
  timers, course/soil/spin/temp/rinse options, tub-clean count, load level, the InitialBit
  option flag, and two undecoded fields (`option3_raw`, `load_level`) exposed as diagnostic
  entities rather than guessed at.
- Control: power off, pause, and starting a cycle by course. `course_selection` only offers
  the 9 physical-dial AP courses - SmartCourse ids were tried there and removed once a real
  capture showed `OperationStart`'s SmartCourse field isn't a live selector, the machine only
  ever runs whatever's actually resident.
- Remote Start stays available through a Paused cycle, not just Off/Initial, since
  `modelJson` has no distinct Resume action - `OperationStart` is how the physical panel
  resumes a paused cycle too. `course_selection` doesn't get the same exception; there's no
  evidence it's safe to swap courses mid-pause. Remote Start also requires `remote_start`
  (RemoteStart armed on the washer itself) - this mirrors the real LG app's own restriction,
  not a lockout of our own.
- Per-cycle energy usage (`last_cycle_energy`/`course`/`completed`) via a second channel
  entirely - HTTP diagmon reports, not the persistent status socket this class otherwise
  reads from.
- Two previously-silently-discarded `thinq1/http.ts` endpoints (`diagmon` reports,
  `sendPushMessage`) now log their bodies instead of being dropped, for visibility into
  traffic that isn't decoded yet.

SmartCourse download support (a `smart_course` select that triggers a real download,
`proxyToLG()`'s byte-forwarding fix, and the new proxy/capture/synthesis machinery in
`cloud/thinq1/http.ts`) is being submitted as a separate, follow-up PR once this one lands -
per your request to split basic device support from the course-download machinery.

## How this was verified

- [x] Checked against `modelJson` (ThinQ1), not just guessed from the app's UI
- [x] Tested against a real physical device (local Docker/Portainer deployment): status,
      timers, options, course display, power off, pause, and remote start all confirmed
      working end-to-end with Home Assistant
- [x] Added `tests/cloud/devices/F3L2CNV4W_WIFI.test.ts` - 23 tests, built from real captured
      data (a mid-cycle diagmon capture, a real `OperationStart` payload)
- [x] `npm test` and `npx tsc --noEmit` pass locally

## Guidelines checklist

- [x] Maps the device protocol to Home Assistant with little or no extra logic - no timers,
      schedules, or safety locks implemented here
- [x] Doesn't circumvent any device-side safety feature
- [x] If any code here was LLM-generated, I understand it and can explain the reasoning
      behind it
