### PR TITLE
Add support for the LG DLHC5502V heat-pump dryer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The following appliances are currently supported in rethink:
     - 🫤 DLE7300WE - preliminary support
     - 👍 DLEX3900B (RV13B6BSD_D_US_WIFI), Electric Dryer - mostly working
     - 👍 RV13B6ES_D_US_WIFI, Electric Dryer - mostly working
+    - 👍 DLHC5502V (BDH_D30007_US), Heat-Pump Dryer - mostly working, read-only
 - WashTowers (combined washer+dryer):
     - 👍 WKEX200HBA (WTL_FXU_BDV_NA_01), WashTower - mostly working
 - Dehumidifiers

--- a/cloud/devices/BDH_D30007_US.ts
+++ b/cloud/devices/BDH_D30007_US.ts
@@ -1,0 +1,465 @@
+import HADevice from './base'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import AABBDevice from './aabb_device'
+import { Enum } from '@/util/enum'
+
+// LG heat-pump dryer, matched on modelId "BDH_D30007_US" (thinq2 deviceType 202), sold as DLHC5502V.
+//
+// Like its matching washer (see FAFXU25006.ts) this model uses the long, length-escaped AABB framing
+// rather than the short one the RV13* dryers use. A frame on the wire looks like:
+//
+//     aa ff 30 0a 00 66 00 00 7e 00 01 00 ec 00 54 <payload> <chk16> bb
+//      │  │  │  │  └──┬──┘             │  └──┬──┘
+//      │  │  │  │     │                │     └ inner payload length
+//      │  │  │  │     │                └ inner frame type
+//      │  │  │  │     └ 16-bit total frame length
+//      │  │  │  └ envelope type
+//      │  │  └ class byte, 0x30 for the dryer (the washer uses 0x20)
+//      │  └ 0xFF escape: the real length follows as 16 bits, not in this byte
+//      └ AA
+//
+// AABBDevice.processData hands us buf = the frame minus AA/length and minus the trailing checksum and
+// BB, so buf[0] is the class byte and the inner type sits at buf[10] rather than at buf[1]. The
+// checksum is 16-bit in this framing, so buf carries one byte past the payload; that is why the
+// expected buf lengths below are one more than header + inner length.
+//
+// Inner types:
+//   0xEC  two stacked 42-byte records, previous state at buf[13] and current state at buf[55]
+//   0xEB  a single current-state record at buf[13], same field layout, sent in reply to a status query
+//   0x85/0x86  not status at all, an ASCII list of deactivated content ids
+//   0x00/0x31/0x4d/0x7f/0xc3/0x19/0x72/0xd8  not decoded
+//
+// Records are 42 bytes here against 72 on the washer and 28/29 on the RV13* dryers, and the fields sit
+// at different offsets from all of them, so this cannot be aliased to any existing handler.
+//
+// Every offset and table entry was confirmed live: real wire traffic captured while the dryer was
+// driven by hand at the panel and from the ThinQ app, with rethink bridged to the LG cloud so each
+// byte change could be matched against the cloud's own decoded washerDryer state at the same timestamp.
+
+const CLASS_BYTE = 0x30
+const ENVELOPE_TYPE = 0x0a
+const INNER_TYPE_OFFSET = 10
+const INNER_LEN_OFFSET = 11
+
+const RECORD_LEN = 42
+
+const STATUS_FRAME_TYPE = 0xec
+const STATUS_INNER_LEN = 2 * RECORD_LEN
+const STATUS_RECORD_OFFSET = 13 + RECORD_LEN // skip the "previous state" record
+const STATUS_BUF_LEN = 13 + STATUS_INNER_LEN + 1
+
+const SINGLE_STATUS_FRAME_TYPE = 0xeb
+const SINGLE_INNER_LEN = RECORD_LEN
+const SINGLE_RECORD_OFFSET = 13
+const SINGLE_BUF_LEN = 13 + SINGLE_INNER_LEN + 1
+
+// Status query, sent on every connect. LG's own, lifted verbatim from the cloud's traffic while
+// bridging, and byte for byte the same query it sends the matching washer. 0xF0ED is the family-wide
+// "report your state" request; actuating commands are 0xF0E5, so this only ever reads.
+const STATUS_REQUEST = 'F0ED112101000000180411120000'
+
+// Offsets are relative to the start of the 42-byte record.
+const DRY_LEVEL_OFFSET = 1
+const ECO_HYBRID_OFFSET = 2
+const COURSE_OFFSET = 5
+// rec[9:11] and rec[11:13] are BIG-endian 16-bit minute counts. Note this is the opposite byte order
+// from the matching washer, which is little-endian. Confirmed on 46 and 42 samples respectively.
+const REMAIN_TIME_OFFSET = 9
+const INITIAL_TIME_OFFSET = 11
+const STATE_OFFSET = 13
+const PRE_STATE_OFFSET = 14
+// rec[17:19], big-endian: energy used so far by the running cycle, in Wh, matching the cloud's
+// courseSpendPower on all 46 samples.
+const SPENT_POWER_OFFSET = 17
+const BUZZER_OFFSET = 19
+// rec[20] is the cloud's baseDownloadCourseData, the cycle the appliance has actually loaded, which
+// is a different field from rec[5] rather than a copy of it. They agree on most cycles, both reading 7
+// while the cloud says NORMAL for each, and part on five seen so far: AI Dry loads SHIRT1EA, Shrinkage
+// Relief loads LOWTEMPDRY, Easy Ironing loads AIRDRY, Silent Dry loads ULTRADELICATES and Rainy Days
+// loads SPEEDDRY. That is the same dial-position-versus-loaded-cycle split the RV13B6ES has on its
+// Downloaded Cycle. rec[5] is what the cloud calls course, so that is what gets published; rec[20] has
+// no table here because its values are the loaded sub-cycles rather than anything an owner selects.
+// rec[24]: options bitfield, each bit isolated by toggling one control at a time against the cloud.
+const OPT1_OFFSET = 24
+const OPT1_WRINKLE_CARE = 0x08
+const OPT1_DRUM_LIGHT = 0x20
+const OPT1_DAMP_DRY_BEEP = 0x40
+// rec[26]: a second options bitfield.
+const OPT2_OFFSET = 26
+const OPT2_DETECT_LOAD = 0x04
+// Remote Start, mirroring the cloud's remoteStart. Confirmed by switching it off at the panel on an
+// idle machine: rec[26] went 0x44 to 0x04 with nothing else moving and the cloud reporting
+// REMOTE_START_OFF.
+//
+// The appliance re-enables it on its own: starting a cycle by hand, with Remote Start off moments
+// earlier, took the byte back to 0x44 as the machine entered DETECTING, cloud REMOTE_START_ON in the
+// same frame. There is no way to turn this auto-enable off, so an ON here just means a cycle is
+// running or about to.
+const OPT2_REMOTE_START = 0x40
+// Condenser clean: set for exactly as long as the state byte in the same record reads 17
+// CONDENSER_CLEAN, and clear either side of it, on every cycle that runs one. The cloud names it
+// selfCleaning, not anything containing "condenser", which is worth knowing before hunting for it by
+// name: rec[26] goes 0x40 to 0x60 as the state becomes CONDENSER_CLEAN with
+// selfCleaning:"SELFCLEANING_ON" in the same frame, and back again five minutes later with
+// SELFCLEANING_OFF.
+const OPT2_CONDENSER_CLEAN = 0x20
+// rec[27]: a third flag byte. 0x40 and 0x80 have both been seen and are undecoded.
+const OPT3_OFFSET = 27
+// Cycle Optimization, which is what both the ThinQ app and the panel call it; LG's cloud files it as
+// autoCourseArrange. Toggled from the app in both directions with the bit alone moving in the record
+// and the cloud naming it in the same frame. It is on by default, which is why the bit reads 1 in
+// almost every record captured.
+const OPT3_CYCLE_OPTIMIZATION = 0x01
+// Remote Maintain, the setting that keeps the drum tumbling after a cycle ends. Confirmed on four
+// transitions across three cycles, each with the cloud naming it in the same second: 0x81 to 0x83 as
+// a run reaches DRYING, matched by remoteMaintain:"REMOTE_MAINTAIN_ON", and 0x83 back to 0x81 at
+// power-off, matched by REMOTE_MAINTAIN_OFF. This is also what makes a cycle end into state 22 rather
+// than 4 END, whether it was started by hand or from the app.
+const OPT3_REMOTE_MAINTAIN = 0x02
+
+const STATE_POWEROFF = 0
+
+// State codes. This dryer's wire codes follow its modelJSON enum indices exactly, the same as its
+// matching washer and unlike the LG range and microwave. Nine values have been seen live: 0 POWEROFF,
+// 1 INITIAL, 3 PAUSE and 7 DRYING from a run driven by hand and from the ThinQ app, and 4 END,
+// 8 COOLING, 14 DETECTING and 17 CONDENSER_CLEAN from a complete Towels cycle, all eight against the
+// cloud's own state field, plus 22 END_REMOTE_MAINTAIN_ON, which every cycle ends into instead of
+// 4 END while remoteMaintain is on, whether started by hand or from the app.
+//
+// The rest of the table is LG's indices for the same field. Anything outside it reports None
+// rather than a guess.
+const STATE = Enum.of({
+    Off: 0,
+    Initial: 1,
+    Running: 2,
+    Pause: 3,
+    End: 4,
+    Error: 5,
+    'Audible diagnosis': 6,
+    Drying: 7,
+    Cooling: 8,
+    'Wrinkle care': 9,
+    Reserved: 10,
+    'Delay load': 11,
+    'Spin reserve': 12,
+    'Auto test': 13,
+    Detecting: 14,
+    Steam: 15,
+    'Clothing recognition': 16,
+    'Condenser clean': 17,
+    'Bedding brushing': 18,
+    'Dry refreshing': 19,
+    'Allergy care': 20,
+    'Condenser care': 21,
+    'End remote maintain on': 22,
+    'Dry ready': 23,
+    'Laundry care': 24,
+    Dehumidification: 25,
+    'Dehumidification end': 26,
+    'End waiting': 27,
+    'Drum care': 28,
+})
+
+// Course codes. Ten are dial positions, the other twelve reachable only from the ThinQ app. This
+// model's modelJSON carries no course index table, so every code came from selecting that cycle and
+// reading the byte. The cloud's 22-entry panelCrsList happens to match this set, but is not the
+// catalogue: on the matching washer it is the panel's currently-assigned slots, seen at ten entries
+// and then six, so expect this table to be missing cycles.
+//
+// Names are what the panel calls each cycle, not the cloud identifiers, which disagree on most of
+// them and not merely in wording: code 9 is Small Load here but QUICKDRY there, while the panel's own
+// Quick Dry is code 23 (BABYWEAR). Publishing the cloud names would tell an owner their dryer was
+// running something it is not, so each entry keeps its identifier as a trailing comment instead.
+const COURSE = Enum.of({
+    Towels: 2, // TOWELS
+    Bedding: 4, // BEDDING
+    'Perm. Press': 5, // EASYCARE
+    Normal: 7, // NORMAL
+    Activewear: 8, // SPORTWEAR
+    'Small Load': 9, // QUICKDRY
+    Delicates: 10, // DELICATES
+    'Air Dry': 13, // COOLAIR
+    'Bedding Refresh': 15, // BEDDINGBRUSH
+    'Power Dry': 16, // ALLERGYCARE
+    'Heavy Duty': 17, // POWER
+    'Condenser Care': 18, // CONDENSERCARE
+    'Drum Care': 19, // TUBCLEAN
+    'Down Jacket Refresh': 20, // PADDINGREFRESH
+    'Timed Dry': 21, // TIMEDRY
+    'Outerwear Refresh': 22, // WATERREPELLENT
+    'Quick Dry': 23, // BABYWEAR
+    'AI Dry': 44, // AI_COURSE
+    'Silent Dry': 45, // SILENT
+    'Shrinkage Relief': 46, // CLOTHCARE
+    'Rainy Days': 50, // RAINYDAY
+    'Easy Ironing': 51, // EASYIRON
+    // Not a cycle of its own: the appliance is running a cycle pushed to it from the app, and which
+    // one is in rec[23] rather than here.
+    'Downloaded cycle': 255, // DOWNLOAD
+})
+
+// rec[23]: which downloaded cycle is loaded, the cloud's downloadCourse, and 0 when none is. It is a
+// separate field from the course precisely because rec[5] reads the same 255 sentinel for any of
+// them. Two have been pushed to this appliance so far; the app offers more, and an unlisted id
+// reports None rather than a guess.
+const DOWNLOAD_COURSE_OFFSET = 23
+const DOWNLOAD_COURSE = Enum.of({
+    None: 0,
+    'Wrinkle Prevention': 114, // MINIMIZEWRINKLES
+    'Rack Dry': 140, // RACKDRY
+})
+
+// Dry level 1-5, confirmed by stepping the button against the cloud's dryLevel. 0 (NO_DRYLEVEL) is
+// what the courses that do not sense dryness report, and falls through to None.
+const DRY_LEVEL = Enum.of({
+    'Damp Dry': 1,
+    'Less Dry': 2,
+    Iron: 3,
+    Cupboard: 4,
+    'Very Dry': 5,
+})
+
+// Eco Hybrid 1-3, confirmed the same way against the cloud's ecoHybrid. 0 is NO_ECOHYBRID.
+const ECO_HYBRID = Enum.of({
+    Eco: 1,
+    Normal: 2,
+    Turbo: 3,
+})
+
+// Buzzer volume 0-4, confirmed against the cloud's buzzer. Unlike the RV13B6ES, whose beeper setting
+// the cloud never reports, this model publishes it, so the whole scale is cloud-confirmed.
+const BUZZER = Enum.of({
+    Off: 0,
+    '1': 1,
+    '2': 2,
+    '3': 3,
+    '4': 4,
+})
+
+export default class Device extends AABBDevice {
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: 'LG Dryer' }),
+                components: {
+                    power: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-power',
+                        state_topic: '$this/power',
+                        name: 'Power',
+                        icon: 'mdi:tumble-dryer',
+                        device_class: 'running',
+                    },
+                    status: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-status',
+                        state_topic: '$this/status',
+                        name: 'Status',
+                        icon: 'mdi:state-machine',
+                        // free-text (NOT device_class:enum): unmapped state codes emit None.
+                    },
+                    pre_state: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-pre_state',
+                        state_topic: '$this/pre_state',
+                        name: 'Previous status',
+                        icon: 'mdi:history',
+                        entity_category: 'diagnostic',
+                    },
+                    download_course: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-download_course',
+                        state_topic: '$this/download_course',
+                        name: 'Downloaded cycle',
+                        icon: 'mdi:cloud-download-outline',
+                        entity_category: 'diagnostic',
+                    },
+                    course: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-course',
+                        state_topic: '$this/course',
+                        name: 'Course',
+                        icon: 'mdi:pin-outline',
+                    },
+                    remaining_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-remaining_time',
+                        state_topic: '$this/remaining_time',
+                        name: 'Remaining time',
+                        icon: 'mdi:timer-outline',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                    },
+                    initial_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-initial_time',
+                        state_topic: '$this/initial_time',
+                        name: 'Initial time estimate',
+                        icon: 'mdi:clock-outline',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        entity_category: 'diagnostic',
+                    },
+                    spent_power: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-spent_power',
+                        state_topic: '$this/spent_power',
+                        name: 'Energy',
+                        icon: 'mdi:lightning-bolt',
+                        device_class: 'energy',
+                        unit_of_measurement: 'Wh',
+                        state_class: 'total_increasing',
+                    },
+                    dry_level: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-dry_level',
+                        state_topic: '$this/dry_level',
+                        name: 'Dry level',
+                        icon: 'mdi:water-percent',
+                    },
+                    eco_hybrid: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-eco_hybrid',
+                        state_topic: '$this/eco_hybrid',
+                        name: 'Eco Hybrid',
+                        icon: 'mdi:leaf',
+                    },
+                    buzzer: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-buzzer',
+                        state_topic: '$this/buzzer',
+                        name: 'Buzzer',
+                        icon: 'mdi:volume-high',
+                        entity_category: 'diagnostic',
+                    },
+                    wrinkle_care: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-wrinkle_care',
+                        state_topic: '$this/wrinkle_care',
+                        name: 'Wrinkle Care',
+                        icon: 'mdi:tshirt-crew-outline',
+                    },
+                    damp_dry_beep: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-damp_dry_beep',
+                        state_topic: '$this/damp_dry_beep',
+                        name: 'Damp Dry Signal',
+                        icon: 'mdi:water-alert-outline',
+                    },
+                    detect_load: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-detect_load',
+                        state_topic: '$this/detect_load',
+                        name: 'Detect load',
+                        icon: 'mdi:scale',
+                    },
+                    cycle_optimization: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-cycle_optimization',
+                        state_topic: '$this/cycle_optimization',
+                        name: 'Cycle optimization',
+                        icon: 'mdi:auto-fix',
+                        entity_category: 'diagnostic',
+                    },
+                    remote_maintain: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-remote_maintain',
+                        state_topic: '$this/remote_maintain',
+                        name: 'Remote maintain',
+                        icon: 'mdi:cellphone-wireless',
+                        entity_category: 'diagnostic',
+                    },
+                    condenser_clean: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-condenser_clean',
+                        state_topic: '$this/condenser_clean',
+                        name: 'Condenser clean',
+                        icon: 'mdi:air-filter',
+                    },
+                    remote_start: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-remote_start',
+                        state_topic: '$this/remote_start',
+                        name: 'Remote start',
+                        icon: 'mdi:cellphone-wireless',
+                        entity_category: 'diagnostic',
+                    },
+                    drum_light: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-drum_light',
+                        state_topic: '$this/drum_light',
+                        name: 'Drum light',
+                        icon: 'mdi:lightbulb',
+                        entity_category: 'diagnostic',
+                    },
+                },
+            }),
+        )
+    }
+
+    // This dryer only volunteers a status frame when something changes, so a driver that never asks
+    // stays blank until the next physical interaction, and every reconnect would otherwise leave Home
+    // Assistant pinned at unknown. Asking once per connect is what makes the entities survive a
+    // restart. LG's own cloud does exactly this.
+    start() {
+        this.send(Buffer.from(STATUS_REQUEST, 'hex'))
+    }
+
+    processAABB(buf: Buffer) {
+        if (buf.length < 13 || buf[0] !== CLASS_BYTE || buf[1] !== ENVELOPE_TYPE) return
+
+        const innerLen = buf.readUInt16BE(INNER_LEN_OFFSET)
+        switch (buf[INNER_TYPE_OFFSET]) {
+            case STATUS_FRAME_TYPE:
+                if (innerLen !== STATUS_INNER_LEN) return
+                return this.processStatus(buf, STATUS_RECORD_OFFSET, STATUS_BUF_LEN)
+            case SINGLE_STATUS_FRAME_TYPE:
+                if (innerLen !== SINGLE_INNER_LEN) return
+                return this.processStatus(buf, SINGLE_RECORD_OFFSET, SINGLE_BUF_LEN)
+            // 0x85/0x86 (content id lists) and the rest are not status records and are not decoded.
+        }
+    }
+
+    private processStatus(buf: Buffer, recordOffset: number, expectedLen: number) {
+        if (buf.length !== expectedLen) return // reject header/layout drift
+        const rec = buf.subarray(recordOffset, recordOffset + RECORD_LEN)
+
+        const state = rec[STATE_OFFSET]
+        const isOff = state === STATE_POWEROFF
+
+        this.publishProperty('power', isOff ? 'OFF' : 'ON')
+        this.publishProperty('status', STATE.map(state))
+        this.publishProperty('pre_state', STATE.map(rec[PRE_STATE_OFFSET]))
+        this.publishProperty('course', COURSE.map(rec[COURSE_OFFSET]))
+        this.publishProperty('download_course', DOWNLOAD_COURSE.map(rec[DOWNLOAD_COURSE_OFFSET]))
+        this.publishProperty('dry_level', DRY_LEVEL.map(rec[DRY_LEVEL_OFFSET]))
+        this.publishProperty('eco_hybrid', ECO_HYBRID.map(rec[ECO_HYBRID_OFFSET]))
+        this.publishProperty('buzzer', BUZZER.map(rec[BUZZER_OFFSET]))
+        this.publishProperty('remaining_time', isOff ? 0 : rec.readUInt16BE(REMAIN_TIME_OFFSET))
+        this.publishProperty('initial_time', isOff ? 0 : rec.readUInt16BE(INITIAL_TIME_OFFSET))
+        this.publishProperty('spent_power', rec.readUInt16BE(SPENT_POWER_OFFSET))
+
+        const opt1 = rec[OPT1_OFFSET]
+        this.publishProperty('wrinkle_care', (opt1 & OPT1_WRINKLE_CARE) !== 0 ? 'ON' : 'OFF')
+        this.publishProperty('drum_light', (opt1 & OPT1_DRUM_LIGHT) !== 0 ? 'ON' : 'OFF')
+        this.publishProperty('damp_dry_beep', (opt1 & OPT1_DAMP_DRY_BEEP) !== 0 ? 'ON' : 'OFF')
+
+        const opt2 = rec[OPT2_OFFSET]
+        this.publishProperty('detect_load', (opt2 & OPT2_DETECT_LOAD) !== 0 ? 'ON' : 'OFF')
+        this.publishProperty('remote_start', (opt2 & OPT2_REMOTE_START) !== 0 ? 'ON' : 'OFF')
+        this.publishProperty('condenser_clean', (opt2 & OPT2_CONDENSER_CLEAN) !== 0 ? 'ON' : 'OFF')
+
+        const opt3 = rec[OPT3_OFFSET]
+        this.publishProperty('remote_maintain', (opt3 & OPT3_REMOTE_MAINTAIN) !== 0 ? 'ON' : 'OFF')
+        this.publishProperty('cycle_optimization', (opt3 & OPT3_CYCLE_OPTIMIZATION) !== 0 ? 'ON' : 'OFF')
+        // Not published: rec[16], a cycle-phase index that runs the same sequence on every complete
+        // cycle and also differs per course while idle, but matches no cloud field and so has no name
+        // to publish it under, and the 0x40 and 0x80 bits of rec[27]. The error code was never
+        // located. There is no door sensor to find: this model's full state dump carries doorLock but
+        // no doorClose, where the matching washer's carries both.
+    }
+}

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -22,6 +22,7 @@ import F3L7CYK5W_US_WIFI from './devices/F3L7CYK5W_US_WIFI'
 import RV13B6BSD_D_US_WIFI from './devices/RV13B6BSD_D_US_WIFI'
 import RV13B6ES_D_US_WIFI from './devices/RV13B6ES_D_US_WIFI'
 import WTL_FXU_BDV_NA_01 from './devices/WTL_FXU_BDV_NA_01'
+import BDH_D30007_US from './devices/BDH_D30007_US'
 import DHUM_056905_WW from './devices/DHUM_056905_WW'
 import ST_B_E4H01Y_APL from './devices/ST_B_E4H01Y_APL'
 import { Device as T1Device } from './thinq1/device'
@@ -70,6 +71,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['RV13B6ES_D_US_WIFI']: RV13B6ES_D_US_WIFI, // LG electric dryer, same frame layout as RV13B6BSD but
     // Wrinkle Care sits in a different bitfield, so it needs its own handler rather than an alias
     WTL_FXU_BDV_NA_01, // LG WashTower
+    BDH_D30007_US, // LG DLHC5502V heat-pump dryer, long 0xFF-escaped AABB framing with 42-byte records
     DHUM_056905_WW,
     ST_B_E4H01Y_APL,
 }

--- a/tests/cloud/devices/BDH_D30007_US.test.ts
+++ b/tests/cloud/devices/BDH_D30007_US.test.ts
@@ -1,0 +1,402 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/BDH_D30007_US'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'BDH_D30007_US'
+const META: Metadata = { modelId: MODEL_ID, modelName: MODEL_ID, swVersion: '0.0.0' }
+
+// All fixtures are REAL frames captured live from the appliance via rethink-capture, each cross-checked
+// against the LG cloud's own decoded washerDryer state at matching timestamps, not guessed from static
+// analysis. The comments name the cloud field that confirmed each one.
+
+// Tub Clean selected: cloud course:"TUBCLEAN", ecoHybrid:"ECOHYBRID_TURBO", remainTimeMinute:160.
+const TUB_CLEAN = buf(
+    'aaff300a0066004f45000100ec005400030200020700000000640000010000000000040700000000000481070000000000000000000000000000000300021300000000a000000100000200000413000000000000810700000000000000000000000000317ebb',
+)
+
+// Time Dry: cloud course:"TIMEDRY", ecoHybrid:"ECOHYBRID_NORMAL", and a 30-minute estimate that shows
+// in both the countdown and the cycle-length field.
+const TIME_DRY = buf(
+    'aaff300a0066004f48000100ec005400000300021300000000a000000100000200000413000000000000810700000000000000000000000000000002000215000000001e001e0100000200000415000000000000810700000000000000000000000000b665bb',
+)
+
+// The AI dial position: cloud course:"AI_COURSE". This is the one place rec[5] and rec[20] disagree:
+// 44 on the dial, 28 for the cycle it loads, so it is what proves rec[5] is the field the cloud names.
+const AI_COURSE = buf(
+    'aaff300a0066004f5d000100ec005400000200020400000000c3001e010000020000040400000000000081070000000000000000000000000000000200022c0000000064001e010000000000041c00000000000481070000000000000000000000000039cabb',
+)
+
+// Towels: cloud course:"TOWELS" with detectLoad:"DETECT_LOAD_ON" (rec[26] bit 0x04).
+const TOWELS = buf(
+    'aaff300a0066004f51000100ec00540000030002100000000096001e01000001000004100000000000008107000000000000000000000000000000020002020000000064001e0100000000000402000000000004810700000000000000000000000000e470bb',
+)
+
+// Mid-run on Bedding: cloud course:"BEDDING", state:"DRYING" with preState:"PAUSE" (this frame is the
+// resume), remainTimeMinute:193 against an initialTimeMinute of 195, courseSpendPower:3.
+const DRYING = buf(
+    'aaff300a0066004e58000100ec005400000200020400000000c200c3070300020002040400000000004081070000000000000000000000000000000200020400000000c100c30703000200030404000000000040810700000000000000000000000000959ebb',
+)
+
+// Dry level stepped to the top: cloud dryLevel:"DRYLEVEL_VERYDRY" (rec[1] = 5).
+const DRY_LEVEL_VERY = buf(
+    'aaff300a0066004f13000100ec00540004020002070000000064000001000000000004070000002000048107000000000000000000000000000005020002070000000064000001000000000004070000002000048107000000000000000000000000004992bb',
+)
+
+// Eco Hybrid stepped to Eco: cloud ecoHybrid:"ECOHYBRID_ECO" (rec[2] = 1), with the dry level parked
+// at Iron in the same record.
+const ECO_HYBRID_ECO = buf(
+    'aaff300a0066004f05000100ec005400030200020700000000640000010000000000040700000020000481070000000000000000000000000000030100020700000000640000010000000000040700000020000481070000000000000000000000000002b3bb',
+)
+
+// Buzzer turned off: cloud buzzer:"BUZZER_OFF" (rec[19] = 0). Unlike the RV13B6ES, this model's beeper
+// setting is reported by the cloud, so the scale is confirmed rather than read off the panel LEDs.
+const BUZZER_OFF = buf(
+    'aaff300a0066004f26000100ec005400030200020700000000640000010000000000040700000000000481070000000000000000000000000000030200020700000000640000010000000000000700000000000481070000000000000000000000000000b1bb',
+)
+
+// Wrinkle Care on: cloud wrinkleCare:"WRINKLECARE_ON" (rec[24] bit 0x08), with the neighbouring bits
+// in the same byte clear.
+const WRINKLE_CARE_ON = buf(
+    'aaff300a0066004f3b000100ec00540003020002070000000064000001000000000004070000000000048107000000000000000000000000000003020002070000000064000001000000000004070000000800048107000000000000000000000000002692bb',
+)
+
+// Damp Dry Beep on: cloud dampDryBeep:"DAMPDRYBEEP_ON" (rec[24] bit 0x40), the other bit of that byte.
+const DAMP_DRY_BEEP_ON = buf(
+    'aaff300a0066004f20000100ec005400030200020700000000640000010000000000040700000000000481070000000000000000000000000000030200020700000000640000010000000000040700000040000481070000000000000000000000000086bfbb',
+)
+
+// Remote Start enabled at the panel: rec[26] went 0x04 to 0x44 with nothing else in the record moving,
+// and the cloud reported remoteStart:"REMOTE_START_ON" in the same notification.
+const REMOTE_START_ON = buf(
+    'aaff300a0066004f6b000100ec00540003020002070000000064001e01000000000004070000000000048107000000000000000000000000000003020002070000000064001e0100000000000407000000000044810700000000000000000000000000a3d4bb',
+)
+
+// Paused: cloud state:"PAUSE" with preState:"DRYING", and the drum light coming on with it
+// (rec[24] bit 0x20, cloud drumLight:"DRUMLIGHT_ON").
+const PAUSES = buf(
+    'aaff300a0066004e86000100ec005400000200020400000000bf00c3070300020006040400000000004081070000000000000000000000000000000200020400000000bf00c303070002000a0404000000200000810700000000000000000000000000e6fdbb',
+)
+
+// Powered off from the pause: cloud state:"POWEROFF" with preState:"PAUSE". The course and the timers
+// clear, but the 10 Wh the part-run used is still in rec[17:19].
+const POWERS_OFF = buf(
+    'aaff300a0066004e8f000100ec005400000200020400000000bf00c303070002000a04040000002000008107000000000000000000000000000000000002000000000000000000030000000a0400000000000000810700000000000000000000000000f3b5bb',
+)
+
+// The end of a 195-minute Bedding cycle: state 7 DRYING gives way to 17 CONDENSER_CLEAN and rec[26]
+// goes 0x40 to 0x60 in the same frame, the previous-state record still holding the old pair. The cloud
+// feed had lapsed an hour earlier, so this frame is confirmed against the state byte beside it; the
+// cloud pairing came from a later run, in CONDENSER_CLEAN_CLOUD below.
+const CONDENSER_CLEAN = buf(
+    'aaff300a0066005f34000100ec0054000002000204000000001500c30703000406f70404000000000040830700000000000000000000000000000002000204000000001400c31107000506fd0404000000000060830700000000000000000000000000ed51bb',
+)
+
+// Five minutes later the condenser clean ends: state 17 gives way to 8 COOLING and the 0x20 bit clears
+// again, which is the other half of the pairing.
+const COOLING = buf(
+    'aaff300a0066005f7f000100ec0054000002000204000000001000c31107000507040404000000000060830700000000000000000000000000000002000204000000001000c30811000507060404000000000040830700000000000000000000000000c820bb',
+)
+
+// The same cycle finishing. Because it had been remote-started, it settles into state 22
+// END_REMOTE_MAINTAIN_ON rather than 4 END, and lights the drum as it does so.
+const END_REMOTE_MAINTAIN = buf(
+    'aaff300a0066006060000100ec0054000002000204000000000100c30811000507180404000000000040830700000000000000000000000000000002000204000000000100c316080007071a0404000000200040830700000000000000000000000000c4ebbb',
+)
+
+// Remote Maintain coming on as a Normal cycle reaches DRYING: rec[27] goes 0x81 to 0x83 between the
+// previous-state and current-state records, and the cloud reported remoteMaintain:"REMOTE_MAINTAIN_ON"
+// in the same second.
+const REMOTE_MAINTAIN_ON = buf(
+    'aaff300a0066006191000100ec0054000302000207000000006400640e0100000000040700000000004481070000000000000000000000000000030200020700000000680069070e0002000a040700000000004083070000000000000000000000000000a8bb',
+)
+
+// And going off again as the previous cycle's remote-maintain end is powered off: 0x83 back to 0x81,
+// with the cloud reporting REMOTE_MAINTAIN_OFF a second later.
+const REMOTE_MAINTAIN_OFF = buf(
+    'aaff300a00660060fe000100ec0054000002000204000000000100c316080007071a04040000000000408307000000000000000000000000000000000002000000000000000000160000071c0400000000000000810700000000000000000000000000b025bb',
+)
+
+// Remote Start switched OFF at the panel with the machine idle: rec[26] goes 0x44 to 0x04 and the
+// cloud reports remoteStart:"REMOTE_START_OFF", which is what shows the bit is the setting itself.
+const REMOTE_START_SWITCHED_OFF = buf(
+    'aaff300a0066007b9f000100ec0054000302000207000000006400000100000000000407000000000044810700000000000000000000000000000302000207000000006400000100000000000407000000000004810700000000000000000000000000bd50bb',
+)
+
+// And a cycle started BY HAND moments later, with the setting still off: the byte goes straight back
+// to 0x44 as the machine enters DETECTING and the cloud reports REMOTE_START_ON again. The appliance
+// turns the setting on by itself when a cycle starts, which the matching LG range exposes as its
+// "Auto Remote" setting and this dryer does not.
+const HAND_STARTED_WITH_REMOTE_OFF = buf(
+    'aaff300a0066006eac000100ec0054000000000200000000000000000100000000000400000000200000810700000000000000000000000000000302000207000000006400640e010000000004070000000000448107000000000000000000000000002823bb',
+)
+
+// The same transition on a later run with the feed live, which names the field: the cloud reported
+// selfCleaning:"SELFCLEANING_ON" with state "CONDENSER_CLEAN" in the frame rec[26] went 0x40 to 0x60.
+const CONDENSER_CLEAN_CLOUD = buf(
+    'aaff300a006600738c000100ec005400030200020700000000150055070e000402500407000000000040830700000000000000000000000000000302000207000000001400551107000502590407000000000060830700000000000000000000000000b6f9bb',
+)
+
+// Cycle Optimization switched off from the app and back on, cloud autoCourseArrange OFF then ON.
+// rec[27] bit 0x01 is the only bit of the record to move either way, which is what separates it from
+// the remote maintain bit sharing the byte.
+const CYCLE_OPTIMIZATION_OFF = buf(
+    'aaff300a0066007c2e000100ec0054000301000207000000006400640100000000000407000000200004810700000000000000000000000000000302000207000000006400640100000000000407000000200004800700000000000000000000000000aaf8bb',
+)
+const CYCLE_OPTIMIZATION_ON = buf(
+    'aaff300a0066007c61000100ec0054000302000207000000006400640100000000000207000000200004800700000000000000000000000000000302000207000000006400640100000000000207000000200004810700000000000000000000000000ee33bb',
+)
+
+// Three cycles reachable only from the app, none of them on the dial. Quick Dry, which the cloud
+// calls BABYWEAR while calling a different cycle QUICKDRY, and Shrinkage Relief, where rec[5] reads
+// 46 for CLOTHCARE while rec[20] loads 32 for LOWTEMPDRY.
+const APP_QUICK_DRY = buf(
+    'aaff300a0066007d2d000100ec005400000000020d000000001e001e010000050000020d000000000000810700000000000000000000000000000002000217000000003c001e0100000200000217000000000000810700000000000000000000000000662cbb',
+)
+const APP_SHRINKAGE_RELIEF = buf(
+    'aaff300a0066007d1e000100ec0054000003000216000000003c001e010000010000021600000000000081070000000000000000000000000000020200022e000000006e001e0100000200000220000000000000810700000000000000000000000000f7e8bb',
+)
+
+// A cycle pushed to the appliance from the app: rec[5] is the 255 DOWNLOAD sentinel rather than a
+// course code, and which cycle it actually is sits in rec[23]. Cloud: course "DOWNLOAD" with
+// downloadCourse "MINIMIZEWRINKLES", which the panel calls Wrinkle Prevention.
+const DOWNLOADED_CYCLE = buf(
+    'aaff300a0066007d52000100ec00540000030002320000000028001e01000002000002220000000000008107000000000000000000000000000003020002ff000000006400280100000000000207000072080004810700000000000000000000000000ede3bb',
+)
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+function feed(frames: Buffer[]) {
+    const { ha, thinq } = makeDevice()
+    for (const f of frames) thinq.emit('data', f)
+    return ha.devices[DEVICE_ID].properties
+}
+
+describe('BDH_D30007_US', () => {
+    test('the course table covers the whole dial', () => {
+        assert.equal(feed([TUB_CLEAN]).course, 'Drum Care')
+        assert.equal(feed([TIME_DRY]).course, 'Timed Dry')
+        assert.equal(feed([TOWELS]).course, 'Towels')
+        assert.equal(feed([DRYING]).course, 'Bedding')
+        assert.equal(feed([DRY_LEVEL_VERY]).course, 'Normal')
+    })
+
+    test('cycles reachable only from the app are named from the panel, not the cloud', () => {
+        // The cloud calls this one BABYWEAR. The panel calls it Quick Dry, and calls the cycle the
+        // cloud names QUICKDRY "Small Load", so publishing LG's identifiers would swap the two.
+        assert.equal(feed([APP_QUICK_DRY]).course, 'Quick Dry')
+        assert.equal(feed([TIME_DRY]).course, 'Timed Dry')
+
+        // rec[5] and rec[20] part company here as well as on the AI position
+        assert.equal(feed([APP_SHRINKAGE_RELIEF]).course, 'Shrinkage Relief')
+    })
+
+    test('a downloaded cycle is a sentinel course plus its own identifier', () => {
+        const p = feed([DOWNLOADED_CYCLE])
+        assert.equal(p.course, 'Downloaded cycle') // rec[5] is 255, cloud course DOWNLOAD
+        assert.equal(p.download_course, 'Wrinkle Prevention') // cloud downloadCourse MINIMIZEWRINKLES
+
+        // and an ordinary cycle reports no downloaded one
+        assert.equal(feed([TOWELS]).download_course, 'None')
+    })
+
+    test('the AI dial position is read from rec[5], not the loaded-cycle byte', () => {
+        // rec[5] is 44 and rec[20] is 28 in this frame; the cloud calls it AI_COURSE, which is rec[5].
+        // The panel calls that position "AI Dry", which is the name published.
+        const p = feed([AI_COURSE])
+        assert.equal(p.course, 'AI Dry')
+    })
+
+    test('the minute counters are big-endian, unlike the matching washer', () => {
+        // 160 arrives as 00 a0. Read little-endian this would be 41 minutes.
+        const tub = feed([TUB_CLEAN])
+        assert.equal(tub.remaining_time, 160)
+
+        // and a course where the countdown and the cycle length differ
+        const drying = feed([DRYING])
+        assert.equal(drying.remaining_time, 193)
+        assert.equal(drying.initial_time, 195)
+        assert.equal(drying.spent_power, 3) // cloud: courseSpendPower 3 Wh
+    })
+
+    test('dry level and eco hybrid each read from their own byte', () => {
+        const very = feed([DRY_LEVEL_VERY])
+        assert.equal(very.dry_level, 'Very Dry') // cloud: DRYLEVEL_VERYDRY
+        assert.equal(very.eco_hybrid, 'Normal')
+
+        const eco = feed([ECO_HYBRID_ECO])
+        assert.equal(eco.eco_hybrid, 'Eco') // cloud: ECOHYBRID_ECO
+        assert.equal(eco.dry_level, 'Iron') // and the dry level is undisturbed
+
+        assert.equal(feed([TUB_CLEAN]).eco_hybrid, 'Turbo')
+        // a course that does not sense dryness reports the 0 sentinel, not a level
+        assert.equal(feed([TUB_CLEAN]).dry_level, 'None')
+    })
+
+    test('the buzzer volume is cloud-confirmed on this model', () => {
+        assert.equal(feed([BUZZER_OFF]).buzzer, 'Off') // cloud: BUZZER_OFF
+        assert.equal(feed([TUB_CLEAN]).buzzer, '4') // cloud: BUZZER_4
+    })
+
+    test('wrinkle care, the drum light and the damp dry beep share rec[24] without collision', () => {
+        const wrinkle = feed([WRINKLE_CARE_ON])
+        assert.equal(wrinkle.wrinkle_care, 'ON')
+        assert.equal(wrinkle.damp_dry_beep, 'OFF')
+        assert.equal(wrinkle.drum_light, 'OFF')
+
+        const beep = feed([DAMP_DRY_BEEP_ON])
+        assert.equal(beep.damp_dry_beep, 'ON')
+        assert.equal(beep.wrinkle_care, 'OFF')
+        assert.equal(beep.drum_light, 'OFF')
+    })
+
+    test('cycle optimization is the low bit of the byte remote maintain sits in', () => {
+        const off = feed([CYCLE_OPTIMIZATION_OFF])
+        assert.equal(off.cycle_optimization, 'OFF') // cloud: autoCourseArrange OFF
+        assert.equal(off.remote_maintain, 'OFF') // 0x02 of the same byte, untouched
+
+        const on = feed([CYCLE_OPTIMIZATION_ON])
+        assert.equal(on.cycle_optimization, 'ON') // cloud: autoCourseArrange ON
+        assert.equal(on.remote_maintain, 'OFF')
+
+        // and it reads on through a run, where remote maintain is on beside it
+        assert.equal(feed([DRYING]).cycle_optimization, 'ON')
+        assert.equal(feed([DRYING]).remote_maintain, 'OFF')
+    })
+
+    test('remote start is the setting, which the appliance switches on at every cycle start', () => {
+        // Switched off at the panel with the machine idle, which is the half that shows the bit is
+        // the setting and not merely "a cycle is running".
+        const off = feed([REMOTE_START_SWITCHED_OFF])
+        assert.equal(off.remote_start, 'OFF') // cloud: remoteStart REMOTE_START_OFF
+        assert.equal(off.status, 'Initial')
+        assert.equal(off.detect_load, 'ON') // 0x04 of the same byte is untouched
+
+        // Then a cycle started by hand, with the setting still off, brings it back by itself.
+        const started = feed([REMOTE_START_SWITCHED_OFF, HAND_STARTED_WITH_REMOTE_OFF])
+        assert.equal(started.status, 'Detecting') // cloud: state DETECTING
+        assert.equal(started.pre_state, 'Initial')
+        assert.equal(started.remote_start, 'ON') // cloud: remoteStart REMOTE_START_ON
+        assert.equal(started.course, 'Normal')
+    })
+
+    test('remote start and detect load share rec[26]', () => {
+        const remote = feed([REMOTE_START_ON])
+        assert.equal(remote.remote_start, 'ON')
+        assert.equal(remote.detect_load, 'ON')
+
+        const towels = feed([TOWELS])
+        assert.equal(towels.detect_load, 'ON')
+        assert.equal(towels.remote_start, 'OFF')
+
+        // Tub Clean does not weigh a load, so the bit is clear there
+        assert.equal(feed([TUB_CLEAN]).detect_load, 'OFF')
+    })
+
+    test('the condenser clean flag tracks the state that names it', () => {
+        const clean = feed([CONDENSER_CLEAN])
+        assert.equal(clean.status, 'Condenser clean')
+        assert.equal(clean.condenser_clean, 'ON')
+        assert.equal(clean.remote_start, 'ON') // the run was remote-started, and 0x40 stays up
+
+        const cooling = feed([CONDENSER_CLEAN, COOLING])
+        assert.equal(cooling.status, 'Cooling')
+        assert.equal(cooling.pre_state, 'Condenser clean')
+        assert.equal(cooling.condenser_clean, 'OFF')
+        assert.equal(cooling.remote_start, 'ON')
+
+        // and it is clear on a course that never runs one
+        assert.equal(feed([TUB_CLEAN]).condenser_clean, 'OFF')
+
+        // the same transition with the cloud watching, which is what named the field
+        const witnessed = feed([CONDENSER_CLEAN_CLOUD])
+        assert.equal(witnessed.status, 'Condenser clean') // cloud: state CONDENSER_CLEAN
+        assert.equal(witnessed.condenser_clean, 'ON') // cloud: selfCleaning SELFCLEANING_ON
+        assert.equal(witnessed.pre_state, 'Drying')
+    })
+
+    test('a remote-started cycle ends into the remote-maintain state, not plain End', () => {
+        const p = feed([COOLING, END_REMOTE_MAINTAIN])
+        assert.equal(p.status, 'End remote maintain on')
+        assert.equal(p.pre_state, 'Cooling')
+        assert.equal(p.power, 'ON')
+        assert.equal(p.remaining_time, 1)
+        assert.equal(p.spent_power, 1818) // what the whole 195-minute Bedding cycle used
+        assert.equal(p.drum_light, 'ON')
+    })
+
+    test('remote maintain is rec[27] bit 0x02, not part of either options byte', () => {
+        const on = feed([REMOTE_MAINTAIN_ON])
+        assert.equal(on.status, 'Drying') // cloud: state DRYING
+        assert.equal(on.remote_maintain, 'ON') // cloud: remoteMaintain REMOTE_MAINTAIN_ON
+
+        const off = feed([REMOTE_MAINTAIN_OFF])
+        assert.equal(off.status, 'Off') // cloud: state POWEROFF
+        assert.equal(off.pre_state, 'End remote maintain on')
+        assert.equal(off.remote_maintain, 'OFF') // cloud: remoteMaintain REMOTE_MAINTAIN_OFF
+
+        // and it is clear on a course selected but never started
+        assert.equal(feed([TUB_CLEAN]).remote_maintain, 'OFF')
+    })
+
+    test('pausing lights the drum and keeps the state it came from', () => {
+        const p = feed([PAUSES])
+        assert.equal(p.status, 'Pause') // cloud: state PAUSE
+        assert.equal(p.pre_state, 'Drying') // cloud: preState DRYING
+        assert.equal(p.drum_light, 'ON') // cloud: drumLight DRUMLIGHT_ON
+        assert.equal(p.remaining_time, 191)
+        assert.equal(p.power, 'ON')
+
+        const resumed = feed([PAUSES, DRYING])
+        assert.equal(resumed.status, 'Drying')
+        assert.equal(resumed.pre_state, 'Pause')
+        assert.equal(resumed.drum_light, 'OFF')
+    })
+
+    test('powering off clears the cycle but not the energy it used', () => {
+        const p = feed([PAUSES, POWERS_OFF])
+        assert.equal(p.power, 'OFF')
+        assert.equal(p.status, 'Off') // cloud: state POWEROFF
+        assert.equal(p.pre_state, 'Pause') // cloud: preState PAUSE
+        assert.equal(p.course, 'None') // the course byte resets to 0
+        assert.equal(p.remaining_time, 0)
+        assert.equal(p.initial_time, 0)
+        assert.equal(p.spent_power, 10) // what the part-run had used
+    })
+
+    test('start() requests a status snapshot, so a reconnect does not leave HA blank', () => {
+        // Without this the driver is purely passive: the dryer only volunteers a frame when something
+        // changes, so after a restart HA would sit at unknown until someone touched the machine.
+        const { thinq, dev } = makeDevice()
+        dev.start()
+
+        // AA | length | 0xF0ED status query | checksum | BB. LG's own query, taken verbatim from the
+        // cloud's traffic and byte for byte the same one it sends the matching washer.
+        assert.deepEqual(
+            thinq.outbox.map((b) => b.toString('hex')),
+            ['aa12f0ed1121010000001804111200005ebb'],
+        )
+    })
+
+    test('frames that are not status records publish nothing', () => {
+        const junk = [
+            'aa0730d82b91bb', // short 0xd8 heartbeat
+            'aa09307200c80048bb', // 0x72 ping
+            'aaff300a0066004f45000100ec0054000302000207', // truncated 0xEC
+            // a washer frame: right shape, wrong class byte, must not be decoded with dryer offsets
+            'aaff200a00a2001002000100ec00900aff000e000000000000000000000100000001002e0001006400000e2004ffff2d3c000000400004300000000000000400004000000000000000f00064000400000000ffff0100000a03090e0f2e00000000000000002700270000002e0101006400000e2004ffff2d3c200000420004300000000000000400004000000000000000f00064000400000000ffff01000049b8bb',
+        ]
+        for (const frame of junk) {
+            const { ha, thinq } = makeDevice()
+            thinq.emit('data', buf(frame))
+            assert.deepEqual(ha.devices[DEVICE_ID]?.properties ?? {}, {}, `frame ${frame} should publish nothing`)
+        }
+    })
+})


### PR DESCRIPTION

Adds a handler for modelId BDH_D30007_US (thinq2 deviceType 202), the
heat-pump dryer sold as DLHC5502V. Read-only.

Frames are the 0xFF-escaped AABB form with 42-byte records, class byte
0x30, against 72 on the matching washer and 28 on the RV13* models,
with the fields at different offsets from either, so this cannot be
aliased. Records carry no marker byte the way the washer's do, so
length and class are the only validation available.

Published: the cycle state and the state before it, the course, dry
level, Eco Hybrid setting and buzzer volume, the remaining time and the
cycle length, the energy the cycle has used, and the Wrinkle Care, Damp
Dry Beep, Detect Load, drum light, condenser clean, remote maintain and
remote start flags.

Confirmed against live capture with rethink bridged to the LG cloud, so
each byte change could be matched against LG's own decoded state at the
same timestamp. Of note:

- The minute counters are big-endian here, the opposite of the matching
  washer's.
- This model's modelJSON enum indices are the wire codes, so the full
  state enum is carried. Nine values were seen live.
- Course has no index table in the modelJSON at all, so all 22 codes
  came from selecting each cycle and reading the byte. Ten are dial
  positions and the other twelve are reachable only from the ThinQ app.
  A 22-entry panelCrsList happens to match that set, but it is not
  proof of completeness: on the matching washer the same field is the
  slots currently assigned to the panel, and it was seen at ten entries
  and then six as they were reassigned.
- The course NAMES are read off the panel rather than taken from LG's
  cloud identifiers, which disagree on most of them and not merely in
  wording. Two cases make the point: the cloud calls code 9 "QUICKDRY"
  while the panel calls it Small Load, and the cycle the panel calls
  Quick Dry is code 23, which the cloud calls "BABYWEAR"; the cloud
  calls code 17 "POWER" while the panel calls it Heavy Duty, Power Dry
  being code 16, which the cloud calls "ALLERGYCARE". The identifiers
  do not merely read awkwardly, they point at the wrong cycles, so
  publishing them would tell an owner their dryer was running something
  it is not. Each entry keeps its identifier as a trailing comment,
  since that is what a capture and the cloud will show.
- A cycle pushed from the app is not a course code at all: rec[5] reads
  the 255 DOWNLOAD sentinel and which cycle it is sits in rec[23], the
  cloud's downloadCourse. Published separately for that reason. One has
  been seen, 114, which the panel calls Wrinkle Prevention.
- rec[5] and rec[20] part company on five cycles, not just the AI
  position, which is what settles rec[20] as the loaded sub-cycle and
  rec[5] as the one to publish.
- The cloud calls condenser cleaning selfCleaning, which is worth
  knowing before hunting for it by name.
- Auto Course Arrange at rec[27] bit 0x01, toggled from the app in both
  directions. It is on by default, which is why that bit reads 1 in
  almost every record captured and had looked like a constant.

rec[26] bit 0x40 is the Remote Start setting, shown by switching it off
at the panel with the machine idle: the byte went 0x44 to 0x04 with
nothing else moving and the cloud reporting REMOTE_START_OFF. What
makes it look ambiguous is that the appliance switches the setting on
by itself: starting a cycle by hand moments later, with the setting
still off, took the byte straight back to 0x44 as the machine entered
DETECTING. The matching LG range names this behaviour in its own
settings, as "Auto Remote": "Starting cooking on the product
automatically turns on Remote Start". This dryer offers no such toggle,
so there is no way to stop it.

Outstanding and unknown:

- rec[16] steps through a small set of values across a run, the same
  sequence on every complete cycle, and also differs per course while
  idle. No cloud field tracks it, so there is no name to publish it
  under.
- rec[27] bits 0x40 and 0x80 are undecoded.
- The door sensor is not there to find: a full 72-field state dump from
  this model carries doorLock but no doorClose, where the matching
  washer's dump carries both.
- The cloud reports error, ductClogging and ductSensingOnOff with no
  wire byte identified. The duct pair would need a blocked vent and the
  error code a real fault.
