### PR TITLE
Add PR/issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Something isn't working as expected
+title: ''
+labels: bug
+---
+
+## What happened
+
+## What you expected
+
+## Environment
+
+- rethink version/image tag (e.g. `:dev`, a release tag, or a commit hash):
+- Device model(s) involved, if relevant:
+- Bridge mode enabled? yes / no
+
+## Logs
+
+<!-- Relevant rethink-cloud log output. Enable more detail in config.json's `log` array if
+     needed (e.g. "incoming", "HTTPS") - see the installation guide. Redact anything you
+     don't want public (device IDs, account info). -->

--- a/.github/ISSUE_TEMPLATE/device_request.md
+++ b/.github/ISSUE_TEMPLATE/device_request.md
@@ -1,0 +1,22 @@
+---
+name: Device support request
+about: Ask for (or track) support for an appliance rethink doesn't translate yet
+title: 'Support for '
+labels: new device
+---
+
+## Device
+
+- Brand / official model name:
+- ThinQ Model ID (from provisioning, or the ThinQ app's device settings):
+- Platform (if known): ThinQ1 / ThinQ2
+
+## What you have available
+
+- [ ] I have the physical device and can test against it
+- [ ] I have (or can create) an LG ThinQ account for [bridge mode](https://github.com/anszom/rethink/wiki/Bridge)
+- [ ] I'm willing to help with the reverse-engineering, not just requesting it
+
+<!-- If you're planning to work on this yourself, see the contributor guide:
+     https://github.com/anszom/rethink/wiki/Adding-support-for-a-new-device
+     Mentioning that here lets others know it's being worked on. -->

--- a/.github/PULL_REQUEST_TEMPLATE/device_support.md
+++ b/.github/PULL_REQUEST_TEMPLATE/device_support.md
@@ -1,0 +1,32 @@
+<!--
+New device support PR. See the contributor guide before opening this:
+https://github.com/anszom/rethink/wiki/Adding-support-for-a-new-device
+
+Delete this comment block before submitting.
+-->
+
+## Device
+
+- Brand / model name:
+- ThinQ Model ID:
+- Platform: ThinQ1 / TLV / AABB
+- Related issue (if one exists):
+
+## What's supported
+
+<!-- What Home Assistant entities does this expose? What's read-only vs. controllable?
+     Call out anything you deliberately left out and why (e.g. a feature you couldn't
+     confirm safely, or one that would require behaviour rethink shouldn't implement). -->
+
+## How this was verified
+
+- [ ] Checked against `modelJson` (ThinQ1) or decoded packet captures (TLV/AABB) - not just guessed from the app's UI
+- [ ] Tested against a real physical device, not just synthetic data
+- [ ] Added a unit test under `tests/cloud/devices/` built from real captured data where possible
+- [ ] `npm test` and `npx tsc --noEmit` pass locally
+
+## Guidelines checklist
+
+- [ ] Maps the device protocol to Home Assistant with little or no extra logic - no timers, schedules, or safety locks implemented here (those belong in Home Assistant)
+- [ ] Doesn't circumvent any device-side safety feature
+- [ ] If any code here was LLM-generated, I understand it and can explain the reasoning behind it

--- a/.github/PULL_REQUEST_TEMPLATE/general.md
+++ b/.github/PULL_REQUEST_TEMPLATE/general.md
@@ -1,0 +1,15 @@
+<!--
+Adding support for a new device? Use the device support template instead:
+https://github.com/anszom/rethink/compare/master...your-branch?template=device_support.md
+
+Delete this comment block before submitting.
+-->
+
+## Summary
+
+<!-- What does this change, and why? -->
+
+## Test plan
+
+<!-- How did you verify this? `npm test` output, manual steps, a real device you tested
+     against - whatever's relevant. -->


### PR DESCRIPTION
## Summary

Adds four templates: `bug_report.md` and `device_request.md` issue templates, plus
`device_support.md` and `general.md` PR templates - this PR's own description uses
`general.md`. Upstream already has its own `CONTRIBUTING.md` covering contribution
guidelines; these just add the templates that structure the report/PR itself, and
`device_support.md`'s checklist deliberately mirrors `CONTRIBUTING.md`'s own device-support
rules (real captures over synthetic data, no debugging entities, etc.) so filling it out
double-checks compliance rather than duplicating a separate set of rules.

## Test plan

- [x] Verified both issue templates' YAML frontmatter has GitHub's expected keys
      (`name`/`about`/`title`/`labels`)
- [x] This PR's own description was written using `general.md`, as a working example
