### PR TITLE
RAC_056905_WW: Don't unconditionally turn off features if the device re-connects

### DIFF
--- a/cloud/devices/RAC_056905_WW.ts
+++ b/cloud/devices/RAC_056905_WW.ts
@@ -961,7 +961,7 @@ export default class Device extends TLVDevice {
         name: string,
         desc: string,
         icon: string,
-        field_name: 'airClean' | 'jetMode' | 'energySave',
+        field_name: 'airClean' | 'energySave',
         check_mode?: CheckMode,
     ) {
         const comp = {

--- a/cloud/devices/RAC_056905_WW.ts
+++ b/cloud/devices/RAC_056905_WW.ts
@@ -17,9 +17,9 @@ export default class Device extends TLVDevice {
     powerStatePrev?: boolean
     modeChangeHooks: PowerModeChangeHook[] = []
     modePrev?: string
-    airClean: boolean = false
-    jetMode: boolean = false
-    energySave: boolean = false
+    airClean: boolean | undefined
+    jetMode: boolean | undefined
+    energySave: boolean | undefined
     tlvBlacklistDisableTimer: ReturnType<typeof setTimeout> | undefined
     increasedQueryIntervalTimeout: ReturnType<typeof setTimeout> | undefined
     filterUsedTime: number = 0
@@ -868,6 +868,7 @@ export default class Device extends TLVDevice {
          * but in a separate message.
          */
         this.modeChangeHooks.push(() => {
+            if (this.jetMode == null) return
             this.setProperty(name + '-', this.jetMode ? 'ON' : 'OFF')
         })
     }
@@ -1001,10 +1002,12 @@ export default class Device extends TLVDevice {
 
         if (!!check_mode) {
             this.modeChangeHooks.push(() => {
+                if (this[field_name] == null) return
                 this.setProperty(name + '-', this[field_name] ? 'ON' : 'OFF')
             })
         } else {
             this.powerChangeHooks.push(() => {
+                if (this[field_name] == null) return
                 if (this.getPowerTLV() === 0) return
                 /*
                  * This value needs to be written at each power up,


### PR DESCRIPTION
Make sure that we don't write unknown `airClean`, `jetMode` or `energySave` initial value.

Otherwise if the device disconnects from rethink then re-connects while it is running we'll always unconditionally turn each of these features OFF.

Since these devices re-connect from time to time the previous logic resulted in these features "randomly" turning off, which is definitely not what a user would expect.