### PR TITLE
Add support for the LG MVEL2033F over-the-range microwave

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The following appliances are currently supported in rethink:
     - 👍 MD19GQGE0, Smart Dehumidifier - mostly working
 - Range Hoods:
     - 👍 HCED3015D (STUDIO_HOOD), Generic identifier and probably works with multiple models. Working.
+- Microwave Ovens:
+    - 👍 MVEL2033F (WMVEL2137), Over-the-Range Microwave - mostly working, with vent fan and lamp control
 - Stylers:
     - 👍 S5BBP (ST_B_E4H01Y_APL), Styler - mostly working
 

--- a/cloud/devices/WMVEL2137.ts
+++ b/cloud/devices/WMVEL2137.ts
@@ -1,0 +1,392 @@
+import HADevice from './base'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import AABBDevice from './aabb_device'
+import { Enum } from '@/util/enum'
+
+// LG over-the-range microwave/hood, marketing model MVEL2033F, matched on modelId "WMVEL2137"
+// (thinq2 deviceType 302).
+//
+// A different appliance from WMVEM1825 and not aliasable to it: that model has two fan levels
+// against this one's four plus off. Both pack the vent/lamp status nibbles the same way (see
+// VENT_LAMP_OFFSET) - it is issue #93's claim for this modelId that is reversed, not WMVEM1825.
+//
+// Frames arrive 0xFF-escaped AABB. The AABB body seen by processAABB is:
+//
+//   41 EC <record: previous state> <record: current state>     94 bytes
+//   41 EB <record: current state>                               48 bytes
+//
+// Each record is 46 bytes. 0xEB answers the status query sent from start(); 0xEC is the
+// unsolicited delta report, whose first record repeats the previous frame's current state. Both
+// frame types share one decoder over the current-state record.
+//
+// Every offset and table entry was confirmed live: the appliance was driven by hand at the panel
+// while rethink bridged to the LG cloud, matching each byte change to the cloud's own ovenState
+// at the same timestamp.
+//
+// Credit: the protocol, the AABB checksum and the fan/light command shape were first documented
+// by XanderLuciano in anszom/rethink issue #93. Two of that issue's claims do not hold here: the
+// vent/lamp nibble order is reversed (VENT_LAMP_OFFSET), and the level byte is absolute rather
+// than an advance count (SET_COMMAND). The state and cook-mode codes also are not the modelJSON
+// enum indices.
+
+const STATUS_FRAME_TYPE = 0xec
+const STATUS_FRAME_LEN = 94 // 2B header + 46B previous record + 46B current record
+const CURRENT_RECORD_OFFSET = 48
+
+const SINGLE_STATUS_FRAME_TYPE = 0xeb
+const SINGLE_STATUS_FRAME_LEN = 48 // 2B header + 46B record, no preceding "previous state" half
+const SINGLE_RECORD_OFFSET = 2
+
+const RECORD_LEN = 46
+const CLASS_BYTE = 0x41
+
+// Status query, sent on connect. Without it the appliance pushes nothing until the panel is
+// touched. Bytes as sent by LG's own cloud while bridged, so known to be read-only and understood.
+const STATUS_REQUEST = 'f0ed114101000000180e111718191a1a1b00000000000000'
+
+// rec[0]: appliance state, matched against the cloud's LWOState. Not the modelJSON UpperOvenState
+// enum index (5 is DONE here, CLEANING there; 4 is PAUSED here, COOLING there).
+const STATE_OFFSET = 0
+const STATES = Enum.of({
+    Idle: 0x00,
+    Cooking: 0x02,
+    Paused: 0x04,
+    Done: 0x05,
+    Settings: 0x07,
+})
+
+// rec[5]: cook mode family, matched against LWOManualCookName. Not the enum index either (SENSOR_
+// COOK is 0x18 here, index 17 there). 0x18 covers every Sensor Cook item, 0x1f every preset menu
+// item (Kids Meal, Steam Cook, Melt, Soften all report it) - these name the family, not the dish.
+const COOK_MODE_OFFSET = 5
+const COOK_MODES = Enum.of({
+    Off: 0x00,
+    Microwave: 0x01,
+    'Inverter defrost': 0x15,
+    'Sensor cook': 0x18,
+    'Auto cook': 0x1f,
+})
+
+// rec[6..7]: big-endian 16-bit dish id, which the cook mode above only names the family of. The
+// cloud reports the same number verbatim as LWOSubCookName (Kids Meal: 0x0d12 here, 3346 there),
+// which confirms both offset and endianness.
+//
+// LG's modelJSON carries no name table for this field, just a bare 0-5000 range, so every name
+// below is read off the panel. Three blocks are alphabetical and contiguous, which cross-checks
+// those: Sensor Cook 245-256, Melt 3359-3363, Steam Cook 3364-3370. That ordering does not extend
+// further - Defrost follows menu position, and the Kids Menu (3338, 3346, 3378) is neither
+// alphabetical nor contiguous - so those rest on the panel reading alone.
+//
+// Ids are sparse, so an unlisted one reports unknown rather than a guess. Menus repeat names
+// (all four Melt > Butter portions report 3359), hence the menu prefixes HA needs for a distinct
+// enum. Defrost is the exception where food type is part of the id, since there the weight is a
+// separate field.
+const COOK_ITEM_OFFSET = 6
+// Code 0 is "no dish chosen". It cannot be published as the string 'None': that is the payload
+// publishProperty sends for an undefined value, which HA renders as unknown - so an unlisted id and
+// an idle appliance would be indistinguishable.
+const COOK_ITEM_NONE = 'Not selected'
+const COOK_ITEMS = Enum.of({
+    [COOK_ITEM_NONE]: 0,
+    'Defrost meat': 211,
+    'Defrost poultry': 212,
+    'Defrost fish': 213,
+    'Defrost bread': 214,
+    Potato: 243,
+    'Boiling water': 245,
+    'Canned vegetables': 246,
+    Casserole: 247,
+    'Chicken pieces': 248,
+    'Fish fillets': 249,
+    'Fresh vegetables hard': 250,
+    'Fresh vegetables soft': 251,
+    'Frozen lasagna': 252,
+    'Frozen vegetables': 253,
+    Popcorn: 254,
+    Rice: 255,
+    Shrimp: 256,
+    'Reheat baked goods': 258,
+    Beverage: 259,
+    'Reheat casserole': 260,
+    'Reheat dinner plate': 261,
+    'Reheat pizza': 263,
+    'Reheat soup or sauce': 264,
+    'Kids corn dog': 3338,
+    'Kids mac and cheese': 3346,
+    'Soften butter': 3354,
+    'Soften cream cheese': 3355,
+    'Soften frozen juice': 3357,
+    'Soften ice cream': 3358,
+    'Melt butter': 3359,
+    'Melt cheese': 3361,
+    'Melt chocolate': 3362,
+    'Melt marshmallow': 3363,
+    'Steam asparagus': 3364,
+    'Steam broccoli': 3365,
+    'Steam brussels sprouts': 3366,
+    'Steam carrots': 3367,
+    'Steam chicken breast': 3368,
+    'Steam fish': 3369,
+    'Steam zucchini': 3370,
+    'Kids chicken nuggets': 3378,
+})
+
+// rec[10]: power level 0-10, matching LWOMGTPowerLevel exactly.
+const POWER_LEVEL_OFFSET = 10
+
+// Durations are a minutes byte then a seconds byte: rec[16..17] remaining time (LWORemainTimeMinute
+// /Second), rec[22..23] the kitchen timer (LWOTimerMinute/Second). Neither minutes byte is
+// minutes-within-an-hour: a 90-minute timer reads 90 and ticks to 60:59 without borrowing, matching
+// the cloud's LWOTimerMinute:90 rather than an hour and thirty. rec[15] and rec[21], the bytes
+// ahead of each pair, are always 0 and deliberately not read as hours: guessing wrong there would
+// silently add whole hours to a duration.
+const REMAIN_TIME_OFFSET = 16
+const TIMER_OFFSET = 22
+
+// rec[18..20]: the length the running cook was given, as hours/minutes/seconds, matching the
+// cloud's LWOTargetTimeHour/Minute plus a seconds byte confirmed on a 30-second half-power run
+// (rec[20]=30 with no minutes given). It holds steady while the remaining time ticks and clears
+// when the cook is cancelled - that stability is what tells the two fields apart, since a 90-minute
+// cook reads 1:30 here while the remaining time counts a flat 90 down.
+const COOK_TIME_OFFSET = 18
+
+// rec[36]: vent speed in the low nibble, lamp level in the high nibble. Confirmed by nine
+// consecutive single-variable transitions each way: 0x20->0x24 as the cloud stepped
+// mwoVentSpeedLevel 0..4 with the lamp untouched, and 0x20->0x00->0x10->0x20 as it stepped
+// mwoLampLevel 2,0,1,2 with the vent off.
+//
+// The vent also runs itself: with range-hood interaction enabled in the ThinQ app, lighting any
+// cooktop element on the matching LG range brings the fan to level 1 with no command from here, and
+// the last element going out returns it to 0. So this handler's fan entity can change state on its
+// own.
+const VENT_LAMP_OFFSET = 36
+
+// rec[35]: constant 0x53 field marker preceding the vent/lamp byte, used as a sanity check that the
+// record is aligned the way we think it is.
+const FIELD_MARKER_OFFSET = 35
+const FIELD_MARKER = 0x53
+
+// Vent/lamp set command, 10-byte inner body:
+//
+//   F0 43 22 04 [fanCmd][fanLevel] [lightCmd][lightLevel] [trailer][trailer]
+//     cmd:   0x01 set this control to the level that follows
+//            0x00 turn this control off
+//            0x80 leave this control exactly as it is
+//     level: ABSOLUTE - fan 0-4, lamp 0-2. Issue #93 describes this byte as a count of presses to
+//            advance by; on this appliance it is not - fan level 2 sent while running at 4 gave 2,
+//            not the 4->off wraparound "advance 4" would produce. The advance reading only agrees
+//            when starting from off.
+//     trailer: 0x80, "no change", covering the motor/time fields issue #93 documents.
+//
+// Bytes as the ThinQ app sends them, watched live while driving all four fan speeds and both lamp
+// levels: always the absolute level, which is the strongest confirmation the level is not a count.
+// Unlike this handler, the app sends 0x00 (not 0x80) for the control it isn't touching, which only
+// happens not to matter because that control was already off; sending 0x80 here means one control
+// provably cannot disturb the other, so there is no need to track a combined desired state the way
+// STUDIO_HOOD.ts does.
+const SET_COMMAND = 'f0432204'
+const CMD_SET = 0x01
+const CMD_OFF = 0x00
+const CMD_NO_CHANGE = 0x80
+const TRAILER_NO_CHANGE = 0x80
+const TRAILER_LENGTH = 2
+
+const MAX_VENT_SPEED = 4
+const MAX_LAMP_LEVEL = 2
+
+function clamp(value: number, max: number): number {
+    return Math.min(max, Math.max(0, Math.round(value)))
+}
+
+export default class Device extends AABBDevice {
+    // The last non-zero level each control reported, so HA's plain on/off restores what the user
+    // had rather than always jumping to the lowest setting.
+    lastVentSpeed = 1
+    lastLampLevel = 1
+
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: 'LG Microwave' }),
+                components: {
+                    status: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-status',
+                        state_topic: '$this/status',
+                        name: 'Status',
+                        icon: 'mdi:microwave',
+                        device_class: 'enum',
+                        options: STATES.options,
+                    },
+                    cook_mode: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-cook_mode',
+                        state_topic: '$this/cook_mode',
+                        name: 'Cook mode',
+                        icon: 'mdi:chef-hat',
+                        device_class: 'enum',
+                        options: COOK_MODES.options,
+                    },
+                    cook_item: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-cook_item',
+                        state_topic: '$this/cook_item',
+                        name: 'Cook item',
+                        icon: 'mdi:silverware-fork-knife',
+                        device_class: 'enum',
+                        options: COOK_ITEMS.options,
+                    },
+                    power_level: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-power_level',
+                        state_topic: '$this/power_level',
+                        name: 'Power level',
+                        icon: 'mdi:gauge',
+                    },
+                    remaining_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-remaining_time',
+                        state_topic: '$this/remaining_time',
+                        name: 'Remaining time',
+                        device_class: 'duration',
+                        unit_of_measurement: 's',
+                    },
+                    cook_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-cook_time',
+                        state_topic: '$this/cook_time',
+                        name: 'Cook time',
+                        icon: 'mdi:timelapse',
+                        device_class: 'duration',
+                        unit_of_measurement: 's',
+                    },
+                    timer: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-timer',
+                        state_topic: '$this/timer',
+                        name: 'Kitchen timer',
+                        icon: 'mdi:timer-outline',
+                        device_class: 'duration',
+                        unit_of_measurement: 's',
+                    },
+                    fan_power: {
+                        platform: 'fan',
+                        unique_id: '$deviceid-fan',
+                        state_topic: '$this/fan_power',
+                        command_topic: '$this/fan_power/set',
+                        // Despite the "percentage" naming, HA's MQTT fan integration publishes
+                        // and expects raw device-native speeds here once speed_range_min/max are
+                        // declared, and converts to and from the percentage slider itself.
+                        percentage_state_topic: '$this/fan_speed',
+                        percentage_command_topic: '$this/fan_speed/set',
+                        speed_range_min: 1,
+                        speed_range_max: MAX_VENT_SPEED,
+                        name: 'Vent fan',
+                        icon: 'mdi:fan',
+                    },
+                    light_power: {
+                        platform: 'light',
+                        unique_id: '$deviceid-light',
+                        state_topic: '$this/light_power',
+                        command_topic: '$this/light_power/set',
+                        brightness_state_topic: '$this/light_level',
+                        brightness_command_topic: '$this/light_level/set',
+                        brightness_scale: MAX_LAMP_LEVEL,
+                        name: 'Cooktop light',
+                        icon: 'mdi:lightbulb',
+                    },
+                },
+            }),
+        )
+    }
+
+    start() {
+        this.send(Buffer.from(STATUS_REQUEST, 'hex'))
+    }
+
+    processAABB(buf: Buffer) {
+        if (buf[0] !== CLASS_BYTE) return
+
+        if (buf[1] === SINGLE_STATUS_FRAME_TYPE && buf.length === SINGLE_STATUS_FRAME_LEN) {
+            this.processStatus(buf.subarray(SINGLE_RECORD_OFFSET, SINGLE_RECORD_OFFSET + RECORD_LEN))
+        } else if (buf[1] === STATUS_FRAME_TYPE && buf.length === STATUS_FRAME_LEN) {
+            this.processStatus(buf.subarray(CURRENT_RECORD_OFFSET, CURRENT_RECORD_OFFSET + RECORD_LEN))
+        }
+        // Anything else - the 41/3e and 41/72 frames, command acks - carries no state we decode.
+    }
+
+    processStatus(rec: Buffer) {
+        // Refuse to publish from a record that is not laid out the way every captured one was.
+        if (rec.length !== RECORD_LEN || rec[FIELD_MARKER_OFFSET] !== FIELD_MARKER) return
+
+        this.publishProperty('status', STATES.map(rec[STATE_OFFSET]))
+        this.publishProperty('cook_mode', COOK_MODES.map(rec[COOK_MODE_OFFSET]))
+        this.publishProperty('cook_item', COOK_ITEMS.map(rec.readUInt16BE(COOK_ITEM_OFFSET)))
+        this.publishProperty('power_level', rec[POWER_LEVEL_OFFSET])
+        this.publishProperty('remaining_time', seconds(rec, REMAIN_TIME_OFFSET))
+        this.publishProperty('timer', seconds(rec, TIMER_OFFSET))
+        this.publishProperty(
+            'cook_time',
+            rec[COOK_TIME_OFFSET] * 3600 + rec[COOK_TIME_OFFSET + 1] * 60 + rec[COOK_TIME_OFFSET + 2],
+        )
+
+        const ventSpeed = rec[VENT_LAMP_OFFSET] & 0x0f
+        const lampLevel = rec[VENT_LAMP_OFFSET] >> 4
+
+        // Remember the last level each control ran at, so a bare "on" from HA restores it.
+        if (ventSpeed) this.lastVentSpeed = ventSpeed
+        if (lampLevel) this.lastLampLevel = lampLevel
+
+        this.publishProperty('fan_speed', ventSpeed)
+        this.publishProperty('fan_power', ventSpeed ? 'ON' : 'OFF')
+        this.publishProperty('light_level', lampLevel)
+        this.publishProperty('light_power', lampLevel ? 'ON' : 'OFF')
+    }
+
+    setProperty(prop: string, mqttValue: string) {
+        if (prop === 'fan_power') {
+            this.setVent(mqttValue === 'ON' ? this.lastVentSpeed : 0)
+        } else if (prop === 'fan_speed') {
+            const value = Number(mqttValue)
+            if (!Number.isFinite(value)) return
+            this.setVent(clamp(value, MAX_VENT_SPEED))
+        } else if (prop === 'light_power') {
+            this.setLamp(mqttValue === 'ON' ? this.lastLampLevel : 0)
+        } else if (prop === 'light_level') {
+            const value = Number(mqttValue)
+            if (!Number.isFinite(value)) return
+            this.setLamp(clamp(value, MAX_LAMP_LEVEL))
+        } else {
+            console.warn(`Unknown property ${prop}`)
+        }
+    }
+
+    // Each setter touches one control and leaves the other explicitly alone.
+    setVent(speed: number) {
+        this.sendCommand(speed ? CMD_SET : CMD_OFF, speed, CMD_NO_CHANGE, CMD_NO_CHANGE)
+    }
+
+    setLamp(level: number) {
+        this.sendCommand(CMD_NO_CHANGE, CMD_NO_CHANGE, level ? CMD_SET : CMD_OFF, level)
+    }
+
+    sendCommand(fanCmd: number, fanLevel: number, lightCmd: number, lightLevel: number) {
+        this.send(
+            Buffer.concat([
+                Buffer.from(SET_COMMAND, 'hex'),
+                Buffer.from([fanCmd, fanLevel, lightCmd, lightLevel]),
+                Buffer.alloc(TRAILER_LENGTH, TRAILER_NO_CHANGE),
+            ]),
+        )
+    }
+}
+
+// A minutes/seconds pair, as a duration in seconds. See REMAIN_TIME_OFFSET for why the byte ahead
+// of each pair is not treated as hours.
+function seconds(rec: Buffer, offset: number): number {
+    return rec[offset] * 60 + rec[offset + 1]
+}

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -8,6 +8,7 @@ import Dev_2RES1VE61NFA2 from './devices/2RES1VE61NFA2'
 import Dev_2REB1GLVB1__2 from './devices/2REB1GLVB1__2'
 import Dev_2RES1VE600FWC from './devices/2RES1VE600FWC'
 import Dev_STUDIO_HOOD from './devices/STUDIO_HOOD'
+import Dev_WMVEL2137 from './devices/WMVEL2137'
 import Y_V8_Y___W_B32QEUK from './devices/Y_V8_Y___W.B32QEUK'
 import F_V8_Y___W_B_2QEUK from './devices/F_V8_Y___W.B_2QEUK'
 import Y_V8_F___W_B_2QEUK from './devices/Y_V8_F___W.B_2QEUK'
@@ -49,6 +50,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['2REB1GLVB1__2']: Dev_2REB1GLVB1__2,
     ['2RES1VE600FWC']: Dev_2RES1VE600FWC,
     ['STUDIO_HOOD']: Dev_STUDIO_HOOD,
+    ['WMVEL2137']: Dev_WMVEL2137,
     ['Y_V8_Y___W.B32QEUK']: Y_V8_Y___W_B32QEUK,
     ['F_V7_Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK, // NOTE: we reuse F_V8_Y___W_B_2QEUK as the models appear to be compatible
     ['F_V7_Y___W.B__QEUK']: F_V8_Y___W_B_2QEUK, // LG F2V5PS0W front-load washer - confirmed working, status/course/spin/temp/energy/remaining_time all decode correctly against a real unit

--- a/tests/cloud/devices/WMVEL2137.test.ts
+++ b/tests/cloud/devices/WMVEL2137.test.ts
@@ -1,0 +1,373 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/WMVEL2137'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf, hex } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'WMVEL2137'
+const META: Metadata = { modelId: MODEL_ID, modelName: 'WMVEL2137', swVersion: '20230920' }
+
+// Real frames captured from an LG MVEL2033F over-the-range microwave (modelId WMVEL2137, thinq2
+// deviceType 302) while it was driven by hand at the panel with rethink bridged to the LG cloud.
+// The comment on each fixture names the cloud field that confirmed the decode, taken from the
+// ovenState the cloud reported within ~300ms of that frame.
+//
+// Frames: AA 62 41 EC <46B previous record> <46B current record> <cksum> BB
+//         AA 34 41 EB <46B current record> <cksum> BB
+
+// mwoVentSpeedLevel=4, mwoLampLevel=2. The vent had just been switched on with the panel's
+// ON/OFF key, which advances four steps from off and so lands on Turbo.
+const SAMPLE_VENT_TURBO_LAMP_HIGH = buf(
+    'AA6241EC003000015500000000000000FF030D000000000000000000000000000000C3000000005320008080808001000000003000015500000000000000FF030D000000000000000000000000000000C300000000532400808080800100000080BB',
+)
+// mwoVentSpeedLevel=0, lamp still 2 - the vent switched back off.
+const SAMPLE_VENT_OFF_LAMP_HIGH = buf(
+    'AA6241EC003000015500000000000000FF030D000000000000000000000000000000C3000000005324008080808001000000003000015500000000000000FF030D000000000000000000000000000000C300000000532000808080800100000080BB',
+)
+// mwoVentSpeedLevel=1, lamp 2. This is the fixture that settles the nibble order: if the halves
+// were read the other way round this frame would report a lamp level of 1 and a vent speed of 2.
+const SAMPLE_VENT_LOW_LAMP_HIGH = buf(
+    'AA6241EC003000015500000000000000FF030D000000000000000000000000000000C3000000005324008080808001000000003000015500000000000000FF030D000000000000000000000000000000C300000000532100808080800100000083BB',
+)
+// mwoLampLevel=1, vent 0.
+const SAMPLE_LAMP_LOW = buf(
+    'AA6241EC003000015500000000000000FF030D000000000000000000000000000000C3000000005300008080808001000000003000015500000000000000FF030D000000000000000000000000000000C3000000005310008080808001000000F4BB',
+)
+// LWOState=COOKING_IN_PROGRESS, LWOManualCookName=MICROWAVE, LWOMGTPowerLevel=10,
+// LWORemainTimeMinute=5, LWOTargetTimeMinute=5 - the start of a five-minute full-power run.
+const SAMPLE_COOKING_FULL_POWER_5MIN = buf(
+    'AA6241EC003000015500000000000000FF030D000000000000000000000000000000C3000000005300008080808001000000023000004401000000000A00FF030D000500000500000000000000000000C7000100005300018080808001000000C9BB',
+)
+// The same run one second later: LWORemainTimeMinute=4, LWORemainTimeSecond=59.
+const SAMPLE_COOKING_4M59S = buf(
+    'AA6241EC023000004401000000000A00FF030D000500000500000000000000000000C7000100005300018080808001000000023000004401000000000A00FF030D00043B000500000000000000000000C7000100005300018080808001000000B4BB',
+)
+// LWOState=PAUSED with LWORemainTimeSecond=30 left of the five minutes - the door was opened.
+const SAMPLE_PAUSED = buf(
+    'AA6241EC023000004401000000000A00FF030D00043B000500000000000000000000C7000100005300018080808001000000043000004401000000000A00FF030D00041E000500000000000000000000C700010000530001808080800100000055BB',
+)
+// LWOMGTPowerLevel=5, LWORemainTimeSecond=30 - the 30-second run at the panel's "50" power.
+const SAMPLE_COOKING_HALF_POWER_30S = buf(
+    'AA6241EC073000004001000000000000FF030D000000000000000000000000000000C3000100005300008080808001000000023000004401000000000500FF030D00001E00001E000000000000000000C7000100005300018080808001000000E9BB',
+)
+// LWOState=DONE at the end of a run.
+const SAMPLE_DONE = buf(
+    'AA6241EC023000004401000000000A00FF030D00001E00001E000000000000000000C7000100005300018080808001000000053000015500000000000000FF030D000000000000000000000000000000C300000000530000808080800100000086BB',
+)
+// LWOState=PREFERENCE, LWOManualCookName=SENSOR_COOK, LWOSubCookName=254 - the panel sitting in
+// its Sensor Cook selection screen.
+const SAMPLE_SENSOR_COOK_SETTINGS = buf(
+    'AA6241EC003000015500000000000000FF030D000000000000000000000000000000C300000000530000808080800100000007300000401800FE00000000FF030D000000000000000000000000000000E3000000005300008080808001000000EDBB',
+)
+// LWOManualCookName=AUTO_COOK, LWOState=COOKING_IN_PROGRESS, LWORemainTimeMinute=1,
+// LWORemainTimeSecond=10 - a Kids Menu > Mac and cheese run. Every other preset reports the same
+// 0x1f mode with a different rec[6..7], which is why 0x1f names the menu and not the dish.
+const SAMPLE_AUTO_COOK_RUNNING = buf(
+    'AA6241EC07300000401F000000000000FF030D000000000000000000000000000000C300000000530000808080800100000002300000441F0D1200000A00FF030D00010A00010A000000000000000000C7000000005300018080808001000000A1BB',
+)
+// Two Sensor Cook dishes running, LWOSubCookName=255 and 264 - Cook > Rice and Reheat > Soup or
+// sauce. The dish id spans both rec[6] and rec[7]: 255 is 0x00FF and 264 is 0x0108.
+const SAMPLE_SENSOR_COOK_RICE = buf(
+    'AA6241EC07300000401800FF00000000FF030D000000000000000000000000000000E300000000530000808080800100000002300000441800FF00000000FF030D000000000000000000000000000000E3000000005300018080808001000000B4BB',
+)
+const SAMPLE_SENSOR_REHEAT_SOUP = buf(
+    'AA6241EC073000004018010800000000FF030D000000000000000000000000000000E3000000005300008080808001000000023000004418010800000000FF030D000000000000000000000000000000E3000000005300018080808001000000A0BB',
+)
+// A Soften > Butter run, LWOSubCookName=3354 at power 2 for 50 seconds. Every portion size on this
+// menu reports the same id and differs only in the time the appliance picks.
+const SAMPLE_SOFTEN_BUTTER = buf(
+    'AA6241EC07300000401F000000000000FF030D000000000000000000000000000000C300000000530000808080800100000002300000441F0D1A00000200FF030D000032000032000000000000000000C700000000530001808080800100000017BB',
+)
+// LWOManualCookName=INVERTER_DEFROST, LWOState=COOKING_IN_PROGRESS, LWOMGTPowerLevel=7 - a
+// two-pound poultry defrost, for which the appliance chose ten minutes at power 7.
+const SAMPLE_DEFROST_RUNNING = buf(
+    'AA6241EC07300000401500D300000000FF030D000000000000000000000000000000C300000000530000808080800100000002300000441500D400000700FF030D000A00000A00000000000000000000C700000000530001808080800100000031BB',
+)
+// The 41 EB single-record reply to the start() status query, captured right after the appliance
+// first connected: idle, vent off, lamp at level 2.
+const SAMPLE_INITIAL_STATUS = buf(
+    'AA3441EB003000015500000000000000FF030D000000000000000000000000000000C300000000532000808080800100000083BB',
+)
+
+// A 90-minute kitchen timer. The minutes byte reads 90, not one hour and thirty: there is no hour
+// byte in front of it and no borrow at 60. Cloud: LWOTimerMinute:90 with LWOTimerSet "ENABLE".
+const TIMER_90_MINUTES = buf(
+    'aa6241ec003000014000000000000000ff030d000000000000000000000000000000c3000000005300008080808001000000003000015500000000000000ff030d000000000000005a00000000000000c300000000530000808080800100000083bb',
+)
+
+// A 90-minute Microwave cook just started: the remaining time reads 90 minutes in its own minutes
+// byte while rec[18..19] carries the length it was given as 1 hour 30, matching the cloud's
+// LWOTargetTimeHour:1 and LWOTargetTimeMinute:30 with LWORemainTimeMinute:90 in the same frame.
+const COOKING_90_MINUTES = buf(
+    'aa6241ec073000004001000000000000ff030d000000000000000000000000000000c3000100005300008080808001000000023000004401000000000a00ff030d005a00011e00000000000000000000c7000100005300018080808001000000abbb',
+)
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('config published on device creation', () => {
+        const { ha } = makeDevice()
+        const dev = ha.devices[DEVICE_ID]
+        assert.ok(dev?.config, 'config published')
+
+        const components = dev.config!.components as Record<string, Record<string, unknown>>
+        assert.deepEqual(Object.keys(components), [
+            'status',
+            'cook_mode',
+            'cook_item',
+            'power_level',
+            'remaining_time',
+            'cook_time',
+            'timer',
+            'fan_power',
+            'light_power',
+        ])
+        assert.equal(components.status.device_class, 'enum')
+        assert.deepEqual(components.status.options, ['Idle', 'Cooking', 'Paused', 'Done', 'Settings'])
+        assert.equal(components.remaining_time.device_class, 'duration')
+        assert.equal(components.remaining_time.unit_of_measurement, 's')
+        assert.equal(components.timer.device_class, 'duration')
+        // 'None' is the payload an undefined value publishes under, which HA reads as unknown, so it
+        // must not double as the label for "no dish chosen".
+        assert.ok(!(components.cook_item.options as string[]).includes('None'))
+        assert.equal(components.fan_power.platform, 'fan')
+        assert.equal(components.fan_power.speed_range_min, 1)
+        assert.equal(components.fan_power.speed_range_max, 4)
+        assert.equal(components.light_power.platform, 'light')
+        assert.equal(components.light_power.brightness_scale, 2)
+    })
+
+    test('start() sends the status query the LG cloud uses', () => {
+        const { thinq, dev } = makeDevice()
+        dev.start()
+        assert.equal(hex(thinq.outbox[0]), 'AA1CF0ED114101000000180E111718191A1A1B0000000000000091BB')
+    })
+
+    test('vent speed and lamp level come from opposite nibbles of one byte', () => {
+        const { ha, thinq } = makeDevice()
+        const props = () => ha.devices[DEVICE_ID].properties
+
+        thinq.emit('data', SAMPLE_VENT_TURBO_LAMP_HIGH)
+        assert.equal(props().fan_speed, 4)
+        assert.equal(props().fan_power, 'ON')
+        assert.equal(props().light_level, 2)
+        assert.equal(props().light_power, 'ON')
+
+        thinq.emit('data', SAMPLE_VENT_LOW_LAMP_HIGH)
+        assert.equal(props().fan_speed, 1)
+        assert.equal(props().light_level, 2)
+
+        thinq.emit('data', SAMPLE_VENT_OFF_LAMP_HIGH)
+        assert.equal(props().fan_speed, 0)
+        assert.equal(props().fan_power, 'OFF')
+        assert.equal(props().light_level, 2)
+
+        thinq.emit('data', SAMPLE_LAMP_LOW)
+        assert.equal(props().fan_speed, 0)
+        assert.equal(props().light_level, 1)
+    })
+
+    // The four frames below are the exact bytes that were sent to a real MVEL2033F during
+    // protocol verification; the appliance acknowledged each with AA084100430063BB and then
+    // reported the state named in the comment.
+    test('setting the vent speed sends an absolute level and leaves the lamp alone', () => {
+        const { thinq, dev } = makeDevice()
+
+        // fan -> 1, lamp untouched. The appliance reported vent=1, lamp unchanged at 0.
+        dev.setProperty('fan_speed', '1')
+        assert.equal(hex(thinq.outbox[0]), 'AA0EF043220401018080808046BB')
+
+        // fan -> 2 while it was running at 4. The appliance went to 2, which is what proves the
+        // level byte is absolute rather than a count of presses to advance by.
+        thinq.resetRecorder()
+        dev.setProperty('fan_speed', '2')
+        assert.equal(hex(thinq.outbox[0]), 'AA0EF043220401028080808041BB')
+    })
+
+    test('setting the lamp level leaves the vent alone', () => {
+        const { thinq, dev } = makeDevice()
+
+        // lamp -> 1 while the vent ran at 1. The appliance reported vent=1, lamp=1.
+        dev.setProperty('light_level', '1')
+        assert.equal(hex(thinq.outbox[0]), 'AA0EF043220480800101808046BB')
+    })
+
+    test('turning a control off sends the off command for that control only', () => {
+        const { thinq, dev } = makeDevice()
+
+        // lamp off, vent untouched. The appliance reported vent=0, lamp=0.
+        dev.setProperty('light_power', 'OFF')
+        assert.equal(hex(thinq.outbox[0]), 'AA0EF043220480800000808044BB')
+
+        thinq.resetRecorder()
+        dev.setProperty('fan_power', 'OFF')
+        assert.equal(hex(thinq.outbox[0]), 'AA0EF043220400008080808044BB')
+    })
+
+    test('turning a control on restores the level it last reported', () => {
+        const { thinq, dev } = makeDevice()
+
+        // the appliance last reported the vent at Turbo and the lamp at High
+        thinq.emit('data', SAMPLE_VENT_TURBO_LAMP_HIGH)
+        thinq.resetRecorder()
+
+        dev.setProperty('fan_power', 'ON')
+        assert.equal(hex(thinq.outbox[0]), 'AA0EF043220401048080808043BB')
+
+        thinq.resetRecorder()
+        dev.setProperty('light_power', 'ON')
+        assert.equal(hex(thinq.outbox[0]), 'AA0EF043220480800102808041BB')
+    })
+
+    test('out-of-range levels are clamped rather than sent verbatim', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.setProperty('fan_speed', '9')
+        assert.equal(hex(thinq.outbox[0]), 'AA0EF043220401048080808043BB')
+
+        thinq.resetRecorder()
+        dev.setProperty('light_level', 'not a number')
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('cooking state, mode, power level and remaining time', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', SAMPLE_COOKING_FULL_POWER_5MIN)
+        let props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.status, 'Cooking')
+        assert.equal(props.cook_mode, 'Microwave')
+        assert.equal(props.power_level, 10)
+        assert.equal(props.remaining_time, 300)
+
+        thinq.emit('data', SAMPLE_COOKING_4M59S)
+        assert.equal(ha.devices[DEVICE_ID].properties.remaining_time, 299)
+
+        thinq.emit('data', SAMPLE_COOKING_HALF_POWER_30S)
+        props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.power_level, 5)
+        assert.equal(props.remaining_time, 30)
+        // rec[20] is a seconds byte: a sub-minute cook length is not just hours*3600+minutes*60.
+        assert.equal(props.cook_time, 30)
+    })
+
+    test('a duration over an hour keeps counting in minutes, it does not borrow', () => {
+        // 90 minutes reads 90 in the minutes byte, and the cloud reports LWOTimerMinute:90 rather
+        // than an hour and thirty. The byte ahead of the pair, which its position would suggest is
+        // hours, stays 0 and is deliberately not read.
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', TIMER_90_MINUTES)
+        assert.equal(ha.devices[DEVICE_ID].properties.timer, 90 * 60)
+    })
+
+    test('the cook length is kept apart from what is left of it', () => {
+        const { ha, thinq } = makeDevice()
+        const props = () => ha.devices[DEVICE_ID].properties
+
+        // A five-minute cook: both read 5 minutes at the start, then the remaining time ticks down
+        // while the length it was given holds.
+        thinq.emit('data', SAMPLE_COOKING_FULL_POWER_5MIN)
+        assert.equal(props().cook_time, 300)
+        assert.equal(props().remaining_time, 300)
+
+        thinq.emit('data', SAMPLE_COOKING_4M59S)
+        assert.equal(props().cook_time, 300)
+        assert.equal(props().remaining_time, 299)
+
+        // 90 minutes is where the two formats diverge: the length is 1 hour 30 in rec[18..19] while
+        // the remaining time is a flat 90 in its minutes byte.
+        thinq.emit('data', COOKING_90_MINUTES)
+        assert.equal(props().cook_time, 90 * 60)
+        assert.equal(props().remaining_time, 90 * 60)
+    })
+
+    test('paused, done and settings states', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', SAMPLE_PAUSED)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Paused')
+        assert.equal(ha.devices[DEVICE_ID].properties.remaining_time, 270)
+
+        thinq.emit('data', SAMPLE_DONE)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Done')
+        assert.equal(ha.devices[DEVICE_ID].properties.remaining_time, 0)
+
+        thinq.emit('data', SAMPLE_SENSOR_COOK_SETTINGS)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Settings')
+        assert.equal(ha.devices[DEVICE_ID].properties.cook_mode, 'Sensor cook')
+    })
+
+    test('a preset run reports the auto cook mode', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', SAMPLE_AUTO_COOK_RUNNING)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.status, 'Cooking')
+        assert.equal(props.cook_mode, 'Auto cook')
+        assert.equal(props.power_level, 10)
+        assert.equal(props.remaining_time, 70)
+    })
+
+    test('the dish is read as one 16-bit id spanning both of its bytes', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', SAMPLE_SENSOR_COOK_RICE)
+        assert.equal(ha.devices[DEVICE_ID].properties.cook_mode, 'Sensor cook')
+        assert.equal(ha.devices[DEVICE_ID].properties.cook_item, 'Rice')
+
+        // 0x0108: the high byte is set here, so a single-byte read would report Shrimp (8).
+        thinq.emit('data', SAMPLE_SENSOR_REHEAT_SOUP)
+        assert.equal(ha.devices[DEVICE_ID].properties.cook_item, 'Reheat soup or sauce')
+
+        thinq.emit('data', SAMPLE_AUTO_COOK_RUNNING)
+        assert.equal(ha.devices[DEVICE_ID].properties.cook_item, 'Kids mac and cheese')
+
+        // Two dishes off the same menu, so the id and not the mode is what tells them apart.
+        thinq.emit('data', SAMPLE_SOFTEN_BUTTER)
+        assert.equal(ha.devices[DEVICE_ID].properties.cook_mode, 'Auto cook')
+        assert.equal(ha.devices[DEVICE_ID].properties.cook_item, 'Soften butter')
+        assert.equal(ha.devices[DEVICE_ID].properties.power_level, 2)
+
+        thinq.emit('data', SAMPLE_INITIAL_STATUS)
+        assert.equal(ha.devices[DEVICE_ID].properties.cook_item, 'Not selected')
+    })
+
+    test('a defrost run reports its mode and the power level the appliance chose', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', SAMPLE_DEFROST_RUNNING)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.status, 'Cooking')
+        assert.equal(props.cook_mode, 'Inverter defrost')
+        assert.equal(props.power_level, 7)
+        assert.equal(props.remaining_time, 600)
+    })
+
+    test('the single-record 41 EB reply decodes like the 41 EC current record', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', SAMPLE_INITIAL_STATUS)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.status, 'Idle')
+        assert.equal(props.cook_mode, 'Off')
+        assert.equal(props.fan_speed, 0)
+        assert.equal(props.light_level, 2)
+    })
+
+    test('frames of the wrong length or class publish nothing', () => {
+        const { ha, thinq } = makeDevice()
+
+        // a 41/3e frame, which carries no state this handler decodes
+        thinq.emit('data', buf('AA0B413E000D000D001BBB'))
+        // an EC frame truncated by one byte
+        thinq.emit('data', buf('AA6141EC003000015500000000000000FFBB'))
+
+        assert.deepEqual(ha.devices[DEVICE_ID].properties, {})
+    })
+})


### PR DESCRIPTION

Adds a handler for modelId WMVEL2137 (thinq2 deviceType 302), the
over-the-range microwave and hood sold as MVEL2033F. Read and write,
verified on the appliance.

This is a different appliance from WMVEM1825 and cannot be aliased to
it: that model has two fan levels, this one four plus off, and the two
pack the vent and lamp nibbles in opposite halves of their status byte.

Published read-only: the appliance state, the cook mode, the dish being
cooked, the power level, the remaining time, the length the cook was
given, and the kitchen timer. The vent fan is a fan platform and the
lamp a light platform, both writable.

Confirmed against live capture, with rethink bridged to the LG cloud so
every byte change could be matched against LG's own decoded state at
the same timestamp:

- The five cook modes, each against LWOManualCookName.
- rec[6:8] as a big-endian dish id, reported verbatim by the cloud as
  LWOSubCookName. 25 dishes are named from the panel.
- The vent and lamp nibbles of rec[36], nine consecutive single-variable
  transitions for the fan and four for the lamp. Issue #93 documents the
  opposite nibble order for this modelId; on this appliance it is
  unambiguous.
- The write path: a 10-byte inner body, with the level absolute rather
  than an advance count, which is the other correction to issue #93.
  Sending level 2 while the fan ran at 4 gave 2, and "advance 4" from
  Low gave 4 rather than wrapping to off.
- All three durations, on cooks of 30 seconds, five and 90 minutes and
  timers of one, 25, 61 and 90 minutes.

The two countdowns are a minutes byte and a seconds byte with no hour
in front, despite the layout suggesting one: a 90-minute timer reads 90
and a 61-minute one counts through 60:59 to 59:58 without borrowing,
and the cloud reports LWOTimerMinute:90 rather than an hour and thirty.
A byte holds 255 minutes, past anything either field needs.

The cook length at rec[18:20] is the one field that does split into
hours and minutes, matching LWOTargetTimeHour and LWOTargetTimeMinute:
a 90-minute cook reads 1 and 30 there while the remaining time counts a
flat 90 down. It holds steady while the remaining time ticks, and both
bytes clear when the cook is cancelled. It carries no seconds, so a
cook shorter than a minute reports 0, which is what LG's own field
does.

Outstanding and unknown:

- rec[15] and rec[21], the bytes ahead of each countdown pair, have been
  0 in every record ever captured and are deliberately not read: taking
  them for hours, which their position suggests, would silently add
  whole hours to a duration if they are something else.
- Dish ids are sparse and only those 25 have been read off the panel.
  An unlisted id reports unknown rather than a guess. The alphabetical
  ordering that corroborates the Sensor Cook, Melt and Steam Cook blocks
  does not extend to Defrost or the Kids Menu, so those entries rest on
  the panel reading alone.
- The modelJSON carries a 12-entry error table that has not been
  exercised, since that needs a real fault. No error entity is exposed.
- The vent can change level with no command from rethink: with the
  range-hood interaction enabled in the ThinQ app, any cooktop element
  on the matching LG range brings the fan to level 1. Documented at
  VENT_LAMP_OFFSET, since a driver assuming the level only moves on
  command would be wrong.
