### PR TITLE
Add support for the LG F4W1175YW (Y_VB_Y___W.B32QEUK) washer

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The following appliances are currently supported in rethink:
     - 👍 WM3900HBA (F3L2CYU\_\_), Front-Load Washing Machine - mostly working
     - 👍 FV1413H2B, Washing Machine - mostly working,
     - 👍 F3L7CYK5W_US_WIFI, Front-Load Washing Machine - mostly working
+    - 👍 F4W1175YW (Y_VB_Y\_\_\_W.B32QEUK), Vivace Front-Load Washing Machine - mostly working
 - Dryers:
     - 🫤 DLE7300WE - preliminary support
     - 👍 DLEX3900B (RV13B6BSD_D_US_WIFI), Electric Dryer - mostly working

--- a/cloud/devices/Y_VB_Y___W.B32QEUK.ts
+++ b/cloud/devices/Y_VB_Y___W.B32QEUK.ts
@@ -18,19 +18,29 @@ export default class Device extends AABBDevice {
     // consecutive frames seen with an empty selection block
     emptyStreak = 0
 
+    // pending status re-reads scheduled after a write
+    statusPollTimers: ReturnType<typeof setTimeout>[] = []
+
     constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
         super(HA, thinq)
         this.setConfig(
             allowExtendedType({
                 ...HADevice.config(meta, { name: 'LG Washer' }),
                 components: {
+                    // F02A0100 is a power-button press, not "set to on": sending it twice turns
+                    // the appliance on and then off again. There is also no usable feedback -
+                    // after a power change the appliance goes quiet for up to 40 seconds and
+                    // ignores F0ED status requests in the meantime, so a switch spent most of
+                    // its time showing the previous state. A button matches both the command and
+                    // what can actually be observed; `status` carries the real state once it
+                    // arrives.
                     power: {
-                        platform: 'switch',
+                        platform: 'button',
                         unique_id: '$deviceid-power',
-                        state_topic: '$this/power',
                         command_topic: '$this/power/set',
-                        name: '',
-                        icon: 'mdi:washing-machine',
+                        payload_press: '',
+                        name: 'Power',
+                        icon: 'mdi:power',
                     },
                     start: {
                         platform: 'button',
@@ -265,16 +275,23 @@ export default class Device extends AABBDevice {
         // not yet - and treating that as standby flipped the switch to OFF on a running
         // machine. Real standby lasts minutes, so wait for a second consecutive empty frame
         // and drop the lone one instead of publishing anything from it.
+        // The Wi-Fi module stays awake after the panel is switched off and keeps reporting
+        // status=1 ("Ready") with the whole selection zeroed, so status>0 on its own would claim
+        // the machine is ready when it is dead. There is no separate power bit: standby is
+        // exactly "status 1 with nothing selected".
+        //
+        // One empty frame is not proof of standby, though - the first reply to F0ED arrives
+        // sparse, with the clock populated but the selection not. Only `status` waits for a
+        // second consecutive empty frame; every other field is still published, because this
+        // appliance reports rarely enough that dropping a whole frame is expensive.
         const selectionEmpty = status === 1 && course === 0 && spin === 0 && temp === 0
         this.emptyStreak = selectionEmpty ? this.emptyStreak + 1 : 0
-        if (selectionEmpty && this.emptyStreak < 2) return
-
         const powered = status > 0 && !selectionEmpty
+        const statusDecided = !selectionEmpty || this.emptyStreak >= 2
 
-        this.publishProperty('power', powered ? 'ON' : 'OFF')
         this.publishProperty('error_message', ERRORS[error] ?? 'unknown') // publish message before set error state
         this.publishProperty('error', error ? 'ON' : 'OFF')
-        this.publishProperty('status', powered ? (STATES[status] ?? 'unknown') : 'Off')
+        if (statusDecided) this.publishProperty('status', powered ? (STATES[status] ?? 'unknown') : 'Off')
         this.publishProperty('course', COURSES_VB[course] ?? 'unknown')
         // Spin and temperature are selections, not live readings, and the appliance stops
         // reporting them part-way through: temperature drops to 0 when Rinsing starts and spin
@@ -302,16 +319,31 @@ export default class Device extends AABBDevice {
         this.publishProperty('delay_end', delay_end)
     }
 
-    setProperty(prop: string, mqttValue: string) {
-        if (prop === 'power') {
-            if (mqttValue === 'ON') {
-                this.send(Buffer.from('F02A0100', 'hex'))
-            } else if (mqttValue === 'OFF') {
-                this.send(Buffer.from('F024010100', 'hex'))
-            }
+    // The appliance does not report a power change on its own. Switching the panel off makes it
+    // fall silent after a couple of frames, and waking it produces nothing at all, because the
+    // MQTT session survives and nothing re-issues the F0ED status request that start() sends on
+    // connect. Home Assistant was left showing whatever it knew before the command. So re-read
+    // the state after every write; the retries cover the appliance being busy repeating an
+    // unanswered 0x03 record, during which it ignores status requests.
+    requestStatusSoon() {
+        for (const delay of [1000, 3000, 8000]) {
+            this.statusPollTimers.push(setTimeout(() => this.start(), delay))
         }
+    }
+
+    drop() {
+        for (const timer of this.statusPollTimers) clearTimeout(timer)
+        this.statusPollTimers = []
+        super.drop()
+    }
+
+    setProperty(prop: string, mqttValue: string) {
+        // toggles the appliance, whichever way it currently is
+        if (prop === 'power') this.send(Buffer.from('F02A0100', 'hex'))
 
         if (prop === 'pause') this.send(Buffer.from('F024040100', 'hex'))
         if (prop === 'start') this.send(Buffer.from(mqttValue || 'F024050100', 'hex'))
+
+        if (prop === 'power' || prop === 'pause' || prop === 'start') this.requestStatusSoon()
     }
 }

--- a/cloud/devices/Y_VB_Y___W.B32QEUK.ts
+++ b/cloud/devices/Y_VB_Y___W.B32QEUK.ts
@@ -6,9 +6,7 @@ import { allowExtendedType } from '@/util/casting'
 import AABBDevice from './aabb_device'
 import { ERRORS, STATES, COURSES, TEMPERATURES, SPINS, DOSES } from './washer_common'
 
-// Course codes are model-specific. This appliance's panel calls 0x3a "AI Wash", while the
-// shared table maps it to "Bedding" for whichever model that was captured from, so override
-// just that entry instead of editing the shared list.
+// This panel calls 0x3a "AI Wash"; the shared table has "Bedding" for some other model.
 const COURSES_VB: Record<number, string> = { ...COURSES, 0x3a: 'AI Wash' }
 
 const HEADER_LENGTH = 14
@@ -21,13 +19,8 @@ export default class Device extends AABBDevice {
             allowExtendedType({
                 ...HADevice.config(meta, { name: 'LG Washer' }),
                 components: {
-                    // F02A0100 is a power-button press, not "set to on": sending it twice turns
-                    // the appliance on and then off again. There is also no usable feedback -
-                    // after a power change the appliance goes quiet for up to 40 seconds and
-                    // ignores F0ED status requests in the meantime, so a switch spent most of
-                    // its time showing the previous state. A button matches both the command and
-                    // what can actually be observed; `status` carries the real state once it
-                    // arrives.
+                    // A button, not a switch: F02A0100 toggles, and after a power change the
+                    // appliance reports nothing for up to 40s, so a switch showed a stale state.
                     power: {
                         platform: 'button',
                         unique_id: '$deviceid-power',
@@ -220,10 +213,8 @@ export default class Device extends AABBDevice {
     processAABB(buf: Buffer) {
         if (buf[0] !== 0x20) return
 
-        // A 14-byte header precedes the status block(s): buf[2..3] is the total frame length,
-        // buf[10] the record kind and buf[11..12] the payload length. This appliance answers
-        // the F0ED status request with a single 0xEB block and then pushes 0xEC frames, which
-        // append the previous block as well. The first block is the current state either way.
+        // 14-byte header: buf[2..3] frame length, buf[10] record kind, buf[11..12] payload
+        // length. 0xEB carries one status block, 0xEC appends the previous one; take the first.
         if (buf[10] === 0xeb && buf.length === HEADER_LENGTH + STATUS_LENGTH) {
             this.processStatus(buf.subarray(HEADER_LENGTH))
         } else if (buf[10] === 0xec && buf.length === HEADER_LENGTH + STATUS_LENGTH * 2) {
@@ -237,41 +228,26 @@ export default class Device extends AABBDevice {
         const time_initial = buf[4] * 60 + buf[5]
         const course = buf[6]
         const error = buf[7]
-        // Spin sits one byte lower than on the V8 sibling, and temperature follows it.
-        // Verified against the panel: Cotton at 800 rpm / 60 C gives buf[9]=5, buf[10]=6, and
-        // the six spin positions this machine offers (0/400/800/1000/1200/1400) come out of
-        // the shared SPINS table without touching any of its "assumed" entries. buf[11], which
-        // the V8 handler reads as temperature, never changes on this firmware.
+        // One byte lower than the V8 sibling reads them; its buf[11] never changes here.
         const spin = buf[9]
         const temp = buf[10]
         const lock_status = buf[16]
         const cycles = buf[22]
         const energy = buf[33] * 256 + buf[34]
-        // ezDispense tank levels, same offsets the F_VB_F___W.B_2QEUK handler uses once its
-        // absolute indices are rebased onto the status block.
         const detergent = buf[31]
         const softener = buf[32]
-        // Option bits, same positions the F_VB_F___W.B_2QEUK handler uses. Each one was
-        // confirmed on its own by the effect it has on the estimated cycle time: 0x01
-        // TurboWash shortened it by 28 min, 0x40 pre-wash added 17, 0x80 steam added 51.
-        // F_VB_F's 0x08 (eco hybrid) never appears here - that is a dryer option.
         const options = buf[15]
-        // Delay is a plain hour count, not a bit. Stepping the panel gave 3 then 4.
         const delay_end = buf[13]
 
-        // The Wi-Fi module stays awake after the panel is switched off and keeps reporting
-        // status=1 ("Ready") with the whole selection zeroed. There is no separate power bit:
-        // standby is exactly "status 1 with nothing selected".
+        // No power bit: switched off, the module stays awake and reports status=1 with the
+        // selection zeroed.
         const powered = status > 0 && !(course === 0 && spin === 0 && temp === 0)
 
         this.publishProperty('error_message', ERRORS[error] ?? 'unknown') // publish message before set error state
         this.publishProperty('error', error ? 'ON' : 'OFF')
         this.publishProperty('status', powered ? (STATES[status] ?? 'unknown') : 'Off')
         this.publishProperty('course', COURSES_VB[course] ?? 'unknown')
-        // Spin and temperature are selections, not live readings, and the appliance stops
-        // reporting them part-way through: temperature drops to 0 when Rinsing starts and spin
-        // drops to 0 at End. Holding the last reported value keeps the sensors showing what was
-        // actually selected instead of blanking out mid-cycle; a powered-off machine clears them.
+        // temp stops being reported at Rinsing and spin at End; hold the selected value.
         if (!powered) {
             this.publishProperty('spin', 'unknown')
             this.publishProperty('temp', 'unknown')
@@ -295,9 +271,7 @@ export default class Device extends AABBDevice {
     }
 
     setProperty(prop: string, mqttValue: string) {
-        // toggles the appliance, whichever way it currently is
         if (prop === 'power') this.send(Buffer.from('F02A0100', 'hex'))
-
         if (prop === 'pause') this.send(Buffer.from('F024040100', 'hex'))
         if (prop === 'start') this.send(Buffer.from(mqttValue || 'F024050100', 'hex'))
     }

--- a/cloud/devices/Y_VB_Y___W.B32QEUK.ts
+++ b/cloud/devices/Y_VB_Y___W.B32QEUK.ts
@@ -1,0 +1,317 @@
+import HADevice from './base'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import AABBDevice from './aabb_device'
+import { ERRORS, STATES, COURSES, TEMPERATURES, SPINS, DOSES } from './washer_common'
+
+// Course codes are model-specific. This appliance's panel calls 0x3a "AI Wash", while the
+// shared table maps it to "Bedding" for whichever model that was captured from, so override
+// just that entry instead of editing the shared list.
+const COURSES_VB: Record<number, string> = { ...COURSES, 0x3a: 'AI Wash' }
+
+const HEADER_LENGTH = 14
+const STATUS_LENGTH = 39
+
+export default class Device extends AABBDevice {
+    // consecutive frames seen with an empty selection block
+    emptyStreak = 0
+
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: 'LG Washer' }),
+                components: {
+                    power: {
+                        platform: 'switch',
+                        unique_id: '$deviceid-power',
+                        state_topic: '$this/power',
+                        command_topic: '$this/power/set',
+                        name: '',
+                        icon: 'mdi:washing-machine',
+                    },
+                    start: {
+                        platform: 'button',
+                        unique_id: '$deviceid-start',
+                        command_topic: '$this/start/set',
+                        payload_press: '',
+                        name: 'Start',
+                        icon: 'mdi:play-circle-outline',
+                    },
+                    pause: {
+                        platform: 'button',
+                        unique_id: '$deviceid-pause',
+                        command_topic: '$this/pause/set',
+                        payload_press: '',
+                        name: 'Pause',
+                        icon: 'mdi:pause-circle-outline',
+                    },
+                    status: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-status',
+                        state_topic: '$this/status',
+                        name: 'Status',
+                        icon: 'mdi:state-machine',
+                        device_class: 'enum',
+                        options: STATES.filter((a) => a !== undefined),
+                    },
+                    error: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-error',
+                        state_topic: '$this/error',
+                        name: 'Error',
+                        icon: 'mdi:check-circle',
+                        device_class: 'problem',
+                        entity_category: 'diagnostic',
+                    },
+                    error_message: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-error-message',
+                        state_topic: '$this/error_message',
+                        name: 'Error message',
+                        icon: 'mdi:alert-circle-outline',
+                        device_class: 'enum',
+                        entity_category: 'diagnostic',
+                        options: ERRORS.filter((a) => a !== undefined),
+                    },
+                    course: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-course',
+                        state_topic: '$this/course',
+                        name: 'Course',
+                        icon: 'mdi:pin-outline',
+                    },
+                    temp: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-temp',
+                        state_topic: '$this/temp',
+                        name: 'Temperature',
+                        device_class: 'temperature',
+                        unit_of_measurement: '°C',
+                        suggested_display_precision: 0,
+                        value_template: "{{ value if value | is_number else 'None' }}",
+                    },
+                    spin: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-spin',
+                        state_topic: '$this/spin',
+                        name: 'Spin',
+                        icon: 'mdi:autorenew',
+                        unit_of_measurement: 'RPM',
+                        value_template: "{{ value if value | is_number else 'None' }}",
+                    },
+                    cycles: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-cycles',
+                        state_topic: '$this/cycles',
+                        name: 'Cycle count',
+                        icon: 'mdi:counter',
+                    },
+                    remote_start: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-remote_start',
+                        state_topic: '$this/remote_start',
+                        name: 'Remote start',
+                        icon: 'mdi:play-circle-outline',
+                    },
+                    door_lock: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-door_lock',
+                        state_topic: '$this/door_lock',
+                        name: 'Door lock',
+                        device_class: 'lock',
+                    },
+                    turbowash: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-turbowash',
+                        state_topic: '$this/turbowash',
+                        name: 'TurboWash',
+                        icon: 'mdi:speedometer',
+                    },
+                    prewash: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-prewash',
+                        state_topic: '$this/prewash',
+                        name: 'Pre-wash',
+                        icon: 'mdi:water-sync',
+                    },
+                    steam: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-steam',
+                        state_topic: '$this/steam',
+                        name: 'Steam',
+                        icon: 'mdi:weather-dust',
+                    },
+                    delay_end: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-delay_end',
+                        state_topic: '$this/delay_end',
+                        name: 'Delay end',
+                        icon: 'mdi:clock-outline',
+                        device_class: 'duration',
+                        unit_of_measurement: 'h',
+                    },
+                    child_lock: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-child_lock',
+                        state_topic: '$this/child_lock',
+                        name: 'Child lock',
+                        icon: 'mdi:account-lock',
+                    },
+                    energy: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-energy',
+                        state_topic: '$this/energy',
+                        name: 'Energy',
+                        icon: 'mdi:lightning-bolt',
+                        device_class: 'energy',
+                        state_class: 'total_increasing',
+                        unit_of_measurement: 'Wh',
+                    },
+                    initial_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-initial_time',
+                        state_topic: '$this/initial_time',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        name: 'Initial time',
+                    },
+                    detergent: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-detergent',
+                        state_topic: '$this/detergent',
+                        name: 'Detergent dose',
+                        icon: 'mdi:cup',
+                        device_class: 'enum',
+                        options: DOSES,
+                    },
+                    softener: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-softener',
+                        state_topic: '$this/softener',
+                        name: 'Softener dose',
+                        icon: 'mdi:cup-outline',
+                        device_class: 'enum',
+                        options: DOSES,
+                    },
+                    remaining_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-remaining_time',
+                        state_topic: '$this/remaining_time',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        name: 'Remaining time',
+                    },
+                },
+            }),
+        )
+    }
+
+    start() {
+        this.send(Buffer.from('F0ED1121010000001800', 'hex'))
+    }
+
+    processAABB(buf: Buffer) {
+        if (buf[0] !== 0x20) return
+
+        // A 14-byte header precedes the status block(s): buf[2..3] is the total frame length,
+        // buf[10] the record kind and buf[11..12] the payload length. This appliance answers
+        // the F0ED status request with a single 0xEB block and then pushes 0xEC frames, which
+        // append the previous block as well. The first block is the current state either way.
+        if (buf[10] === 0xeb && buf.length === HEADER_LENGTH + STATUS_LENGTH) {
+            this.processStatus(buf.subarray(HEADER_LENGTH))
+        } else if (buf[10] === 0xec && buf.length === HEADER_LENGTH + STATUS_LENGTH * 2) {
+            this.processStatus(buf.subarray(HEADER_LENGTH, HEADER_LENGTH + STATUS_LENGTH))
+        }
+    }
+
+    processStatus(buf: Buffer) {
+        const status = buf[1]
+        const time_remain = buf[2] * 60 + buf[3]
+        const time_initial = buf[4] * 60 + buf[5]
+        const course = buf[6]
+        const error = buf[7]
+        // Spin sits one byte lower than on the V8 sibling, and temperature follows it.
+        // Verified against the panel: Cotton at 800 rpm / 60 C gives buf[9]=5, buf[10]=6, and
+        // the six spin positions this machine offers (0/400/800/1000/1200/1400) come out of
+        // the shared SPINS table without touching any of its "assumed" entries. buf[11], which
+        // the V8 handler reads as temperature, never changes on this firmware.
+        const spin = buf[9]
+        const temp = buf[10]
+        const lock_status = buf[16]
+        const cycles = buf[22]
+        const energy = buf[33] * 256 + buf[34]
+        // ezDispense tank levels, same offsets the F_VB_F___W.B_2QEUK handler uses once its
+        // absolute indices are rebased onto the status block.
+        const detergent = buf[31]
+        const softener = buf[32]
+        // Option bits, same positions the F_VB_F___W.B_2QEUK handler uses. Each one was
+        // confirmed on its own by the effect it has on the estimated cycle time: 0x01
+        // TurboWash shortened it by 28 min, 0x40 pre-wash added 17, 0x80 steam added 51.
+        // F_VB_F's 0x08 (eco hybrid) never appears here - that is a dryer option.
+        const options = buf[15]
+        // Delay is a plain hour count, not a bit. Stepping the panel gave 3 then 4.
+        const delay_end = buf[13]
+
+        // The Wi-Fi module stays awake after the panel is switched off and keeps reporting
+        // status=1 ("Ready") with the whole selection zeroed, so status>0 on its own made the
+        // HA switch snap back to ON right after being turned off. There is no separate power
+        // bit: standby is exactly "status 1 with nothing selected".
+        //
+        // One empty frame is not enough to act on, though. The first reply to the F0ED status
+        // request arrives sparse - the clock is populated but course, spin and temperature are
+        // not yet - and treating that as standby flipped the switch to OFF on a running
+        // machine. Real standby lasts minutes, so wait for a second consecutive empty frame
+        // and drop the lone one instead of publishing anything from it.
+        const selectionEmpty = status === 1 && course === 0 && spin === 0 && temp === 0
+        this.emptyStreak = selectionEmpty ? this.emptyStreak + 1 : 0
+        if (selectionEmpty && this.emptyStreak < 2) return
+
+        const powered = status > 0 && !selectionEmpty
+
+        this.publishProperty('power', powered ? 'ON' : 'OFF')
+        this.publishProperty('error_message', ERRORS[error] ?? 'unknown') // publish message before set error state
+        this.publishProperty('error', error ? 'ON' : 'OFF')
+        this.publishProperty('status', powered ? (STATES[status] ?? 'unknown') : 'Off')
+        this.publishProperty('course', COURSES_VB[course] ?? 'unknown')
+        // Spin and temperature are selections, not live readings, and the appliance stops
+        // reporting them part-way through: temperature drops to 0 when Rinsing starts and spin
+        // drops to 0 at End. Holding the last reported value keeps the sensors showing what was
+        // actually selected instead of blanking out mid-cycle; a powered-off machine clears them.
+        if (!powered) {
+            this.publishProperty('spin', 'unknown')
+            this.publishProperty('temp', 'unknown')
+        } else {
+            if (spin !== 0) this.publishProperty('spin', SPINS[spin] ?? 'unknown')
+            if (temp !== 0) this.publishProperty('temp', TEMPERATURES[temp] ?? 'unknown')
+        }
+        this.publishProperty('cycles', cycles)
+        this.publishProperty('remote_start', lock_status & 2 ? 'ON' : 'OFF')
+        this.publishProperty('door_lock', !(lock_status & 0x40) ? 'ON' : 'OFF') // inverted logic, off=locked
+        this.publishProperty('child_lock', lock_status & 0x80 ? 'ON' : 'OFF')
+        this.publishProperty('initial_time', time_initial)
+        this.publishProperty('remaining_time', time_remain)
+        this.publishProperty('energy', energy)
+        this.publishProperty('detergent', DOSES[detergent] ?? 'unknown')
+        this.publishProperty('softener', DOSES[softener] ?? 'unknown')
+        this.publishProperty('turbowash', options & 0x01 ? 'ON' : 'OFF')
+        this.publishProperty('prewash', options & 0x40 ? 'ON' : 'OFF')
+        this.publishProperty('steam', options & 0x80 ? 'ON' : 'OFF')
+        this.publishProperty('delay_end', delay_end)
+    }
+
+    setProperty(prop: string, mqttValue: string) {
+        if (prop === 'power') {
+            if (mqttValue === 'ON') {
+                this.send(Buffer.from('F02A0100', 'hex'))
+            } else if (mqttValue === 'OFF') {
+                this.send(Buffer.from('F024010100', 'hex'))
+            }
+        }
+
+        if (prop === 'pause') this.send(Buffer.from('F024040100', 'hex'))
+        if (prop === 'start') this.send(Buffer.from(mqttValue || 'F024050100', 'hex'))
+    }
+}

--- a/cloud/devices/Y_VB_Y___W.B32QEUK.ts
+++ b/cloud/devices/Y_VB_Y___W.B32QEUK.ts
@@ -15,12 +15,6 @@ const HEADER_LENGTH = 14
 const STATUS_LENGTH = 39
 
 export default class Device extends AABBDevice {
-    // consecutive frames seen with an empty selection block
-    emptyStreak = 0
-
-    // pending status re-reads scheduled after a write
-    statusPollTimers: ReturnType<typeof setTimeout>[] = []
-
     constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
         super(HA, thinq)
         this.setConfig(
@@ -266,32 +260,13 @@ export default class Device extends AABBDevice {
         const delay_end = buf[13]
 
         // The Wi-Fi module stays awake after the panel is switched off and keeps reporting
-        // status=1 ("Ready") with the whole selection zeroed, so status>0 on its own made the
-        // HA switch snap back to ON right after being turned off. There is no separate power
-        // bit: standby is exactly "status 1 with nothing selected".
-        //
-        // One empty frame is not enough to act on, though. The first reply to the F0ED status
-        // request arrives sparse - the clock is populated but course, spin and temperature are
-        // not yet - and treating that as standby flipped the switch to OFF on a running
-        // machine. Real standby lasts minutes, so wait for a second consecutive empty frame
-        // and drop the lone one instead of publishing anything from it.
-        // The Wi-Fi module stays awake after the panel is switched off and keeps reporting
-        // status=1 ("Ready") with the whole selection zeroed, so status>0 on its own would claim
-        // the machine is ready when it is dead. There is no separate power bit: standby is
-        // exactly "status 1 with nothing selected".
-        //
-        // One empty frame is not proof of standby, though - the first reply to F0ED arrives
-        // sparse, with the clock populated but the selection not. Only `status` waits for a
-        // second consecutive empty frame; every other field is still published, because this
-        // appliance reports rarely enough that dropping a whole frame is expensive.
-        const selectionEmpty = status === 1 && course === 0 && spin === 0 && temp === 0
-        this.emptyStreak = selectionEmpty ? this.emptyStreak + 1 : 0
-        const powered = status > 0 && !selectionEmpty
-        const statusDecided = !selectionEmpty || this.emptyStreak >= 2
+        // status=1 ("Ready") with the whole selection zeroed. There is no separate power bit:
+        // standby is exactly "status 1 with nothing selected".
+        const powered = status > 0 && !(course === 0 && spin === 0 && temp === 0)
 
         this.publishProperty('error_message', ERRORS[error] ?? 'unknown') // publish message before set error state
         this.publishProperty('error', error ? 'ON' : 'OFF')
-        if (statusDecided) this.publishProperty('status', powered ? (STATES[status] ?? 'unknown') : 'Off')
+        this.publishProperty('status', powered ? (STATES[status] ?? 'unknown') : 'Off')
         this.publishProperty('course', COURSES_VB[course] ?? 'unknown')
         // Spin and temperature are selections, not live readings, and the appliance stops
         // reporting them part-way through: temperature drops to 0 when Rinsing starts and spin
@@ -319,31 +294,11 @@ export default class Device extends AABBDevice {
         this.publishProperty('delay_end', delay_end)
     }
 
-    // The appliance does not report a power change on its own. Switching the panel off makes it
-    // fall silent after a couple of frames, and waking it produces nothing at all, because the
-    // MQTT session survives and nothing re-issues the F0ED status request that start() sends on
-    // connect. Home Assistant was left showing whatever it knew before the command. So re-read
-    // the state after every write; the retries cover the appliance being busy repeating an
-    // unanswered 0x03 record, during which it ignores status requests.
-    requestStatusSoon() {
-        for (const delay of [1000, 3000, 8000]) {
-            this.statusPollTimers.push(setTimeout(() => this.start(), delay))
-        }
-    }
-
-    drop() {
-        for (const timer of this.statusPollTimers) clearTimeout(timer)
-        this.statusPollTimers = []
-        super.drop()
-    }
-
     setProperty(prop: string, mqttValue: string) {
         // toggles the appliance, whichever way it currently is
         if (prop === 'power') this.send(Buffer.from('F02A0100', 'hex'))
 
         if (prop === 'pause') this.send(Buffer.from('F024040100', 'hex'))
         if (prop === 'start') this.send(Buffer.from(mqttValue || 'F024050100', 'hex'))
-
-        if (prop === 'power' || prop === 'pause' || prop === 'start') this.requestStatusSoon()
     }
 }

--- a/cloud/devices/Y_VB_Y___W.B32QEUK.ts
+++ b/cloud/devices/Y_VB_Y___W.B32QEUK.ts
@@ -233,7 +233,7 @@ export default class Device extends AABBDevice {
         const temp = buf[10]
         const lock_status = buf[16]
         const cycles = buf[22]
-        const energy = buf[33] * 256 + buf[34]
+        const energy = buf[29] * 256 + buf[30]
         const detergent = buf[31]
         const softener = buf[32]
         const options = buf[15]

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -9,6 +9,7 @@ import Dev_2REB1GLVB1__2 from './devices/2REB1GLVB1__2'
 import Dev_2RES1VE600FWC from './devices/2RES1VE600FWC'
 import Dev_STUDIO_HOOD from './devices/STUDIO_HOOD'
 import Y_V8_Y___W_B32QEUK from './devices/Y_V8_Y___W.B32QEUK'
+import Y_VB_Y___W_B32QEUK from './devices/Y_VB_Y___W.B32QEUK'
 import F_V8_Y___W_B_2QEUK from './devices/F_V8_Y___W.B_2QEUK'
 import Y_V8_F___W_B_2QEUK from './devices/Y_V8_F___W.B_2QEUK'
 import F_V__F___W_B_1QEUK from './devices/F_V__F___W.B_1QEUK'
@@ -48,6 +49,10 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['2RES1VE600FWC']: Dev_2RES1VE600FWC,
     ['STUDIO_HOOD']: Dev_STUDIO_HOOD,
     ['Y_V8_Y___W.B32QEUK']: Y_V8_Y___W_B32QEUK,
+    // LG F4W1175YW (Vivace). Same washer family, but the VB firmware (protocolVer 7,
+    // RTK_RTL8720cm) pushes the doubled 0xEC status frame and carries spin/temperature one
+    // byte lower, so it needs its own handler rather than an alias.
+    ['Y_VB_Y___W.B32QEUK']: Y_VB_Y___W_B32QEUK,
     ['F_V7_Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK, // NOTE: we reuse F_V8_Y___W_B_2QEUK as the models appear to be compatible
     ['F_V8_Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK,
     ['Y_V8_F___W.B_2QEUK']: Y_V8_F___W_B_2QEUK,

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -49,9 +49,6 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['2RES1VE600FWC']: Dev_2RES1VE600FWC,
     ['STUDIO_HOOD']: Dev_STUDIO_HOOD,
     ['Y_V8_Y___W.B32QEUK']: Y_V8_Y___W_B32QEUK,
-    // LG F4W1175YW (Vivace). Same washer family, but the VB firmware (protocolVer 7,
-    // RTK_RTL8720cm) pushes the doubled 0xEC status frame and carries spin/temperature one
-    // byte lower, so it needs its own handler rather than an alias.
     ['Y_VB_Y___W.B32QEUK']: Y_VB_Y___W_B32QEUK,
     ['F_V7_Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK, // NOTE: we reuse F_V8_Y___W_B_2QEUK as the models appear to be compatible
     ['F_V8_Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK,

--- a/tests/cloud/devices/Y_VB_Y___W.B32QEUK.test.ts
+++ b/tests/cloud/devices/Y_VB_Y___W.B32QEUK.test.ts
@@ -3,7 +3,6 @@ import assert from 'node:assert/strict'
 import DUT from '@/cloud/devices/Y_VB_Y___W.B32QEUK'
 import type { Metadata } from '@/cloud/thinq'
 import { MockHAConnection, MockThinq2Device, buf, hex } from '@/tests/helpers/mocks'
-import { enableMockTimers, tickMockTimers } from '@/tests/helpers/timers'
 
 const DEVICE_ID = 'test-id'
 const MODEL_ID = 'Y_VB_Y___W.B32QEUK'
@@ -110,7 +109,6 @@ describe(MODEL_ID, () => {
     test('doubled 0xEC frame decodes the current status block', () => {
         const { ha, thinq } = makeDevice()
         thinq.emit('data', SAMPLE_EC_PANEL_OFF)
-        thinq.emit('data', SAMPLE_EC_PANEL_OFF)
         const props = ha.devices[DEVICE_ID].properties
         assert.equal(props.status, 'Off')
         assert.equal(props.error, 'OFF')
@@ -125,7 +123,6 @@ describe(MODEL_ID, () => {
 
     test('single-block 0xEB frame decodes too', () => {
         const { ha, thinq } = makeDevice()
-        thinq.emit('data', SAMPLE_EB_PANEL_OFF)
         thinq.emit('data', SAMPLE_EB_PANEL_OFF)
         const props = ha.devices[DEVICE_ID].properties
         assert.equal(props.status, 'Off')
@@ -180,44 +177,8 @@ describe(MODEL_ID, () => {
     test('standby is reported as powered off, not Ready', () => {
         const { ha, thinq } = makeDevice()
         thinq.emit('data', SAMPLE_EC_STANDBY)
-        thinq.emit('data', SAMPLE_EC_STANDBY)
         const props = ha.devices[DEVICE_ID].properties
         assert.equal(props.status, 'Off')
-    })
-
-    test('a lone empty frame does not flip status to Off', () => {
-        const { ha, thinq } = makeDevice()
-        // running machine reports its selection
-        thinq.emit('data', SAMPLE_EC_COTTON_800_60)
-
-        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Ready')
-
-        // the sparse reply that used to knock the state to Off
-        thinq.emit('data', SAMPLE_EB_PANEL_OFF)
-        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Ready')
-
-        // a second empty frame in a row is real standby
-        thinq.emit('data', SAMPLE_EB_PANEL_OFF)
-        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Off')
-    })
-
-    test('an empty frame does not reset a run of populated frames', () => {
-        const { ha, thinq } = makeDevice()
-        thinq.emit('data', SAMPLE_EB_PANEL_OFF)
-        thinq.emit('data', SAMPLE_EC_COTTON_800_60)
-        thinq.emit('data', SAMPLE_EB_PANEL_OFF)
-        // only one empty frame since the last populated one, so the state still says ON
-    })
-
-    test('a sparse frame still updates the fields it does carry', () => {
-        const { ha, thinq } = makeDevice()
-        thinq.emit('data', SAMPLE_EC_COTTON_800_60)
-        assert.equal(ha.devices[DEVICE_ID].properties.remaining_time, 229)
-
-        // status is held back on a lone empty frame, but the frame is not dropped wholesale
-        thinq.emit('data', SAMPLE_EB_PANEL_OFF)
-        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Ready')
-        assert.equal(ha.devices[DEVICE_ID].properties.remaining_time, 45)
     })
 
     test('option bits are reported one at a time', () => {
@@ -309,35 +270,6 @@ describe(MODEL_ID, () => {
         const before = ha.devices[DEVICE_ID].properties.power
         thinq.emit('data', buf('001122'))
         assert.equal(ha.devices[DEVICE_ID].properties.power, before)
-    })
-
-    test('a write is followed by status re-reads, since the appliance reports nothing itself', (t) => {
-        enableMockTimers(t)
-        const { thinq, dev } = makeDevice()
-        thinq.resetRecorder()
-
-        dev.setProperty('power', '')
-        assert.equal(hex(thinq.outbox[0]), WRITE_POWER_PRESS)
-        assert.equal(thinq.outbox.length, 1, 'nothing extra sent synchronously')
-
-        tickMockTimers(t, 1000)
-        assert.equal(hex(thinq.outbox[1]), WRITE_INIT)
-
-        tickMockTimers(t, 7000)
-        assert.equal(thinq.outbox.length, 4, 'three retries in total')
-        assert.ok(thinq.outbox.slice(1).every((p) => hex(p) === WRITE_INIT))
-    })
-
-    test('pending status re-reads are cancelled when the device drops', (t) => {
-        enableMockTimers(t)
-        const { thinq, dev } = makeDevice()
-        thinq.resetRecorder()
-
-        dev.setProperty('power', '')
-        dev.drop()
-
-        tickMockTimers(t, 10000)
-        assert.equal(thinq.outbox.length, 1, 'only the original command was sent')
     })
 
     test('power is a single toggle press, since F02A0100 toggles the appliance', () => {

--- a/tests/cloud/devices/Y_VB_Y___W.B32QEUK.test.ts
+++ b/tests/cloud/devices/Y_VB_Y___W.B32QEUK.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import DUT from '@/cloud/devices/Y_VB_Y___W.B32QEUK'
 import type { Metadata } from '@/cloud/thinq'
 import { MockHAConnection, MockThinq2Device, buf, hex } from '@/tests/helpers/mocks'
+import { enableMockTimers, tickMockTimers } from '@/tests/helpers/timers'
 
 const DEVICE_ID = 'test-id'
 const MODEL_ID = 'Y_VB_Y___W.B32QEUK'
@@ -60,6 +61,7 @@ const SAMPLE_EC_DELAY_4H = buf(
 )
 
 const WRITE_INIT = 'AA0EF0ED1121010000001800B5BB'
+const WRITE_POWER_PRESS = 'AA08F02A010098BB'
 
 function makeDevice() {
     const ha = new MockHAConnection()
@@ -100,6 +102,9 @@ describe(MODEL_ID, () => {
         ]) {
             assert.ok(components[c], `component ${c} present`)
         }
+        // power is a stateless press, not a switch: the appliance gives no timely feedback
+        assert.equal(components.power.platform, 'button')
+        assert.equal(components.power.state_topic, undefined)
     })
 
     test('doubled 0xEC frame decodes the current status block', () => {
@@ -107,7 +112,6 @@ describe(MODEL_ID, () => {
         thinq.emit('data', SAMPLE_EC_PANEL_OFF)
         thinq.emit('data', SAMPLE_EC_PANEL_OFF)
         const props = ha.devices[DEVICE_ID].properties
-        assert.equal(props.power, 'OFF')
         assert.equal(props.status, 'Off')
         assert.equal(props.error, 'OFF')
         assert.equal(props.error_message, 'OK')
@@ -178,24 +182,23 @@ describe(MODEL_ID, () => {
         thinq.emit('data', SAMPLE_EC_STANDBY)
         thinq.emit('data', SAMPLE_EC_STANDBY)
         const props = ha.devices[DEVICE_ID].properties
-        assert.equal(props.power, 'OFF')
         assert.equal(props.status, 'Off')
     })
 
-    test('a lone empty frame publishes nothing, so a sparse F0ED reply cannot flip the switch', () => {
+    test('a lone empty frame does not flip status to Off', () => {
         const { ha, thinq } = makeDevice()
         // running machine reports its selection
         thinq.emit('data', SAMPLE_EC_COTTON_800_60)
-        assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
 
-        // the sparse reply that used to knock the switch to OFF
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Ready')
+
+        // the sparse reply that used to knock the state to Off
         thinq.emit('data', SAMPLE_EB_PANEL_OFF)
-        assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
-        assert.equal(ha.devices[DEVICE_ID].properties.course, 'Cotton')
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Ready')
 
         // a second empty frame in a row is real standby
         thinq.emit('data', SAMPLE_EB_PANEL_OFF)
-        assert.equal(ha.devices[DEVICE_ID].properties.power, 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Off')
     })
 
     test('an empty frame does not reset a run of populated frames', () => {
@@ -204,7 +207,17 @@ describe(MODEL_ID, () => {
         thinq.emit('data', SAMPLE_EC_COTTON_800_60)
         thinq.emit('data', SAMPLE_EB_PANEL_OFF)
         // only one empty frame since the last populated one, so the state still says ON
-        assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
+    })
+
+    test('a sparse frame still updates the fields it does carry', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_EC_COTTON_800_60)
+        assert.equal(ha.devices[DEVICE_ID].properties.remaining_time, 229)
+
+        // status is held back on a lone empty frame, but the frame is not dropped wholesale
+        thinq.emit('data', SAMPLE_EB_PANEL_OFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Ready')
+        assert.equal(ha.devices[DEVICE_ID].properties.remaining_time, 45)
     })
 
     test('option bits are reported one at a time', () => {
@@ -296,6 +309,42 @@ describe(MODEL_ID, () => {
         const before = ha.devices[DEVICE_ID].properties.power
         thinq.emit('data', buf('001122'))
         assert.equal(ha.devices[DEVICE_ID].properties.power, before)
+    })
+
+    test('a write is followed by status re-reads, since the appliance reports nothing itself', (t) => {
+        enableMockTimers(t)
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+
+        dev.setProperty('power', '')
+        assert.equal(hex(thinq.outbox[0]), WRITE_POWER_PRESS)
+        assert.equal(thinq.outbox.length, 1, 'nothing extra sent synchronously')
+
+        tickMockTimers(t, 1000)
+        assert.equal(hex(thinq.outbox[1]), WRITE_INIT)
+
+        tickMockTimers(t, 7000)
+        assert.equal(thinq.outbox.length, 4, 'three retries in total')
+        assert.ok(thinq.outbox.slice(1).every((p) => hex(p) === WRITE_INIT))
+    })
+
+    test('pending status re-reads are cancelled when the device drops', (t) => {
+        enableMockTimers(t)
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+
+        dev.setProperty('power', '')
+        dev.drop()
+
+        tickMockTimers(t, 10000)
+        assert.equal(thinq.outbox.length, 1, 'only the original command was sent')
+    })
+
+    test('power is a single toggle press, since F02A0100 toggles the appliance', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.setProperty('power', '')
+        assert.equal(hex(thinq.outbox[0]), WRITE_POWER_PRESS)
     })
 
     test('start() sends the F0ED status request', () => {

--- a/tests/cloud/devices/Y_VB_Y___W.B32QEUK.test.ts
+++ b/tests/cloud/devices/Y_VB_Y___W.B32QEUK.test.ts
@@ -1,0 +1,308 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/Y_VB_Y___W.B32QEUK'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf, hex } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'Y_VB_Y___W.B32QEUK'
+const META: Metadata = { modelId: MODEL_ID, modelName: MODEL_ID, swVersion: '2.11.224' }
+
+// Real captures from an LG F4W1175YW (Vivace, EU) running the VB firmware:
+// DeviceType 201, protocolVer 7, RTK_RTL8720cm, clip_ble_v1.9.237.
+//
+// Frame layout: AA FF <14-byte header> <status block(s)> <crc16> BB, where header[2..3] is the
+// total frame length, header[10] the record kind and header[11..12] the payload length.
+// 0xEB carries one 39-byte status block (inner 53), 0xEC appends the previous block too
+// (inner 92). The appliance answers the F0ED status request with 0xEB and then pushes 0xEC.
+
+// Panel switched off: the selection bytes are zeroed while remaining_time keeps whatever the
+// last selection left behind. Lifetime counters stay readable: 19 cycles, 10782 Wh.
+const SAMPLE_EC_PANEL_OFF = buf(
+    'AAFF200A006000479E000100EC004E000001000000000000000000000000000000000000000013006400000000000002022A1E000001000001000000000000000000000000000000000000000013006400000000000002022A1E0040016307BB',
+)
+
+// The 0xEB reply to F0ED1121010000001800, also with the panel off and a stale 45 on the clock.
+const SAMPLE_EB_PANEL_OFF = buf(
+    'AAFF200A0039004A04000100EB0027000001002D002D0000000000000000000000000001000013006400000000000002022A1E000001017CBB',
+)
+
+// Cotton with the panel showing 800 rpm and 60 C. This is what pins the spin and temperature
+// offsets to the display instead of to a guess.
+const SAMPLE_EC_COTTON_800_60 = buf(
+    'AAFF200A0060004BE6000100EC004E000001033103310100030506010000000000000004020013006400000400000002022A1E000001000001033103310100030506010000000000000004020013006400000400000002022A1E004001EE61BB',
+)
+
+// Same appliance state twice, the child lock toggled between them: detergent tank at High,
+// softener tank empty, and buf[16] flipping between 0x80 and 0x00.
+const SAMPLE_EC_CHILD_LOCK_ON = buf(
+    'AAFF200A0060004D19000100EC004E000001003B003B3A00030A04010000000080010002020013006400000400000003002A1E000401000001003B003B3A00030A04010000000000010002020013006400000400000003002A1E0004014D9BBB',
+)
+const SAMPLE_EC_CHILD_LOCK_OFF = buf(
+    'AAFF200A0060004D3D000100EC004E000001003B003B3A00030A04010000000000010002020013006400000400000003002A1E004401000001003B003B3A00030A04010000000000010002020013006400000400000003002A1E0004010824BB',
+)
+
+// One option at a time, each captured while the panel showed only that option enabled. The
+// estimated cycle time corroborates every bit on its own: TurboWash took 28 minutes off,
+// pre-wash added 17, steam added 51.
+const SAMPLE_EC_STEAM = buf(
+    'AAFF200A0060004F7A000100EC004E000001013201323A00030A06010000008000010003000013006400000400000003002A1E000001000001013201323A00030A06010000008000010003000013006400000400000003002A1E0040014397BB',
+)
+const SAMPLE_EC_TURBOWASH = buf(
+    'AAFF200A0060004F8D000100EC004E000001030E030E0100030704010000000100000002000013006400000400000002022A1E000001000001030E030E0100030704010000000100000002000013006400000400000002022A1E00400111A8BB',
+)
+const SAMPLE_EC_PREWASH = buf(
+    'AAFF200A0060004F94000100EC004E000001033B033B0100030704010000004000000003000013006400000500000002022A1E000001000001033B033B0100030704010000004000000003000013006400000500000002022A1E004001DA2CBB',
+)
+// Delay set to 4 hours, no option bits.
+const SAMPLE_EC_DELAY_4H = buf(
+    'AAFF200A0060004FA6000100EC004E000001032A032A0100030704010004000000000003000013006400000400000002022A1E000001000001032A032A0100030704010000000000000003000013006400000400000002022A1E00000175AABB',
+)
+
+const WRITE_INIT = 'AA0EF0ED1121010000001800B5BB'
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('config exposes expected components on construction', () => {
+        const { ha } = makeDevice()
+        const cfg = ha.devices[DEVICE_ID].config
+        assert.ok(cfg, 'config published')
+        const components = cfg!.components as Record<string, Record<string, unknown>>
+        for (const c of [
+            'power',
+            'start',
+            'pause',
+            'status',
+            'error',
+            'error_message',
+            'course',
+            'temp',
+            'spin',
+            'cycles',
+            'remote_start',
+            'door_lock',
+            'child_lock',
+            'detergent',
+            'softener',
+            'turbowash',
+            'prewash',
+            'steam',
+            'delay_end',
+            'energy',
+            'initial_time',
+            'remaining_time',
+        ]) {
+            assert.ok(components[c], `component ${c} present`)
+        }
+    })
+
+    test('doubled 0xEC frame decodes the current status block', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_EC_PANEL_OFF)
+        thinq.emit('data', SAMPLE_EC_PANEL_OFF)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.power, 'OFF')
+        assert.equal(props.status, 'Off')
+        assert.equal(props.error, 'OFF')
+        assert.equal(props.error_message, 'OK')
+        assert.equal(props.remaining_time, 0)
+        assert.equal(props.initial_time, 0)
+        assert.equal(props.cycles, 19)
+        assert.equal(props.energy, 10782)
+        assert.equal(props.remote_start, 'OFF')
+        assert.equal(props.door_lock, 'ON') // unlocked, the inverted convention
+    })
+
+    test('single-block 0xEB frame decodes too', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_EB_PANEL_OFF)
+        thinq.emit('data', SAMPLE_EB_PANEL_OFF)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.status, 'Off')
+        assert.equal(props.remaining_time, 45)
+        assert.equal(props.initial_time, 45)
+        assert.equal(props.cycles, 19)
+        assert.equal(props.energy, 10782)
+    })
+
+    test('spin and temperature match the panel', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_EC_COTTON_800_60)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.course, 'Cotton')
+        assert.equal(props.spin, 800)
+        assert.equal(props.temp, 60)
+        assert.equal(props.remaining_time, 229)
+    })
+
+    test('ezDispense tank levels decode, tank 1 is the detergent', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_EC_CHILD_LOCK_ON)
+        const props = ha.devices[DEVICE_ID].properties
+        // Confirmed on the panel: tank 1 (detergent) at 3/3, tank 2 (softener) empty.
+        assert.equal(props.detergent, 'High')
+        assert.equal(props.softener, 'Off')
+    })
+
+    test('child lock tracks bit 0x80 of the lock byte', () => {
+        const on = makeDevice()
+        on.thinq.emit('data', SAMPLE_EC_CHILD_LOCK_ON)
+        assert.equal(on.ha.devices[DEVICE_ID].properties.child_lock, 'ON')
+        assert.equal(on.ha.devices[DEVICE_ID].properties.door_lock, 'ON') // 0x40 clear, so unlocked
+
+        const off = makeDevice()
+        off.thinq.emit('data', SAMPLE_EC_CHILD_LOCK_OFF)
+        assert.equal(off.ha.devices[DEVICE_ID].properties.child_lock, 'OFF')
+    })
+
+    test('course 0x3a is AI Wash on this model, not the shared table Bedding', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_EC_CHILD_LOCK_ON)
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'AI Wash')
+    })
+
+    // Captured six seconds after switching the panel off: status is back to 1 but course, spin
+    // and temperature are all zero. Reported as ON, this made the HA switch bounce back.
+    const SAMPLE_EC_STANDBY = buf(
+        'AAFF200A0060004E65000100EC004E000001033803380000000000000000000000000004000013006400000000000002022A1E004001000001033803380000000000000000000000000004000013006400000000000002022A1E000001100EBB',
+    )
+
+    test('standby is reported as powered off, not Ready', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_EC_STANDBY)
+        thinq.emit('data', SAMPLE_EC_STANDBY)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.power, 'OFF')
+        assert.equal(props.status, 'Off')
+    })
+
+    test('a lone empty frame publishes nothing, so a sparse F0ED reply cannot flip the switch', () => {
+        const { ha, thinq } = makeDevice()
+        // running machine reports its selection
+        thinq.emit('data', SAMPLE_EC_COTTON_800_60)
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
+
+        // the sparse reply that used to knock the switch to OFF
+        thinq.emit('data', SAMPLE_EB_PANEL_OFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'Cotton')
+
+        // a second empty frame in a row is real standby
+        thinq.emit('data', SAMPLE_EB_PANEL_OFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'OFF')
+    })
+
+    test('an empty frame does not reset a run of populated frames', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_EB_PANEL_OFF)
+        thinq.emit('data', SAMPLE_EC_COTTON_800_60)
+        thinq.emit('data', SAMPLE_EB_PANEL_OFF)
+        // only one empty frame since the last populated one, so the state still says ON
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
+    })
+
+    test('option bits are reported one at a time', () => {
+        const steam = makeDevice()
+        steam.thinq.emit('data', SAMPLE_EC_STEAM)
+        assert.deepEqual(
+            {
+                steam: steam.ha.devices[DEVICE_ID].properties.steam,
+                turbowash: steam.ha.devices[DEVICE_ID].properties.turbowash,
+                prewash: steam.ha.devices[DEVICE_ID].properties.prewash,
+            },
+            { steam: 'ON', turbowash: 'OFF', prewash: 'OFF' },
+        )
+
+        const turbo = makeDevice()
+        turbo.thinq.emit('data', SAMPLE_EC_TURBOWASH)
+        assert.deepEqual(
+            {
+                steam: turbo.ha.devices[DEVICE_ID].properties.steam,
+                turbowash: turbo.ha.devices[DEVICE_ID].properties.turbowash,
+                prewash: turbo.ha.devices[DEVICE_ID].properties.prewash,
+            },
+            { steam: 'OFF', turbowash: 'ON', prewash: 'OFF' },
+        )
+
+        const pre = makeDevice()
+        pre.thinq.emit('data', SAMPLE_EC_PREWASH)
+        assert.deepEqual(
+            {
+                steam: pre.ha.devices[DEVICE_ID].properties.steam,
+                turbowash: pre.ha.devices[DEVICE_ID].properties.turbowash,
+                prewash: pre.ha.devices[DEVICE_ID].properties.prewash,
+            },
+            { steam: 'OFF', turbowash: 'OFF', prewash: 'ON' },
+        )
+    })
+
+    test('delay is an hour count, not an option bit', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_EC_DELAY_4H)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.delay_end, 4)
+        assert.equal(props.turbowash, 'OFF')
+        assert.equal(props.prewash, 'OFF')
+        assert.equal(props.steam, 'OFF')
+    })
+
+    test('spin and temperature hold their last value when the appliance stops reporting them', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_EC_COTTON_800_60)
+        assert.equal(ha.devices[DEVICE_ID].properties.spin, 800)
+        assert.equal(ha.devices[DEVICE_ID].properties.temp, 60)
+
+        // Rinsing zeroes the temperature byte and End zeroes the spin byte; neither should
+        // blank the sensor while the machine is still running.
+        const rinsing = Buffer.from(SAMPLE_EC_COTTON_800_60)
+        const block = 2 + 14
+        rinsing[block + 1] = 7 // Rinsing
+        rinsing[block + 10] = 0 // temperature no longer reported
+        thinq.emit('data', rinsing)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Rinsing')
+        assert.equal(ha.devices[DEVICE_ID].properties.temp, 60)
+        assert.equal(ha.devices[DEVICE_ID].properties.spin, 800)
+
+        const ending = Buffer.from(rinsing)
+        ending[block + 1] = 10 // End
+        ending[block + 9] = 0 // spin no longer reported
+        thinq.emit('data', ending)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'End')
+        assert.equal(ha.devices[DEVICE_ID].properties.spin, 800)
+        assert.equal(ha.devices[DEVICE_ID].properties.temp, 60)
+    })
+
+    test('a 0xEC frame truncated to the single-block length is ignored', () => {
+        const { ha, thinq } = makeDevice()
+        const before = ha.devices[DEVICE_ID].properties.power
+        // declares the doubled payload but only carries one block
+        thinq.emit(
+            'data',
+            buf(
+                'AAFF200A0039000381000100EC0027000001032603260000000000000000000000000003000011007100000000000000000000000000974EBB',
+            ),
+        )
+        assert.equal(ha.devices[DEVICE_ID].properties.power, before)
+    })
+
+    test('frames not matching the AA..BB envelope are ignored', () => {
+        const { ha, thinq } = makeDevice()
+        const before = ha.devices[DEVICE_ID].properties.power
+        thinq.emit('data', buf('001122'))
+        assert.equal(ha.devices[DEVICE_ID].properties.power, before)
+    })
+
+    test('start() sends the F0ED status request', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.start()
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(hex(thinq.outbox[0]), WRITE_INIT)
+    })
+})

--- a/tests/cloud/devices/Y_VB_Y___W.B32QEUK.test.ts
+++ b/tests/cloud/devices/Y_VB_Y___W.B32QEUK.test.ts
@@ -48,6 +48,11 @@ const SAMPLE_EC_DELAY_4H = buf(
     'AAFF200A0060004FA6000100EC004E000001032A032A0100030704010004000000000003000013006400000400000002022A1E000001000001032A032A0100030704010000000000000003000013006400000400000002022A1E00000175AABB',
 )
 
+// End of a real 40 C wash; buf[29..30] = 0x01AE = 430 Wh, the exact ThinQ app figure.
+const SAMPLE_EC_WASH_END_430WH = buf(
+    'AAFF200A00600019F2000100EC004E00000A00000129050000000000000000004000000108001400640000030001AE02022A1E0002010000000000012905000000000000000000000000020A001400640000030001AE02022A1E0002016153BB',
+)
+
 const WRITE_INIT = 'AA0EF0ED1121010000001800B5BB'
 const WRITE_POWER_PRESS = 'AA08F02A010098BB'
 
@@ -104,7 +109,7 @@ describe(MODEL_ID, () => {
         assert.equal(props.remaining_time, 0)
         assert.equal(props.initial_time, 0)
         assert.equal(props.cycles, 19)
-        assert.equal(props.energy, 10782)
+        assert.equal(props.energy, 0)
         assert.equal(props.remote_start, 'OFF')
         assert.equal(props.door_lock, 'ON') // unlocked, the inverted convention
     })
@@ -117,7 +122,7 @@ describe(MODEL_ID, () => {
         assert.equal(props.remaining_time, 45)
         assert.equal(props.initial_time, 45)
         assert.equal(props.cycles, 19)
-        assert.equal(props.energy, 10782)
+        assert.equal(props.energy, 0)
     })
 
     test('spin and temperature match the panel', () => {
@@ -136,6 +141,12 @@ describe(MODEL_ID, () => {
         const props = ha.devices[DEVICE_ID].properties
         assert.equal(props.detergent, 'High')
         assert.equal(props.softener, 'Off')
+    })
+
+    test('energy is the per-cycle Wh counter at buf[29..30]', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_EC_WASH_END_430WH)
+        assert.equal(ha.devices[DEVICE_ID].properties.energy, 430)
     })
 
     test('child lock tracks bit 0x80 of the lock byte', () => {

--- a/tests/cloud/devices/Y_VB_Y___W.B32QEUK.test.ts
+++ b/tests/cloud/devices/Y_VB_Y___W.B32QEUK.test.ts
@@ -8,33 +8,24 @@ const DEVICE_ID = 'test-id'
 const MODEL_ID = 'Y_VB_Y___W.B32QEUK'
 const META: Metadata = { modelId: MODEL_ID, modelName: MODEL_ID, swVersion: '2.11.224' }
 
-// Real captures from an LG F4W1175YW (Vivace, EU) running the VB firmware:
-// DeviceType 201, protocolVer 7, RTK_RTL8720cm, clip_ble_v1.9.237.
-//
-// Frame layout: AA FF <14-byte header> <status block(s)> <crc16> BB, where header[2..3] is the
-// total frame length, header[10] the record kind and header[11..12] the payload length.
-// 0xEB carries one 39-byte status block (inner 53), 0xEC appends the previous block too
-// (inner 92). The appliance answers the F0ED status request with 0xEB and then pushes 0xEC.
+// Real captures from an LG F4W1175YW on the VB firmware (protocolVer 7, clip_ble_v1.9.237).
 
-// Panel switched off: the selection bytes are zeroed while remaining_time keeps whatever the
-// last selection left behind. Lifetime counters stay readable: 19 cycles, 10782 Wh.
+// Panel off: selection zeroed, remaining_time left over from the last selection.
 const SAMPLE_EC_PANEL_OFF = buf(
     'AAFF200A006000479E000100EC004E000001000000000000000000000000000000000000000013006400000000000002022A1E000001000001000000000000000000000000000000000000000013006400000000000002022A1E0040016307BB',
 )
 
-// The 0xEB reply to F0ED1121010000001800, also with the panel off and a stale 45 on the clock.
+// 0xEB reply to the F0ED status request, panel off.
 const SAMPLE_EB_PANEL_OFF = buf(
     'AAFF200A0039004A04000100EB0027000001002D002D0000000000000000000000000001000013006400000000000002022A1E000001017CBB',
 )
 
-// Cotton with the panel showing 800 rpm and 60 C. This is what pins the spin and temperature
-// offsets to the display instead of to a guess.
+// Panel showed Cotton, 800 rpm, 60 C.
 const SAMPLE_EC_COTTON_800_60 = buf(
     'AAFF200A0060004BE6000100EC004E000001033103310100030506010000000000000004020013006400000400000002022A1E000001000001033103310100030506010000000000000004020013006400000400000002022A1E004001EE61BB',
 )
 
-// Same appliance state twice, the child lock toggled between them: detergent tank at High,
-// softener tank empty, and buf[16] flipping between 0x80 and 0x00.
+// Identical state, child lock toggled: detergent High, softener empty, buf[16] 0x80 vs 0x00.
 const SAMPLE_EC_CHILD_LOCK_ON = buf(
     'AAFF200A0060004D19000100EC004E000001003B003B3A00030A04010000000080010002020013006400000400000003002A1E000401000001003B003B3A00030A04010000000000010002020013006400000400000003002A1E0004014D9BBB',
 )
@@ -42,9 +33,7 @@ const SAMPLE_EC_CHILD_LOCK_OFF = buf(
     'AAFF200A0060004D3D000100EC004E000001003B003B3A00030A04010000000000010002020013006400000400000003002A1E004401000001003B003B3A00030A04010000000000010002020013006400000400000003002A1E0004010824BB',
 )
 
-// One option at a time, each captured while the panel showed only that option enabled. The
-// estimated cycle time corroborates every bit on its own: TurboWash took 28 minutes off,
-// pre-wash added 17, steam added 51.
+// One option at a time, each captured with only that option enabled on the panel.
 const SAMPLE_EC_STEAM = buf(
     'AAFF200A0060004F7A000100EC004E000001013201323A00030A06010000008000010003000013006400000400000003002A1E000001000001013201323A00030A06010000008000010003000013006400000400000003002A1E0040014397BB',
 )
@@ -54,7 +43,7 @@ const SAMPLE_EC_TURBOWASH = buf(
 const SAMPLE_EC_PREWASH = buf(
     'AAFF200A0060004F94000100EC004E000001033B033B0100030704010000004000000003000013006400000500000002022A1E000001000001033B033B0100030704010000004000000003000013006400000500000002022A1E004001DA2CBB',
 )
-// Delay set to 4 hours, no option bits.
+// Delay 4 h, no option bits.
 const SAMPLE_EC_DELAY_4H = buf(
     'AAFF200A0060004FA6000100EC004E000001032A032A0100030704010004000000000003000013006400000400000002022A1E000001000001032A032A0100030704010000000000000003000013006400000400000002022A1E00000175AABB',
 )
@@ -101,7 +90,6 @@ describe(MODEL_ID, () => {
         ]) {
             assert.ok(components[c], `component ${c} present`)
         }
-        // power is a stateless press, not a switch: the appliance gives no timely feedback
         assert.equal(components.power.platform, 'button')
         assert.equal(components.power.state_topic, undefined)
     })
@@ -146,7 +134,6 @@ describe(MODEL_ID, () => {
         const { ha, thinq } = makeDevice()
         thinq.emit('data', SAMPLE_EC_CHILD_LOCK_ON)
         const props = ha.devices[DEVICE_ID].properties
-        // Confirmed on the panel: tank 1 (detergent) at 3/3, tank 2 (softener) empty.
         assert.equal(props.detergent, 'High')
         assert.equal(props.softener, 'Off')
     })
@@ -168,8 +155,7 @@ describe(MODEL_ID, () => {
         assert.equal(ha.devices[DEVICE_ID].properties.course, 'AI Wash')
     })
 
-    // Captured six seconds after switching the panel off: status is back to 1 but course, spin
-    // and temperature are all zero. Reported as ON, this made the HA switch bounce back.
+    // Six seconds after switching the panel off: status back to 1, selection zeroed.
     const SAMPLE_EC_STANDBY = buf(
         'AAFF200A0060004E65000100EC004E000001033803380000000000000000000000000004000013006400000000000002022A1E004001000001033803380000000000000000000000000004000013006400000000000002022A1E000001100EBB',
     )
@@ -232,8 +218,6 @@ describe(MODEL_ID, () => {
         assert.equal(ha.devices[DEVICE_ID].properties.spin, 800)
         assert.equal(ha.devices[DEVICE_ID].properties.temp, 60)
 
-        // Rinsing zeroes the temperature byte and End zeroes the spin byte; neither should
-        // blank the sensor while the machine is still running.
         const rinsing = Buffer.from(SAMPLE_EC_COTTON_800_60)
         const block = 2 + 14
         rinsing[block + 1] = 7 // Rinsing


### PR DESCRIPTION
Adds a handler for `Y_VB_Y___W.B32QEUK` — LG F4W1175YW (Vivace, EU), protocolVer 7.

Dzięki mordeczko za fajny projekt :)