### PR TITLE
Add LG MVEM1825 microwave support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The following appliances are currently supported in rethink:
     - 👍 MD19GQGE0, Smart Dehumidifier - mostly working
 - Range Hoods:
     - 👍 HCED3015D (STUDIO_HOOD), Generic identifier and probably works with multiple models. Working.
+- Microwave Ovens:
+    - 👍 MVEM1825D/F (WMVEM1825), Smart Over-the-Range Microwave - mostly working
 - Stylers:
     - 👍 S5BBP (ST_B_E4H01Y_APL), Styler - mostly working
 

--- a/cloud/devices/WMVEM1825.ts
+++ b/cloud/devices/WMVEM1825.ts
@@ -1,0 +1,176 @@
+import HADevice from './base'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import AABBDevice from './aabb_device'
+
+const STATUS: Record<number, string> = {
+    0x00: 'Idle',
+    0x02: 'Cooking',
+    0x04: 'Paused',
+    0x05: 'Done',
+    0x07: 'Ready to start',
+}
+
+export default class Device extends AABBDevice {
+    fanSpeed = 0
+    lightLevel = 0
+
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: 'LG Microwave' }),
+                components: {
+                    status: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-status',
+                        state_topic: '$this/status',
+                        name: 'Status',
+                        icon: 'mdi:microwave',
+                        device_class: 'enum',
+                        options: Object.values(STATUS),
+                    },
+                    remaining_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-remaining_time',
+                        state_topic: '$this/remaining_time',
+                        name: 'Remaining time',
+                        device_class: 'duration',
+                        unit_of_measurement: 's',
+                    },
+                    power_level: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-power_level',
+                        state_topic: '$this/power_level',
+                        name: 'Power level',
+                        icon: 'mdi:gauge',
+                        unit_of_measurement: '%',
+                    },
+                    door: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-door',
+                        state_topic: '$this/door',
+                        name: 'Door',
+                        device_class: 'door',
+                    },
+                    fan_power: {
+                        platform: 'fan',
+                        unique_id: '$deviceid-fan',
+                        state_topic: '$this/fan_power',
+                        command_topic: '$this/fan_power/set',
+                        percentage_state_topic: '$this/fan_speed',
+                        percentage_command_topic: '$this/fan_speed/set',
+                        speed_range_min: 1,
+                        speed_range_max: 2,
+                        name: 'Vent fan',
+                        icon: 'mdi:fan',
+                    },
+                    light_power: {
+                        platform: 'light',
+                        unique_id: '$deviceid-light',
+                        state_topic: '$this/light_power',
+                        command_topic: '$this/light_power/set',
+                        brightness_state_topic: '$this/light_level',
+                        brightness_command_topic: '$this/light_level/set',
+                        brightness_scale: 2,
+                        name: 'Cooktop light',
+                        icon: 'mdi:lightbulb',
+                    },
+                },
+            }),
+        )
+    }
+
+    start() {
+        this.send(Buffer.from('f0ed114101000000181a0207080c14191a1e262b30353a00000000000000000000000000', 'hex'))
+    }
+
+    private processStatus(rec: Buffer) {
+        const state = rec[0]
+        // Confirmed independently of target seconds with a 20-second level-5 cook.
+        const powerLevel = rec[10]
+        const remainingSeconds = rec[15] * 3600 + rec[16] * 60 + rec[17]
+        const hood = rec[36]
+        const fanSpeed = hood & 0x0f
+        const lightLevel = (hood >> 4) & 0x07
+
+        this.publishProperty('status', STATUS[state] ?? 'unknown')
+        this.publishProperty('remaining_time', remainingSeconds)
+        if (powerLevel <= 10) this.publishProperty('power_level', powerLevel * 10)
+        if (fanSpeed <= 2) {
+            this.fanSpeed = fanSpeed
+            this.publishProperty('fan_power', fanSpeed > 0 ? 'ON' : 'OFF')
+            this.publishProperty('fan_speed', fanSpeed)
+        }
+        if (lightLevel <= 2) {
+            this.lightLevel = lightLevel
+            this.publishProperty('light_power', lightLevel > 0 ? 'ON' : 'OFF')
+            this.publishProperty('light_level', lightLevel)
+        }
+    }
+
+    processAABB(buf: Buffer) {
+        if (buf.length === 48 && buf[0] === 0x41 && buf[1] === 0xeb) {
+            this.processStatus(buf.subarray(2, 48))
+            return
+        }
+
+        if (buf.length === 94 && buf[0] === 0x41 && buf[1] === 0xec) {
+            this.processStatus(buf.subarray(48, 94))
+            return
+        }
+
+        // Door changes use a short event packet rather than the regular status record.
+        if (
+            buf.length === 12 &&
+            buf[0] === 0x41 &&
+            buf[1] === 0xb2 &&
+            buf.subarray(2, 11).equals(Buffer.from('000f070a0103000000', 'hex'))
+        ) {
+            if (buf[11] === 0 || buf[11] === 1) this.publishProperty('door', buf[11] === 1 ? 'ON' : 'OFF')
+        }
+    }
+
+    private sendHoodCommand() {
+        // The ThinQ app clears the other hood control on every change. Sending the complete
+        // desired state avoids that behavior; the combined form was verified on live hardware.
+        this.send(
+            Buffer.from([
+                0xf0,
+                0x43,
+                0x22,
+                0x04,
+                this.fanSpeed > 0 ? 1 : 0,
+                this.fanSpeed,
+                this.lightLevel > 0 ? 1 : 0,
+                this.lightLevel,
+                0x80,
+                0x80,
+            ]),
+        )
+    }
+
+    setProperty(prop: string, mqttValue: string) {
+        if (prop === 'fan_power') {
+            this.fanSpeed = mqttValue === 'ON' ? this.fanSpeed || 1 : 0
+            this.sendHoodCommand()
+        } else if (prop === 'fan_speed') {
+            const value = Number(mqttValue)
+            if (!Number.isFinite(value)) return
+            this.fanSpeed = Math.min(2, Math.max(0, Math.round(value)))
+            this.sendHoodCommand()
+        } else if (prop === 'light_power') {
+            this.lightLevel = mqttValue === 'ON' ? this.lightLevel || 1 : 0
+            this.sendHoodCommand()
+        } else if (prop === 'light_level') {
+            const value = Number(mqttValue)
+            if (!Number.isFinite(value)) return
+            this.lightLevel = Math.min(2, Math.max(0, Math.round(value)))
+            this.sendHoodCommand()
+        } else {
+            console.warn(`Unknown property ${prop}`)
+        }
+    }
+}

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -8,6 +8,7 @@ import Dev_2RES1VE61NFA2 from './devices/2RES1VE61NFA2'
 import Dev_2REB1GLVB1__2 from './devices/2REB1GLVB1__2'
 import Dev_2RES1VE600FWC from './devices/2RES1VE600FWC'
 import Dev_STUDIO_HOOD from './devices/STUDIO_HOOD'
+import Dev_WMVEM1825 from './devices/WMVEM1825'
 import Y_V8_Y___W_B32QEUK from './devices/Y_V8_Y___W.B32QEUK'
 import F_V8_Y___W_B_2QEUK from './devices/F_V8_Y___W.B_2QEUK'
 import Y_V8_F___W_B_2QEUK from './devices/Y_V8_F___W.B_2QEUK'
@@ -48,6 +49,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['2REB1GLVB1__2']: Dev_2REB1GLVB1__2,
     ['2RES1VE600FWC']: Dev_2RES1VE600FWC,
     ['STUDIO_HOOD']: Dev_STUDIO_HOOD,
+    ['WMVEM1825']: Dev_WMVEM1825,
     ['Y_V8_Y___W.B32QEUK']: Y_V8_Y___W_B32QEUK,
     ['F_V7_Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK, // NOTE: we reuse F_V8_Y___W_B_2QEUK as the models appear to be compatible
     ['F_V8_Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK,

--- a/tests/cloud/devices/WMVEM1825.test.ts
+++ b/tests/cloud/devices/WMVEM1825.test.ts
@@ -1,0 +1,210 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/WMVEM1825'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf, hex } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'WMVEM1825'
+const META: Metadata = { modelId: MODEL_ID, modelName: MODEL_ID, swVersion: '20220616' }
+
+// Real captures from an LG MVEM1825-series microwave. Each input frame was matched
+// to the physical appliance; the combined outbound command was also verified live.
+const SAMPLE_INITIAL_OFF = buf(
+    'AA3441EB003100015500000000000000FF030D000000000000000000000000000000C3000000004000008080808001000000F1BB',
+)
+const SAMPLE_COOKING_10_SECONDS_HIGH = buf(
+    'AA6241EC073000004001000000000000FF030D000000000000000000000000000000C3000100004000008080808001000000023000004401000000000A00FF030D00000A00000A000000000000000000C700010000400001808080800100000026BB',
+)
+const SAMPLE_COOKING_1_05_POWER_5 = buf(
+    'AA6241EC073000004001000000000000FF030D000000000000000000000000000000C3000100004000008080808001000000023000004401000000000500FF030D000105000105000000000000000000C700010000400001808080800100000033BB',
+)
+const SAMPLE_PAUSED_AT_57_SECONDS = buf(
+    'AA6241EC023000004401000000000500FF030D000039000105000000000000000000C7000100004000018080808001000000043000004401000000000500FF030D000039000105000000000000000000C7000100004000018080808001000000B6BB',
+)
+const SAMPLE_DONE = buf(
+    'AA6241EC023000004401000000000A00FF030D00000100000A000000000000000000C7000100004000018080808001000000053000015500000000000000FF030D000000000000000000000000000000C300000000400000808080800100000029BB',
+)
+const SAMPLE_DOOR_OPEN = buf('AA0041B2000F070A01030000000197BB')
+const SAMPLE_DOOR_CLOSED = buf('AA0041B2000F070A01030000000094BB')
+const SAMPLE_LIGHT_LOW = buf(
+    'AA6241EC003000015500000000000000FF030D000000000000000000000000000000C3000000004000008080808001000000003000015500000000000000FF030D000000000000000000000000000000C30000000040100080808080010000002EBB',
+)
+const SAMPLE_FAN_HIGH = buf(
+    'AA6241EC003000015500000000000000FF030D000000000000000000000000000000C3000000004001008080808001000000003000015500000000000000FF030D000000000000000000000000000000C30000000040020080808080010000003BBB',
+)
+const SAMPLE_FAN_HIGH_LIGHT_LOW = buf(
+    'AA6241EC003000015500000000000000FF030D000000000000000000000000000000C3000000004010008080808001000000003000015500000000000000FF030D000000000000000000000000000000C3000000004012008080808001000000D8BB',
+)
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('power differs from target seconds in a captured 20-second level-5 cook', () => {
+        // Physical panel: 20 seconds at power level 5, allowed to finish.
+        // Current record: [10] = 05 (50%), [17] = 14 (20s remaining),
+        // [20] = 14 (20s target). Unlike the earlier fixtures, these values
+        // distinguish power from the seconds portion of the target time.
+        const packet = buf(
+            'aa6241ec073000004001000000000000ff030d000000000000000000000000000000c3000100004000008080808001000000023000004401000000000500ff030d000014000014000000000000000000c7000100004000018080808001000000d7bb',
+        )
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', packet)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Cooking')
+        assert.equal(ha.devices[DEVICE_ID].properties.power_level, 50)
+        assert.equal(ha.devices[DEVICE_ID].properties.remaining_time, 20)
+    })
+
+    test('config exposes microwave status and controllable hood components', () => {
+        const { ha } = makeDevice()
+        const config = ha.devices[DEVICE_ID].config
+        assert.ok(config)
+
+        const components = config.components as Record<string, Record<string, unknown>>
+        assert.deepEqual(Object.keys(components), [
+            'status',
+            'remaining_time',
+            'power_level',
+            'door',
+            'fan_power',
+            'light_power',
+        ])
+        assert.equal(components.status.device_class, 'enum')
+        assert.deepEqual(components.status.options, ['Idle', 'Cooking', 'Paused', 'Done', 'Ready to start'])
+        assert.equal(components.remaining_time.device_class, 'duration')
+        assert.equal(components.remaining_time.unit_of_measurement, 's')
+        assert.equal(components.door.device_class, 'door')
+        assert.equal(components.fan_power.platform, 'fan')
+        assert.equal(components.fan_power.speed_range_max, 2)
+        assert.equal(components.light_power.platform, 'light')
+        assert.equal(components.light_power.brightness_scale, 2)
+    })
+
+    test('initial status reports idle with both hood controls off', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_INITIAL_OFF)
+        const props = ha.devices[DEVICE_ID].properties
+
+        assert.equal(props.status, 'Idle')
+        assert.equal(props.remaining_time, 0)
+        assert.equal(props.power_level, 0)
+        assert.equal(props.fan_power, 'OFF')
+        assert.equal(props.fan_speed, 0)
+        assert.equal(props.light_power, 'OFF')
+        assert.equal(props.light_level, 0)
+    })
+
+    test('10-second high-power cook reports cooking, time, and power', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_COOKING_10_SECONDS_HIGH)
+        const props = ha.devices[DEVICE_ID].properties
+
+        assert.equal(props.status, 'Cooking')
+        assert.equal(props.remaining_time, 10)
+        assert.equal(props.power_level, 100)
+    })
+
+    test('1:05 power-level-5 cook converts time and power to HA units', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_COOKING_1_05_POWER_5)
+        const props = ha.devices[DEVICE_ID].properties
+
+        assert.equal(props.status, 'Cooking')
+        assert.equal(props.remaining_time, 65)
+        assert.equal(props.power_level, 50)
+    })
+
+    test('pause and completion states decode from real transitions', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_PAUSED_AT_57_SECONDS)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Paused')
+        assert.equal(ha.devices[DEVICE_ID].properties.remaining_time, 57)
+
+        thinq.emit('data', SAMPLE_DONE)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Done')
+        assert.equal(ha.devices[DEVICE_ID].properties.remaining_time, 0)
+    })
+
+    test('door events publish open and closed states', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_DOOR_OPEN)
+        assert.equal(ha.devices[DEVICE_ID].properties.door, 'ON')
+        thinq.emit('data', SAMPLE_DOOR_CLOSED)
+        assert.equal(ha.devices[DEVICE_ID].properties.door, 'OFF')
+    })
+
+    test('packed hood status decodes fan and light independently', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_FAN_HIGH_LIGHT_LOW)
+        const props = ha.devices[DEVICE_ID].properties
+
+        assert.equal(props.fan_power, 'ON')
+        assert.equal(props.fan_speed, 2)
+        assert.equal(props.light_power, 'ON')
+        assert.equal(props.light_level, 1)
+    })
+
+    test('fan speed command preserves the reported light state', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.emit('data', SAMPLE_LIGHT_LOW)
+        thinq.resetRecorder()
+
+        dev.setProperty('fan_speed', '2')
+        assert.equal(hex(thinq.outbox[0]), 'AA0EF043220401020101808043BB')
+    })
+
+    test('light level command preserves the reported fan state', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.emit('data', SAMPLE_FAN_HIGH)
+        thinq.resetRecorder()
+
+        dev.setProperty('light_level', '2')
+        assert.equal(hex(thinq.outbox[0]), 'AA0EF043220401020102808042BB')
+    })
+
+    test('turning the fan off preserves the reported light state', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.emit('data', SAMPLE_FAN_HIGH_LIGHT_LOW)
+        thinq.resetRecorder()
+
+        dev.setProperty('fan_power', 'OFF')
+        assert.equal(hex(thinq.outbox[0]), 'AA0EF043220400000101808046BB')
+    })
+
+    test('invalid numeric control values are ignored', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('fan_speed', 'not-a-number')
+        dev.setProperty('light_level', 'not-a-number')
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('start sends the captured status query', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+        dev.start()
+
+        assert.equal(
+            hex(thinq.outbox[0]),
+            'AA28F0ED114101000000181A0207080C14191A1E262B30353A00000000000000000000000000F3BB',
+        )
+    })
+
+    test('unknown status uses the Home Assistant enum fallback', () => {
+        const { ha, thinq } = makeDevice()
+        const unknown = Buffer.from(SAMPLE_INITIAL_OFF)
+        unknown[4] = 0xff
+        thinq.emit('data', unknown)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'unknown')
+    })
+
+    test('unrecognised frame shapes are ignored', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', buf('AA084100430063BB'))
+        assert.deepEqual(ha.devices[DEVICE_ID].properties, {})
+    })
+})


### PR DESCRIPTION
## Summary

- add a ThinQ2 handler for the WMVEM1825 protocol used by MVEM1825D/F over-the-range microwaves
- expose cooking status, remaining time, power level, and door state
- expose controllable two-level vent fan and cooktop light entities
- preserve the other hood control when either fan or light is changed
- register the model and document the marketing model names

## Hardware validation

All status fixtures come from the live device and were matched to physical actions. Captures cover idle, ready, cooking, paused, done, 10-second and 1:05 countdowns, power levels 5 and 10, door open/closed, and both hood levels.

ThinQ app commands were captured separately for fan and light. The app explicitly clears the other hood control when changing one. A combined fan High + light Low command was therefore tested directly, acknowledged by the appliance, reflected in its status packet, and physically confirmed before implementing state preservation.

This is intentionally a separate handler from the WMVEL2137 protocol documented in #93: WMVEM1825 has two direct fan levels and packs light in the upper status nibble, while that device reports four advance-count fan levels with the opposite nibble layout.

## Tests

- npm test
- npm run build
- 14 WMVEM1825 handler tests using real captured packets