### PR TITLE
Add LG LREL6323S oven and cooktop status support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The following appliances are currently supported in rethink:
     - 👍 MD19GQGE0, Smart Dehumidifier - mostly working
 - Range Hoods:
     - 👍 HCED3015D (STUDIO_HOOD), Generic identifier and probably works with multiple models. Working.
+- Ovens and Ranges:
+    - 🫤 LREL6323S (WLREL6323S), Electric range - preliminary read-only oven and cooktop support
 - Stylers:
     - 👍 S5BBP (ST_B_E4H01Y_APL), Styler - mostly working
 

--- a/cloud/devices/WLREL6323S.ts
+++ b/cloud/devices/WLREL6323S.ts
@@ -1,0 +1,157 @@
+import HADevice from './base'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import AABBDevice from './aabb_device'
+import log from '@/util/logging'
+
+// LG LREL6323S electric range, reporting modelName "WLREL6323S" (deviceType 301).
+//
+// Captures from the physical panel establish the single-cavity oven fields, door-open bit,
+// and aggregate cooktop state. Normal elements and the warming zone use different bytes, but
+// individual normal elements report the same transition, so no individual entities are exposed.
+// Writes remain disabled until their complete command shapes and appliance interlocks are captured.
+
+const CLASS_BYTE = 0x40
+const SINGLE_STATUS_FRAME_TYPE = 0xeb
+const STATUS_FRAME_TYPE = 0xec
+const STATUS_RECORD_LENGTH = 62
+
+const OVEN_STATE_OFFSET = 0
+const OVEN_MODE_OFFSET = 1
+const OVEN_SET_TEMPERATURE_OFFSET = 5
+const OVEN_DOOR_FLAGS_OFFSET = 11
+const OVEN_DOOR_OPEN_MASK = 0x08
+// Normal surface elements set bytes 36 and 38 together; the warming zone sets
+// bytes 37 and 39 together. Treat all four as one read-only cooktop status.
+const COOKTOP_STATE_OFFSETS = [36, 37, 38, 39]
+
+const OVEN_STATE_NAMES: Record<number, string> = {
+    0x00: 'Idle',
+    0x01: 'Preheating',
+    0x02: 'Cooking',
+    0x04: 'Cooling',
+    0x09: 'Cleaning',
+}
+const OVEN_MODE_NAMES: Record<number, string> = {
+    0x00: 'None',
+    0x01: 'Bake',
+    0x03: 'Convection Bake',
+    0x04: 'Convection Roast',
+    0x07: 'Broil',
+    0x08: 'Warm',
+    0x0d: 'EasyClean',
+    0x0f: 'Self Clean',
+    0x10: 'Air Fry',
+}
+const OVEN_STATE_OPTIONS = Object.values(OVEN_STATE_NAMES)
+const OVEN_MODE_OPTIONS = Object.values(OVEN_MODE_NAMES)
+
+// Observed from LG's cloud and confirmed against the WLREL6323S: the reply is a 40 EB status frame.
+const STATUS_QUERY = 'f0ed114101000000181a0207080c14191a1e262b30353a00000000000000000000000000'
+
+export default class Device extends AABBDevice {
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: 'LG Electric Range' }),
+                components: {
+                    cooktop_status: {
+                        platform: 'binary_sensor',
+                        icon: 'mdi:stove',
+                        unique_id: '$deviceid-cooktop_status',
+                        state_topic: '$this/cooktop_status',
+                        name: 'Cooktop',
+                        payload_on: 'ON',
+                        payload_off: 'OFF',
+                    },
+                    oven_status: {
+                        platform: 'sensor',
+                        device_class: 'enum',
+                        icon: 'mdi:stove',
+                        unique_id: '$deviceid-oven_status',
+                        state_topic: '$this/oven_status',
+                        name: 'Oven Status',
+                        options: OVEN_STATE_OPTIONS,
+                    },
+                    oven_mode: {
+                        platform: 'sensor',
+                        device_class: 'enum',
+                        icon: 'mdi:chef-hat',
+                        unique_id: '$deviceid-oven_mode',
+                        state_topic: '$this/oven_mode',
+                        name: 'Oven Mode',
+                        options: OVEN_MODE_OPTIONS,
+                    },
+                    oven_set_temperature: {
+                        platform: 'sensor',
+                        device_class: 'temperature',
+                        icon: 'mdi:thermometer-chevron-up',
+                        unique_id: '$deviceid-oven_set_temperature',
+                        state_topic: '$this/oven_set_temperature',
+                        name: 'Oven Set Temperature',
+                        unit_of_measurement: '°F',
+                    },
+                    oven_door: {
+                        platform: 'binary_sensor',
+                        device_class: 'door',
+                        unique_id: '$deviceid-oven_door',
+                        state_topic: '$this/oven_door',
+                        name: 'Oven Door',
+                        payload_on: 'ON',
+                        payload_off: 'OFF',
+                    },
+                },
+            }),
+        )
+    }
+
+    start() {
+        this.send(Buffer.from(STATUS_QUERY, 'hex'))
+    }
+
+    processAABB(buf: Buffer) {
+        if (buf.length >= 2 && buf[0] === CLASS_BYTE) {
+            if (buf[1] === SINGLE_STATUS_FRAME_TYPE && buf.length === 2 + STATUS_RECORD_LENGTH) {
+                this.publishStatus(buf.subarray(2))
+                return
+            }
+
+            // EC contains equal-sized previous and current records; publish only the current one.
+            if (buf[1] === STATUS_FRAME_TYPE && buf.length === 2 + STATUS_RECORD_LENGTH * 2) {
+                this.publishStatus(buf.subarray(2 + STATUS_RECORD_LENGTH))
+                return
+            }
+        }
+
+        log('WLREL6323S', 'undecoded frame', buf.toString('hex'))
+    }
+
+    publishStatus(current: Buffer) {
+        this.publishProperty('oven_status', Device.formatOvenState(current[OVEN_STATE_OFFSET]))
+        this.publishProperty('oven_mode', Device.formatOvenMode(current[OVEN_MODE_OFFSET]))
+
+        const setTemperature = current.readUInt16BE(OVEN_SET_TEMPERATURE_OFFSET)
+        this.publishProperty('oven_set_temperature', setTemperature === 0 ? 'unknown' : setTemperature)
+
+        const doorOpen = (current[OVEN_DOOR_FLAGS_OFFSET] & OVEN_DOOR_OPEN_MASK) !== 0
+        this.publishProperty('oven_door', doorOpen ? 'ON' : 'OFF')
+
+        const cooktopOn = COOKTOP_STATE_OFFSETS.some((offset) => current[offset] !== 0)
+        this.publishProperty('cooktop_status', cooktopOn ? 'ON' : 'OFF')
+    }
+
+    static formatOvenState(value: number) {
+        const state = OVEN_STATE_NAMES[value]
+        if (state === undefined) log('WLREL6323S', 'undecoded oven state', value.toString(16))
+        return state ?? 'unknown'
+    }
+
+    static formatOvenMode(value: number) {
+        const mode = OVEN_MODE_NAMES[value]
+        if (mode === undefined) log('WLREL6323S', 'undecoded oven mode', value.toString(16))
+        return mode ?? 'unknown'
+    }
+}

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -23,6 +23,7 @@ import RV13B6ES_D_US_WIFI from './devices/RV13B6ES_D_US_WIFI'
 import WTL_FXU_BDV_NA_01 from './devices/WTL_FXU_BDV_NA_01'
 import DHUM_056905_WW from './devices/DHUM_056905_WW'
 import ST_B_E4H01Y_APL from './devices/ST_B_E4H01Y_APL'
+import WLREL6323S from './devices/WLREL6323S'
 import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
 import { type Connection } from './homeassistant'
@@ -69,6 +70,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     WTL_FXU_BDV_NA_01, // LG WashTower
     DHUM_056905_WW,
     ST_B_E4H01Y_APL,
+    WLREL6323S, // LG LREL6323S single-oven electric range
 }
 
 class Bridge {

--- a/tests/cloud/devices/WLREL6323S.test.ts
+++ b/tests/cloud/devices/WLREL6323S.test.ts
@@ -1,0 +1,196 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/WLREL6323S'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf, hex } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'WLREL6323S'
+const META: Metadata = { modelId: MODEL_ID, modelName: MODEL_ID, swVersion: '20160616' }
+
+// Real WLREL6323S packets captured on 2026-08-30 while operating the physical range panel.
+// EC frames contain a previous 62-byte record followed by the current 62-byte record.
+const IDLE_INITIAL_STATUS = buf(
+    'AA4440EB0000000000000000000000000000000E0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000072BB',
+)
+
+// Left-front, left-rear, and right-front tests all produced this same aggregate transition.
+const COOKTOP_OFF_TO_ON = buf(
+    'AA8240EC0000000000000000000000000000000E0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000001000100000000000000000000000000000000000000000000003BBB',
+)
+const COOKTOP_ON_TO_OFF = buf(
+    'AA8240EC00000000000000000000000000000006000000000000000000000000000000000000000001000100000000000000000000000000000000000000000000000000000000000000000000000000000E000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003BBB',
+)
+// The center-rear warming zone uses the adjacent pair of aggregate bytes (37 and 39).
+const WARMING_ZONE_OFF_TO_ON = buf(
+    'AA8240EC0000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000010001000000000000000000000000000000000000000000000033BB',
+)
+
+const OVEN_DOOR_CLOSED_TO_OPEN = buf(
+    'aa8240ec0000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080000000e0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000029bb',
+)
+const OVEN_DOOR_OPEN_TO_CLOSED = buf(
+    'aa8240ec0000000000000000000000080000000e000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000029bb',
+)
+
+// Panel-started Bake at 350°F (0x015E), followed by Cancel/Off ten seconds later.
+const BAKE_350_PREHEATING = buf(
+    'aa8240ec00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000101000000015e0000000000000000230000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000089bb',
+)
+const BAKE_CANCELLED = buf(
+    'aa8240ec0101000000015e000000000000000023000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000bfbb',
+)
+
+// Additional panel-started modes captured on 2026-09-07. Each frame's current record
+// identifies the mode independently of the mode-specific set-temperature behavior.
+const CONVECTION_BAKE_PREHEATING = buf(
+    'aa8240ec0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010300000001450000000000000000230000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000090bb',
+)
+const CONVECTION_ROAST_PREHEATING = buf(
+    'aa8240ec0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010400000001450000000000000000230000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000093bb',
+)
+const AIR_FRY_COOKING = buf(
+    'aa8240ec000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002100000000190000000000000000023000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004bbb',
+)
+const BROIL_COOKING = buf(
+    'aa8240ec00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000207000000000000000000000000004200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f6bb',
+)
+const WARM_COOKING = buf(
+    'aa8240ec00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000208000000000000000000000000004200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f1bb',
+)
+const EASY_CLEAN = buf(
+    'aa8240ec0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000090d000a00000000000000000000004200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000efbb',
+)
+const SELF_CLEAN = buf(
+    'aa8240ec0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000090f000004000000000000000000004200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e3bb',
+)
+const SELF_CLEAN_CANCELLED = buf(
+    'aa8240ec090f313b0300000000000001000000420000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000100000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000007cbb',
+)
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('publishes read-only oven and aggregate cooktop components', () => {
+        const { ha } = makeDevice()
+        const config = ha.devices[DEVICE_ID].config
+        assert.ok(config)
+
+        const components = config.components as Record<string, Record<string, unknown>>
+        assert.equal(components.cooktop_status.platform, 'binary_sensor')
+        assert.equal(components.oven_status.device_class, 'enum')
+        assert.deepEqual(components.oven_status.options, ['Idle', 'Preheating', 'Cooking', 'Cooling', 'Cleaning'])
+        assert.equal(components.oven_mode.device_class, 'enum')
+        assert.deepEqual(components.oven_mode.options, [
+            'None',
+            'Bake',
+            'Convection Bake',
+            'Convection Roast',
+            'Broil',
+            'Warm',
+            'EasyClean',
+            'Self Clean',
+            'Air Fry',
+        ])
+        assert.equal(components.oven_set_temperature.unit_of_measurement, '°F')
+        assert.equal(components.oven_door.device_class, 'door')
+        assert.equal(components.oven_door.icon, undefined)
+        assert.equal(components.oven_status.command_topic, undefined)
+    })
+
+    test('start sends the captured status query', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.start()
+        assert.equal(
+            hex(thinq.outbox[0]),
+            'AA28F0ED114101000000181A0207080C14191A1E262B30353A00000000000000000000000000F3BB',
+        )
+    })
+
+    test('decodes the initial idle status', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', IDLE_INITIAL_STATUS)
+        assert.deepEqual(ha.devices[DEVICE_ID].properties, {
+            oven_status: 'Idle',
+            oven_mode: 'None',
+            oven_set_temperature: 'unknown',
+            oven_door: 'OFF',
+            cooktop_status: 'OFF',
+        })
+    })
+
+    test('decodes aggregate cooktop on and off transitions from the current EC record', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', COOKTOP_OFF_TO_ON)
+        assert.equal(ha.devices[DEVICE_ID].properties.cooktop_status, 'ON')
+
+        thinq.emit('data', COOKTOP_ON_TO_OFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.cooktop_status, 'OFF')
+    })
+
+    test('includes the warming zone in aggregate cooktop status', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', WARMING_ZONE_OFF_TO_ON)
+        assert.equal(ha.devices[DEVICE_ID].properties.cooktop_status, 'ON')
+    })
+
+    test('decodes oven door open and closed transitions', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', OVEN_DOOR_CLOSED_TO_OPEN)
+        assert.equal(ha.devices[DEVICE_ID].properties.oven_door, 'ON')
+
+        thinq.emit('data', OVEN_DOOR_OPEN_TO_CLOSED)
+        assert.equal(ha.devices[DEVICE_ID].properties.oven_door, 'OFF')
+    })
+
+    test('decodes panel-started Bake at 350°F and cancellation', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', BAKE_350_PREHEATING)
+        assert.equal(ha.devices[DEVICE_ID].properties.oven_status, 'Preheating')
+        assert.equal(ha.devices[DEVICE_ID].properties.oven_mode, 'Bake')
+        assert.equal(ha.devices[DEVICE_ID].properties.oven_set_temperature, 350)
+
+        thinq.emit('data', BAKE_CANCELLED)
+        assert.equal(ha.devices[DEVICE_ID].properties.oven_status, 'Idle')
+        assert.equal(ha.devices[DEVICE_ID].properties.oven_mode, 'None')
+        assert.equal(ha.devices[DEVICE_ID].properties.oven_set_temperature, 'unknown')
+    })
+
+    test('decodes every captured cooking mode', () => {
+        const { ha, thinq } = makeDevice()
+        const cases = [
+            [CONVECTION_BAKE_PREHEATING, 'Preheating', 'Convection Bake', 325],
+            [CONVECTION_ROAST_PREHEATING, 'Preheating', 'Convection Roast', 325],
+            [AIR_FRY_COOKING, 'Cooking', 'Air Fry', 400],
+            [BROIL_COOKING, 'Cooking', 'Broil', 'unknown'],
+            [WARM_COOKING, 'Cooking', 'Warm', 'unknown'],
+            [EASY_CLEAN, 'Cleaning', 'EasyClean', 'unknown'],
+            [SELF_CLEAN, 'Cleaning', 'Self Clean', 'unknown'],
+            [SELF_CLEAN_CANCELLED, 'Cooling', 'None', 'unknown'],
+        ] as const
+
+        for (const [packet, status, mode, temperature] of cases) {
+            thinq.emit('data', packet)
+            assert.equal(ha.devices[DEVICE_ID].properties.oven_status, status)
+            assert.equal(ha.devices[DEVICE_ID].properties.oven_mode, mode)
+            assert.equal(ha.devices[DEVICE_ID].properties.oven_set_temperature, temperature)
+        }
+    })
+
+    test('does not mask unknown oven-mode bits into a known mode', () => {
+        assert.equal(DUT.formatOvenMode(0x81), 'unknown')
+    })
+
+    test('ignores frames outside the AA..BB envelope and unexpected status lengths', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', buf('001122'))
+        thinq.emit('data', buf('AA0840EB000073BB'))
+        assert.deepEqual(ha.devices[DEVICE_ID].properties, {})
+    })
+})


### PR DESCRIPTION
## Summary

- add a dedicated ThinQ2 handler for the LG LREL6323S (`WLREL6323S`) electric range
- expose confirmed read-only Home Assistant entities for oven state, Bake mode, set temperature, oven door, and aggregate cooktop state
- register the model in the bridge and list its consumer-facing model name in the README

## Capture evidence

The handler and tests come from live packets captured from a physical WLREL6323S on 2026-08-30 while:

- cycling the left-front, left-rear, and right-front elements independently
- opening and closing the oven door
- starting Bake at 350°F and cancelling it

All three tested elements produced the same cooktop transition, so this exposes one aggregate Cooktop binary sensor instead of guessing at individual burner identities. Writes and uncaptured oven modes are intentionally omitted.

This is not an alias of or duplicate of #144. That PR targets the WFV474PGV double oven/range; this single-cavity model has different observed door and cooktop field layouts and therefore needs its own handler.

## Verification

- `npm run build`
- `node --import tsx --test --test-reporter=spec tests/cloud/devices/WLREL6323S.test.ts` (8/8 pass)
- full repository suite: 444 tests passed in the sandbox; the 7 loopback-binding tests blocked there were rerun outside the sandbox and all 7 passed
- `npx prettier . --check --ignore-path .gitignore`
- `git diff --check`
