### PR TITLE
Add GBBS322CEV/BEV support and telemetry (continues #142)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The following appliances are currently supported in rethink:
     - 🫤 GSJV70PZTE, LG Side by Side Refrigerator - preliminary support,
     - 🫤 GSB470BASZ, American Style Side by Side Refrigerator - preliminary support,
     - 🫤 GA-B509CMUM - preliminary support,
+    - 🫤 GBBS322CEV and GBBS322BEV (2REBGLUB_2P\_\_), Bottom-Freezer Refrigerators - preliminary support,
 - Washing Machines:
     - 🫤 (model name unknown) Washing Machine - preliminary support
     - 👍 F2J7HG1W, Washing Machine - mostly working,

--- a/cloud/devices/2REBGLUB_2P__.ts
+++ b/cloud/devices/2REBGLUB_2P__.ts
@@ -1,0 +1,173 @@
+// LG GBBS322CEV refrigerator
+// ThinQ2 model ID: 2REBGLUB_2P__
+// Device type: 101
+import HADevice from './base'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { DeviceDiscovery, type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import AABBDevice from './aabb_device'
+import {
+    convertFreezerTemperature,
+    convertFridgeTemperature,
+    freezerRange,
+    fridgeRange,
+    packStatus,
+    Status,
+    TemperatureUnit,
+    unpackStatus,
+} from './fridge_common'
+
+const STATUS_LENGTH = 96
+
+export default class Device extends AABBDevice {
+    readonly deviceConfig: DeviceDiscovery
+    temperatureUnit: TemperatureUnit | undefined
+
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        this.deviceConfig = HADevice.config(meta, { name: 'LG Fridge' })
+
+        // HomeAssistant configuration will be ready once we find out the temperature unit
+    }
+
+    setTemperatureUnit(unit: TemperatureUnit) {
+        if (this.temperatureUnit === unit) return
+
+        this.temperatureUnit = unit
+        // set or re-set the temperature unit
+        this.setConfig(
+            allowExtendedType({
+                ...this.deviceConfig,
+                components: {
+                    fridge_setpoint: {
+                        platform: 'number',
+                        device_class: 'temperature',
+                        unique_id: '$deviceid-fridge_setpoint',
+                        state_topic: '$this/fridge_setpoint',
+                        command_topic: '$this/fridge_setpoint/set',
+                        name: 'Fridge temperature',
+                        ...fridgeRange(unit),
+                    },
+                    express_cool: {
+                        platform: 'switch',
+                        unique_id: '$deviceid-express_cool',
+                        state_topic: '$this/express_cool',
+                        command_topic: '$this/express_cool/set',
+                        icon: 'mdi:snowflake-variant',
+                        name: 'Express Cool',
+                    },
+                    freezer_setpoint: {
+                        platform: 'number',
+                        device_class: 'temperature',
+                        unique_id: '$deviceid-freezer_setpoint',
+                        state_topic: '$this/freezer_setpoint',
+                        command_topic: '$this/freezer_setpoint/set',
+                        name: 'Freezer temperature',
+                        ...freezerRange(unit),
+                    },
+                    express_freeze: {
+                        platform: 'switch',
+                        unique_id: '$deviceid-express_freeze',
+                        state_topic: '$this/express_freeze',
+                        command_topic: '$this/express_freeze/set',
+                        icon: 'mdi:snowflake',
+                        name: 'Express Freeze',
+                    },
+                    door: {
+                        platform: 'binary_sensor',
+                        device_class: 'door',
+                        unique_id: '$deviceid-door',
+                        state_topic: '$this/door',
+                        name: 'Door',
+                    },
+                    // Expose the decoded drawer mode and its raw value for validation/debugging.
+                    drawer_mode: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-drawer_mode',
+                        state_topic: '$this/drawer_mode',
+                        icon: 'mdi:food',
+                        name: 'Drawer mode',
+                    },
+                    drawer_mode_raw: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-drawer_mode_raw',
+                        state_topic: '$this/drawer_mode_raw',
+                        icon: 'mdi:code-brackets',
+                        name: 'Drawer mode raw',
+                    },
+                },
+            }),
+        )
+    }
+
+    start() {
+        this.send(Buffer.from('F0ED1211010000010400', 'hex'))
+    }
+
+    processAABB(buf: Buffer) {
+        // I'm not sure what is the proper way to identify packet types, so let's match
+        // on the length and a few initial bytes
+
+        if (buf.length === 2 + STATUS_LENGTH * 2 && buf[0] == 0x10 && buf[1] == 0xec) {
+            // 10EC (prev status) (cur status)
+            this.processStatus(buf.subarray(2 + STATUS_LENGTH, 2 + STATUS_LENGTH * 2))
+        }
+
+        if (buf.length === 2 + STATUS_LENGTH && buf[0] == 0x10 && buf[1] == 0xeb) {
+            // 10EB (initial status)
+            this.processStatus(buf.subarray(2, 2 + STATUS_LENGTH))
+        }
+    }
+
+    drawerModeName(raw: number | undefined): string {
+        // Drawer mode observed at status offset 95:
+        // 0 = Cheese, 1 = Fish, 2 = Meat
+        if (raw === 0) return 'Cheese'
+        if (raw === 1) return 'Fish'
+        if (raw === 2) return 'Meat'
+        if (raw === 0xff || raw === undefined) return 'Unknown'
+        return 'Unknown ' + raw
+    }
+
+    processStatus(curStatus: Buffer) {
+        const s = unpackStatus(curStatus)
+        this.setTemperatureUnit(s.tempUnit ? 'C' : 'F')
+        this.publishProperty('door', s.anyDoorOpen === 1 ? 'ON' : 'OFF')
+        this.publishProperty('fridge_setpoint', convertFridgeTemperature(this.temperatureUnit!, s.fridgeSetpoint))
+        this.publishProperty('freezer_setpoint', convertFreezerTemperature(this.temperatureUnit!, s.freezerSetpoint))
+        this.publishProperty('express_cool', s.expressCool === 1 ? 'ON' : 'OFF')
+        this.publishProperty('express_freeze', s.expressFreeze === 2 ? 'ON' : 'OFF')
+
+        const drawerModeRaw = curStatus[95]
+        this.publishProperty('drawer_mode_raw', drawerModeRaw === undefined ? 'Unknown' : String(drawerModeRaw))
+        this.publishProperty('drawer_mode', this.drawerModeName(drawerModeRaw))
+    }
+
+    sendSetting(setting: Partial<Status>) {
+        this.send(Buffer.concat([Buffer.from('F017', 'hex'), packStatus(setting, STATUS_LENGTH)]))
+    }
+
+    setProperty(prop: string, mqttValue: string) {
+        // We shouldn't receive any setProperty calls before the temperatureUnit is set. But let's be safe
+        const unit = this.temperatureUnit || 'C'
+
+        let setting: Partial<Status> = {
+            tempUnit: unit === 'C' ? 1 : 0,
+        }
+
+        if (prop === 'fridge_setpoint') {
+            setting.fridgeSetpoint = convertFridgeTemperature(unit, Number(mqttValue))
+            this.sendSetting(setting)
+        } else if (prop === 'freezer_setpoint') {
+            setting.freezerSetpoint = convertFreezerTemperature(unit, Number(mqttValue))
+            this.sendSetting(setting)
+        } else if (prop === 'express_cool') {
+            setting.expressCool = mqttValue === 'ON' ? 1 : 0
+            this.sendSetting(setting)
+        } else if (prop === 'express_freeze') {
+            setting.expressFreeze = mqttValue === 'ON' ? 2 : 1
+            this.sendSetting(setting)
+        }
+    }
+}

--- a/cloud/devices/2REBGLUB_2P__.ts
+++ b/cloud/devices/2REBGLUB_2P__.ts
@@ -19,6 +19,7 @@ import {
 } from './fridge_common'
 
 const STATUS_LENGTH = 96
+const ENERGY_WH_PER_COUNT = 0.5
 
 const DRAWER_MODES: Record<number, string> = {
     0: 'Cheese (2 °C)',
@@ -149,6 +150,15 @@ export default class Device extends AABBDevice {
                         state_topic: '$this/freezer_thermal_state',
                         name: 'Freezer thermal state',
                     },
+                    energy: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-energy',
+                        state_topic: '$this/energy',
+                        name: 'Energy',
+                        device_class: 'energy',
+                        state_class: 'total_increasing',
+                        unit_of_measurement: 'Wh',
+                    },
                     drawer_mode: {
                         platform: 'sensor',
                         device_class: 'enum',
@@ -204,6 +214,10 @@ export default class Device extends AABBDevice {
             this.HA.publishProperty(this.id, 'open_door_alarm', JSON.stringify({ event_type: 'triggered' }), {
                 retain: false,
             })
+        }
+
+        if (buf.length === 7 && buf[0] == 0x10 && buf[1] == 0xaf) {
+            this.publishProperty('energy', buf.readUIntBE(2, 3) * ENERGY_WH_PER_COUNT)
         }
     }
 

--- a/cloud/devices/2REBGLUB_2P__.ts
+++ b/cloud/devices/2REBGLUB_2P__.ts
@@ -162,7 +162,7 @@ export default class Device extends AABBDevice {
                     drawer_mode: {
                         platform: 'sensor',
                         device_class: 'enum',
-                        options: Object.values(DRAWER_MODES),
+                        options: [...Object.values(DRAWER_MODES), 'unknown'],
                         unique_id: '$deviceid-drawer_mode',
                         state_topic: '$this/drawer_mode',
                         icon: 'mdi:food',
@@ -171,6 +171,16 @@ export default class Device extends AABBDevice {
                 },
             }),
         )
+    }
+
+    publishConfig() {
+        if (this.config) {
+            this.HA.publishConfig(this.id, {
+                ...this.config,
+                components: { ...this.config.components, drawer_mode_raw: { platform: 'sensor' } },
+            })
+        }
+        super.publishConfig()
     }
 
     start() {
@@ -210,7 +220,7 @@ export default class Device extends AABBDevice {
             this.publishProperty('freezer_time', buf.readUIntBE(25, 3) - doorTime)
         }
 
-        if (buf.length === 15 && buf[0] == 0x10 && buf[1] == 0x72) {
+        if (buf.length === 15 && buf[0] == 0x10 && buf[1] == 0x72 && this.HA.isConnected) {
             this.HA.publishProperty(this.id, 'open_door_alarm', JSON.stringify({ event_type: 'triggered' }), {
                 retain: false,
             })

--- a/cloud/devices/2REBGLUB_2P__.ts
+++ b/cloud/devices/2REBGLUB_2P__.ts
@@ -26,6 +26,13 @@ const DRAWER_MODES: Record<number, string> = {
     2: 'Meat (-3 °C)',
 }
 
+const THERMAL_STATES: Record<number, string> = {
+    1: 'settled',
+    2: 'unknown',
+    3: 'disturbed',
+    5: 'unsettled',
+}
+
 export default class Device extends AABBDevice {
     readonly deviceConfig: DeviceDiscovery
     temperatureUnit: TemperatureUnit | undefined
@@ -119,6 +126,22 @@ export default class Device extends AABBDevice {
                         state_class: 'total_increasing',
                         unit_of_measurement: 's',
                     },
+                    fridge_thermal_state: {
+                        platform: 'sensor',
+                        device_class: 'enum',
+                        options: Object.values(THERMAL_STATES),
+                        unique_id: '$deviceid-fridge_thermal_state',
+                        state_topic: '$this/fridge_thermal_state',
+                        name: 'Fridge thermal state',
+                    },
+                    freezer_thermal_state: {
+                        platform: 'sensor',
+                        device_class: 'enum',
+                        options: Object.values(THERMAL_STATES),
+                        unique_id: '$deviceid-freezer_thermal_state',
+                        state_topic: '$this/freezer_thermal_state',
+                        name: 'Freezer thermal state',
+                    },
                     drawer_mode: {
                         platform: 'sensor',
                         device_class: 'enum',
@@ -186,6 +209,8 @@ export default class Device extends AABBDevice {
 
         const drawerModeRaw = curStatus[95]
         this.publishProperty('drawer_mode', this.drawerModeName(drawerModeRaw))
+        this.publishProperty('fridge_thermal_state', THERMAL_STATES[curStatus[27]] ?? 'unknown')
+        this.publishProperty('freezer_thermal_state', THERMAL_STATES[curStatus[28]] ?? 'unknown')
     }
 
     sendSetting(setting: Partial<Status>) {

--- a/cloud/devices/2REBGLUB_2P__.ts
+++ b/cloud/devices/2REBGLUB_2P__.ts
@@ -94,6 +94,13 @@ export default class Device extends AABBDevice {
                         state_topic: '$this/door',
                         name: 'Door',
                     },
+                    open_door_alarm: {
+                        platform: 'event',
+                        unique_id: '$deviceid-open_door_alarm',
+                        state_topic: '$this/open_door_alarm',
+                        name: 'Open door alarm',
+                        event_types: ['triggered'],
+                    },
                     door_openings: {
                         platform: 'sensor',
                         unique_id: '$deviceid-door_openings',
@@ -191,6 +198,12 @@ export default class Device extends AABBDevice {
             this.publishProperty('door_time', doorTime)
             this.publishProperty('freezer_openings', buf.readUIntBE(13, 3) - doorOpenings)
             this.publishProperty('freezer_time', buf.readUIntBE(25, 3) - doorTime)
+        }
+
+        if (buf.length === 15 && buf[0] == 0x10 && buf[1] == 0x72) {
+            this.HA.publishProperty(this.id, 'open_door_alarm', JSON.stringify({ event_type: 'triggered' }), {
+                retain: false,
+            })
         }
     }
 

--- a/cloud/devices/2REBGLUB_2P__.ts
+++ b/cloud/devices/2REBGLUB_2P__.ts
@@ -87,6 +87,38 @@ export default class Device extends AABBDevice {
                         state_topic: '$this/door',
                         name: 'Door',
                     },
+                    door_openings: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-door_openings',
+                        state_topic: '$this/door_openings',
+                        name: 'Fridge door openings',
+                        state_class: 'total_increasing',
+                    },
+                    door_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-door_time',
+                        state_topic: '$this/door_time',
+                        name: 'Fridge door open time',
+                        device_class: 'duration',
+                        state_class: 'total_increasing',
+                        unit_of_measurement: 's',
+                    },
+                    freezer_openings: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-freezer_openings',
+                        state_topic: '$this/freezer_openings',
+                        name: 'Freezer door openings',
+                        state_class: 'total_increasing',
+                    },
+                    freezer_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-freezer_time',
+                        state_topic: '$this/freezer_time',
+                        name: 'Freezer door open time',
+                        device_class: 'duration',
+                        state_class: 'total_increasing',
+                        unit_of_measurement: 's',
+                    },
                     drawer_mode: {
                         platform: 'sensor',
                         device_class: 'enum',
@@ -117,6 +149,25 @@ export default class Device extends AABBDevice {
         if (buf.length === 2 + STATUS_LENGTH && buf[0] == 0x10 && buf[1] == 0xeb) {
             // 10EB (initial status)
             this.processStatus(buf.subarray(2, 2 + STATUS_LENGTH))
+        }
+
+        if (
+            buf.length === 28 &&
+            buf[0] == 0x10 &&
+            buf[1] == 0xc5 &&
+            buf[3] == 4 &&
+            buf[4] == 0x01 &&
+            buf[10] == 0x03 &&
+            buf[16] == 0x11 &&
+            buf[22] == 0x13
+        ) {
+            const doorOpenings = buf.readUIntBE(7, 3)
+            const doorTime = buf.readUIntBE(19, 3)
+
+            this.publishProperty('door_openings', doorOpenings)
+            this.publishProperty('door_time', doorTime)
+            this.publishProperty('freezer_openings', buf.readUIntBE(13, 3) - doorOpenings)
+            this.publishProperty('freezer_time', buf.readUIntBE(25, 3) - doorTime)
         }
     }
 

--- a/cloud/devices/2REBGLUB_2P__.ts
+++ b/cloud/devices/2REBGLUB_2P__.ts
@@ -1,4 +1,4 @@
-// LG GBBS322CEV refrigerator
+// LG GBBS322CEV and GBBS322BEV refrigerators
 // ThinQ2 model ID: 2REBGLUB_2P__
 // Device type: 101
 import HADevice from './base'
@@ -19,6 +19,12 @@ import {
 } from './fridge_common'
 
 const STATUS_LENGTH = 96
+
+const DRAWER_MODES: Record<number, string> = {
+    0: 'Cheese (2 °C)',
+    1: 'Fish (0 °C)',
+    2: 'Meat (-3 °C)',
+}
 
 export default class Device extends AABBDevice {
     readonly deviceConfig: DeviceDiscovery
@@ -81,20 +87,14 @@ export default class Device extends AABBDevice {
                         state_topic: '$this/door',
                         name: 'Door',
                     },
-                    // Expose the decoded drawer mode and its raw value for validation/debugging.
                     drawer_mode: {
                         platform: 'sensor',
+                        device_class: 'enum',
+                        options: Object.values(DRAWER_MODES),
                         unique_id: '$deviceid-drawer_mode',
                         state_topic: '$this/drawer_mode',
                         icon: 'mdi:food',
-                        name: 'Drawer mode',
-                    },
-                    drawer_mode_raw: {
-                        platform: 'sensor',
-                        unique_id: '$deviceid-drawer_mode_raw',
-                        state_topic: '$this/drawer_mode_raw',
-                        icon: 'mdi:code-brackets',
-                        name: 'Drawer mode raw',
+                        name: 'Fresh Converter+ (Drawer temperature)',
                     },
                 },
             }),
@@ -120,14 +120,8 @@ export default class Device extends AABBDevice {
         }
     }
 
-    drawerModeName(raw: number | undefined): string {
-        // Drawer mode observed at status offset 95:
-        // 0 = Cheese, 1 = Fish, 2 = Meat
-        if (raw === 0) return 'Cheese'
-        if (raw === 1) return 'Fish'
-        if (raw === 2) return 'Meat'
-        if (raw === 0xff || raw === undefined) return 'Unknown'
-        return 'Unknown ' + raw
+    drawerModeName(raw: number): string {
+        return DRAWER_MODES[raw] ?? 'unknown'
     }
 
     processStatus(curStatus: Buffer) {
@@ -140,7 +134,6 @@ export default class Device extends AABBDevice {
         this.publishProperty('express_freeze', s.expressFreeze === 2 ? 'ON' : 'OFF')
 
         const drawerModeRaw = curStatus[95]
-        this.publishProperty('drawer_mode_raw', drawerModeRaw === undefined ? 'Unknown' : String(drawerModeRaw))
         this.publishProperty('drawer_mode', this.drawerModeName(drawerModeRaw))
     }
 

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -7,6 +7,7 @@ import Dev_2REF11EBIVPC4 from './devices/2REF11EBIVPC4'
 import Dev_2RES1VE61NFA2 from './devices/2RES1VE61NFA2'
 import Dev_2REB1GLVB1__2 from './devices/2REB1GLVB1__2'
 import Dev_2RES1VE600FWC from './devices/2RES1VE600FWC'
+import Dev_2REBGLUB_2P__ from './devices/2REBGLUB_2P__'
 import Dev_STUDIO_HOOD from './devices/STUDIO_HOOD'
 import Y_V8_Y___W_B32QEUK from './devices/Y_V8_Y___W.B32QEUK'
 import F_V8_Y___W_B_2QEUK from './devices/F_V8_Y___W.B_2QEUK'
@@ -45,6 +46,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['2REF11EBIVPC4']: Dev_2REF11EBIVPC4,
     ['2RES1VE61NFA2']: Dev_2RES1VE61NFA2,
     ['2REB1GLVB1__2']: Dev_2REB1GLVB1__2,
+    ['2REBGLUB_2P__']: Dev_2REBGLUB_2P__, // LG GBBS322CEV refrigerator
     ['2RES1VE600FWC']: Dev_2RES1VE600FWC,
     ['STUDIO_HOOD']: Dev_STUDIO_HOOD,
     ['Y_V8_Y___W.B32QEUK']: Y_V8_Y___W_B32QEUK,

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -46,7 +46,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['2REF11EBIVPC4']: Dev_2REF11EBIVPC4,
     ['2RES1VE61NFA2']: Dev_2RES1VE61NFA2,
     ['2REB1GLVB1__2']: Dev_2REB1GLVB1__2,
-    ['2REBGLUB_2P__']: Dev_2REBGLUB_2P__, // LG GBBS322CEV refrigerator
+    ['2REBGLUB_2P__']: Dev_2REBGLUB_2P__, // LG GBBS322CEV and GBBS322BEV refrigerators
     ['2RES1VE600FWC']: Dev_2RES1VE600FWC,
     ['STUDIO_HOOD']: Dev_STUDIO_HOOD,
     ['Y_V8_Y___W.B32QEUK']: Y_V8_Y___W_B32QEUK,

--- a/cloud/homeassistant.ts
+++ b/cloud/homeassistant.ts
@@ -182,7 +182,7 @@ export type DeviceDiscovery = {
     origin: OriginInfo
     availability?: AvailabilityInfo[]
     availability_mode?: 'all' | 'any' | 'latest'
-    components: Record<string, ComponentInfo>
+    components: Record<string, ComponentInfo | { platform: string }>
 }
 
 export type ClimateComponent = ComponentInfo & {

--- a/tests/cloud/devices/2REBGLUB_2P__.test.ts
+++ b/tests/cloud/devices/2REBGLUB_2P__.test.ts
@@ -1,0 +1,301 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/2REBGLUB_2P__'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf, hex } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = '2REBGLUB_2P__'
+const META: Metadata = {
+    modelId: MODEL_ID,
+    modelName: MODEL_ID,
+    swVersion: '1.0',
+}
+
+// Real packet captures from an LG GBBS322CEV refrigerator.
+// ThinQ2 model ID: 2REBGLUB_2P__
+// Device type: 101
+//
+// STATUS_LENGTH = 96. Frames:
+//   AA 0x66 10 EB <96 bytes> <checksum> BB
+//       Full/initial status
+//
+//   AA 0xC6 10 EC <96 previous> <96 current> <checksum> BB
+//       Status delta; only the current status block is decoded.
+
+// Fridge=3C, freezer=-20C, door closed,
+// Express Cool OFF, Express Freeze OFF,
+// drawer mode Cheese, unit Celsius.
+const SAMPLE_INITIAL = buf(
+    'AA6610EB02050601FFFFFF0201FFFFFF00FFFFFF0000FFFFFFFFFFFFFFFF010101FF02FFFFFFFFFFFFFFFFFF01FF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0078FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0005FFFFFFFFFF01010101000EBB',
+)
+
+// Same values as SAMPLE_INITIAL, but door open.
+const SAMPLE_DOOR_OPEN = buf(
+    'AA6610EB02050601FFFFFF0101FFFFFF00FFFFFF0000FFFFFFFFFFFFFFFF010101FF02FFFFFFFFFFFFFFFFFF01FF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0078FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0005FFFFFFFFFF01010101000FBB',
+)
+
+// Fridge=3C, freezer=-23C, door open,
+// Express Freeze ON, drawer mode Cheese.
+const SAMPLE_EXPRESS_FREEZE_ON = buf(
+    'AA6610EB02050902FFFFFF0101FFFFFF00FFFFFF0000FFFFFFFFFFFFFFFF010103FF02FFFFFFFFFFFFFFFFFF01FF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0078FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0005FFFFFFFFFF01010000000BBB',
+)
+
+// Fridge=3C, freezer=-20C, door open,
+// Express Cool ON, Express Freeze OFF,
+// drawer mode Cheese.
+const SAMPLE_EXPRESS_COOL_ON = buf(
+    'AA6610EB02050601FFFFFF0101FFFFFF00FFFFFF0100FFFFFFFFFFFFFFFF010103FF02FFFFFFFFFFFFFFFFFF01FF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0078FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0005FFFFFFFFFF01010000000EBB',
+)
+
+// Drawer mode Fish, raw value 1.
+const SAMPLE_DRAWER_FISH = buf(
+    'AA6610EB02050601FFFFFF0101FFFFFF00FFFFFF0000FFFFFFFFFFFFFFFF010103FF02FFFFFFFFFFFFFFFFFF01FF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0078FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0005FFFFFFFFFF010101010108BB',
+)
+
+// Drawer mode Meat, raw value 2.
+const SAMPLE_DRAWER_MEAT = buf(
+    'AA6610EB02050601FFFFFF0101FFFFFF00FFFFFF0000FFFFFFFFFFFFFFFF010103FF02FFFFFFFFFFFFFFFFFF01FF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0078FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0005FFFFFFFFFF01010101020BBB',
+)
+
+// Delta: previous state has the door open, current state has the door closed.
+// Fridge remains at 3C, freezer remains at -20C, and drawer mode remains Cheese.
+const SAMPLE_DELTA_DOOR_OPEN_TO_CLOSED = buf(
+    'AAC610EC02050601FFFFFF0101FFFFFF00FFFFFF0000FFFFFFFFFFFFFFFF010101FF02FFFFFFFFFFFFFFFFFF01FF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0078FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0005FFFFFFFFFF010101010002050601FFFFFF0201FFFFFF00FFFFFF0000FFFFFFFFFFFFFFFF010101FF02FFFFFFFFFFFFFFFFFF01FF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0078FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0005FFFFFFFFFF01010101005EBB',
+)
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('config is not published until a valid status frame establishes the temperature unit', () => {
+        const { ha } = makeDevice()
+
+        assert.equal(ha.devices[DEVICE_ID], undefined)
+    })
+
+    test('0x10EB full status publishes Celsius configuration and decodes the appliance state', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', SAMPLE_INITIAL)
+
+        const dev = ha.devices[DEVICE_ID]
+        assert.ok(dev?.config, 'Home Assistant configuration published')
+
+        const components = dev.config!.components as Record<string, Record<string, unknown>>
+
+        assert.equal(components.fridge_setpoint.unit_of_measurement, '°C')
+        assert.equal(components.fridge_setpoint.min, 1)
+        assert.equal(components.fridge_setpoint.max, 7)
+
+        assert.equal(components.freezer_setpoint.unit_of_measurement, '°C')
+        assert.equal(components.freezer_setpoint.min, -23)
+        assert.equal(components.freezer_setpoint.max, -15)
+
+        assert.ok(components.door, 'door component')
+        assert.ok(components.express_cool, 'express_cool component')
+        assert.ok(components.express_freeze, 'express_freeze component')
+        assert.ok(components.drawer_mode, 'drawer_mode component')
+        assert.ok(components.drawer_mode_raw, 'drawer_mode_raw component')
+
+        assert.equal(dev.properties.fridge_setpoint, 3)
+        assert.equal(dev.properties.freezer_setpoint, -20)
+        assert.equal(dev.properties.door, 'OFF')
+        assert.equal(dev.properties.express_cool, 'OFF')
+        assert.equal(dev.properties.express_freeze, 'OFF')
+        assert.equal(dev.properties.drawer_mode, 'Cheese')
+        assert.equal(dev.properties.drawer_mode_raw, '0')
+    })
+
+    test('0x10EB full status decodes an open door', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', SAMPLE_DOOR_OPEN)
+
+        const props = ha.devices[DEVICE_ID].properties
+
+        assert.equal(props.door, 'ON')
+        assert.equal(props.fridge_setpoint, 3)
+        assert.equal(props.freezer_setpoint, -20)
+    })
+
+    test('0x10EB full status decodes Express Freeze ON', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', SAMPLE_EXPRESS_FREEZE_ON)
+
+        const props = ha.devices[DEVICE_ID].properties
+
+        assert.equal(props.freezer_setpoint, -23)
+        assert.equal(props.express_freeze, 'ON')
+        assert.equal(props.express_cool, 'OFF')
+        assert.equal(props.door, 'ON')
+    })
+
+    test('0x10EB full status decodes Express Cool ON', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', SAMPLE_EXPRESS_COOL_ON)
+
+        const props = ha.devices[DEVICE_ID].properties
+
+        assert.equal(props.express_cool, 'ON')
+        assert.equal(props.express_freeze, 'OFF')
+        assert.equal(props.door, 'ON')
+    })
+
+    test('drawer mode raw 0 is decoded as Cheese', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', SAMPLE_INITIAL)
+
+        const props = ha.devices[DEVICE_ID].properties
+
+        assert.equal(props.drawer_mode_raw, '0')
+        assert.equal(props.drawer_mode, 'Cheese')
+    })
+
+    test('drawer mode raw 1 is decoded as Fish', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', SAMPLE_DRAWER_FISH)
+
+        const props = ha.devices[DEVICE_ID].properties
+
+        assert.equal(props.drawer_mode_raw, '1')
+        assert.equal(props.drawer_mode, 'Fish')
+    })
+
+    test('drawer mode raw 2 is decoded as Meat', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', SAMPLE_DRAWER_MEAT)
+
+        const props = ha.devices[DEVICE_ID].properties
+
+        assert.equal(props.drawer_mode_raw, '2')
+        assert.equal(props.drawer_mode, 'Meat')
+    })
+
+    test('0x10EC delta decodes only the current status block', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', SAMPLE_DELTA_DOOR_OPEN_TO_CLOSED)
+
+        const props = ha.devices[DEVICE_ID].properties
+
+        assert.equal(props.fridge_setpoint, 3)
+        assert.equal(props.freezer_setpoint, -20)
+        assert.equal(props.door, 'OFF')
+        assert.equal(props.express_cool, 'OFF')
+        assert.equal(props.express_freeze, 'OFF')
+        assert.equal(props.drawer_mode, 'Cheese')
+        assert.equal(props.drawer_mode_raw, '0')
+    })
+
+    test('frames not matching the AA..BB envelope are ignored', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', buf('001122'))
+
+        assert.equal(ha.devices[DEVICE_ID], undefined)
+    })
+
+    test('frames with an unrecognised inner shape are ignored', () => {
+        const { ha, thinq } = makeDevice()
+
+        // Valid AA..BB frame, but the inner packet type is not 0x10EB or 0x10EC.
+        thinq.emit('data', buf('AA08109901020304BB'))
+
+        assert.equal(ha.devices[DEVICE_ID], undefined)
+    })
+
+    test('start() sends the F0ED status query packet', () => {
+        const { thinq, dev } = makeDevice()
+
+        thinq.resetRecorder()
+        dev.start()
+
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(hex(thinq.outbox[0]), 'AA0EF0ED1211010000010400EBBB')
+    })
+
+    test('HA write fridge_setpoint=4C creates a 96-byte setting frame', () => {
+        const { thinq, dev } = makeDevice()
+
+        thinq.emit('data', SAMPLE_INITIAL)
+        thinq.resetRecorder()
+
+        dev.setProperty('fridge_setpoint', '4')
+
+        const pkt = thinq.outbox[0]
+
+        // Frame layout:
+        // AA <length> F0 17 <96-byte status> <checksum> BB
+        assert.equal(pkt[2], 0xf0)
+        assert.equal(pkt[3], 0x17)
+        assert.equal(pkt[4 + 1], 4)
+        assert.equal(pkt[4 + 8], 1)
+
+        // Unchanged fields use the 0xFF sentinel.
+        assert.equal(pkt[4 + 0], 0xff)
+        assert.equal(pkt[4 + 2], 0xff)
+    })
+
+    test('HA write freezer_setpoint=-20C creates the expected raw value', () => {
+        const { thinq, dev } = makeDevice()
+
+        thinq.emit('data', SAMPLE_INITIAL)
+        thinq.resetRecorder()
+
+        dev.setProperty('freezer_setpoint', '-20')
+
+        const pkt = thinq.outbox[0]
+
+        assert.equal(pkt[4 + 2], 6)
+        assert.equal(pkt[4 + 1], 0xff)
+        assert.equal(pkt[4 + 8], 1)
+    })
+
+    test('HA write express_cool=ON sets the Express Cool field', () => {
+        const { thinq, dev } = makeDevice()
+
+        thinq.emit('data', SAMPLE_INITIAL)
+        thinq.resetRecorder()
+
+        dev.setProperty('express_cool', 'ON')
+
+        const pkt = thinq.outbox[0]
+
+        assert.equal(pkt[4 + 16], 1)
+    })
+
+    test('HA write express_freeze=ON sets the Express Freeze field', () => {
+        const { thinq, dev } = makeDevice()
+
+        thinq.emit('data', SAMPLE_INITIAL)
+        thinq.resetRecorder()
+
+        dev.setProperty('express_freeze', 'ON')
+
+        const pkt = thinq.outbox[0]
+
+        assert.equal(pkt[4 + 3], 2)
+    })
+
+    test('HA write to an unknown property sends nothing', () => {
+        const { thinq, dev } = makeDevice()
+
+        thinq.emit('data', SAMPLE_INITIAL)
+        thinq.resetRecorder()
+
+        dev.setProperty('does-not-exist', '1')
+
+        assert.equal(thinq.outbox.length, 0)
+    })
+})

--- a/tests/cloud/devices/2REBGLUB_2P__.test.ts
+++ b/tests/cloud/devices/2REBGLUB_2P__.test.ts
@@ -107,7 +107,7 @@ describe(MODEL_ID, () => {
         assert.ok(components.drawer_mode, 'drawer_mode component')
         assert.equal(components.drawer_mode.name, 'Fresh Converter+ (Drawer temperature)')
         assert.equal(components.drawer_mode.device_class, 'enum')
-        assert.deepEqual(components.drawer_mode.options, ['Cheese (2 °C)', 'Fish (0 °C)', 'Meat (-3 °C)'])
+        assert.deepEqual(components.drawer_mode.options, ['Cheese (2 °C)', 'Fish (0 °C)', 'Meat (-3 °C)', 'unknown'])
         assert.equal(components.drawer_mode_raw, undefined)
 
         assert.equal(dev.properties.fridge_setpoint, 3)
@@ -116,6 +116,33 @@ describe(MODEL_ID, () => {
         assert.equal(dev.properties.express_cool, 'OFF')
         assert.equal(dev.properties.express_freeze, 'OFF')
         assert.equal(dev.properties.drawer_mode, 'Cheese (2 °C)')
+    })
+
+    test('discovery removes drawer_mode_raw before omitting it, including on rediscovery', (t) => {
+        const { ha, thinq, dev } = makeDevice()
+        ha.publishConfig(DEVICE_ID, {
+            ...dev.deviceConfig,
+            components: {
+                drawer_mode_raw: { platform: 'sensor', unique_id: '$deviceid-drawer_mode_raw' },
+            },
+        })
+        const publish = t.mock.method(ha, 'publishConfig')
+
+        for (const discover of [() => thinq.emit('data', SAMPLE_INITIAL), () => dev.publishConfig()]) {
+            publish.mock.resetCalls()
+            discover()
+
+            assert.equal(publish.mock.callCount(), 2)
+            const [removal, current] = publish.mock.calls.map((call) => call.arguments[1])
+            assert.deepEqual(removal, {
+                ...current,
+                components: { ...current.components, drawer_mode_raw: { platform: 'sensor' } },
+            })
+            assert.equal(current.components.drawer_mode_raw, undefined)
+            assert.equal(Object.keys(current.components).length, 14)
+            assert.equal(ha.devices[DEVICE_ID].config, dev.config)
+        }
+        assert.equal(thinq.outbox.length, 0)
     })
 
     test('0x10EB full status decodes an open door', () => {
@@ -185,11 +212,25 @@ describe(MODEL_ID, () => {
         assert.equal(props.drawer_mode, 'Meat (-3 °C)')
     })
 
-    test('unsupported Fresh Converter+ values use the Home Assistant enum fallback', () => {
-        const { dev } = makeDevice()
+    test('unsupported Fresh Converter+ values replace a valid mode with the advertised fallback', () => {
+        const { ha, thinq, dev } = makeDevice()
+        const status = Buffer.from(SAMPLE_INITIAL.subarray(2, -2))
 
-        assert.equal(dev.drawerModeName(0xff), 'unknown')
-        assert.equal(dev.drawerModeName(3), 'unknown')
+        for (const raw of [0xff, 3]) {
+            thinq.emit('data', SAMPLE_DRAWER_MEAT)
+            const device = ha.devices[DEVICE_ID]
+            assert.equal(device.properties.drawer_mode, 'Meat (-3 °C)')
+
+            status[2 + 95] = raw
+            dev.processAABB(status)
+
+            const components = device.config!.components as Record<string, Record<string, unknown>>
+            assert.equal(device.properties.drawer_mode, 'unknown')
+            assert.ok((components.drawer_mode.options as string[]).includes(device.properties.drawer_mode))
+        }
+
+        thinq.emit('data', SAMPLE_DRAWER_FISH)
+        assert.equal(ha.devices[DEVICE_ID].properties.drawer_mode, 'Fish (0 °C)')
     })
 
     test('0x10EC delta decodes only the current status block', () => {
@@ -443,6 +484,36 @@ describe(MODEL_ID, () => {
         }
 
         assert.equal(ha.devices[DEVICE_ID], undefined)
+    })
+
+    test('0x1072 drops offline alarms without replaying them on reconnect', (t) => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', SAMPLE_INITIAL)
+        const publish = t.mock.method(ha.asConnection(), 'publishProperty')
+
+        ha.isConnected = false
+        dev.processAABB(SAMPLE_DOOR_ALARM)
+        dev.processAABB(SAMPLE_DOOR_ALARM)
+        dev.processAABB(SAMPLE_ENERGY)
+        assert.deepEqual(
+            publish.mock.calls.map((call) => call.arguments),
+            [[DEVICE_ID, 'energy', 128.5]],
+        )
+
+        ha.isConnected = true
+        dev.publishConfig()
+        assert.equal(publish.mock.calls.filter((call) => call.arguments[1] === 'open_door_alarm').length, 0)
+
+        dev.processAABB(SAMPLE_DOOR_ALARM)
+        const alarms = publish.mock.calls.filter((call) => call.arguments[1] === 'open_door_alarm')
+        assert.equal(alarms.length, 1)
+        assert.deepEqual(alarms[0].arguments, [
+            DEVICE_ID,
+            'open_door_alarm',
+            '{"event_type":"triggered"}',
+            { retain: false },
+        ])
+        assert.equal(thinq.outbox.length, 0)
     })
 
     test('start() sends the F0ED status query packet', () => {

--- a/tests/cloud/devices/2REBGLUB_2P__.test.ts
+++ b/tests/cloud/devices/2REBGLUB_2P__.test.ts
@@ -66,6 +66,7 @@ const SAMPLE_DELTA_DOOR_OPEN_TO_CLOSED = buf(
 
 const SAMPLE_DOOR_USAGE = buf('10C5000401000200000A03000300000E11001E00006413003C000096')
 const SAMPLE_DOOR_ALARM = buf('107200080A00000000000000000000')
+const SAMPLE_ENERGY = buf('10AF0001010605')
 
 function makeDevice() {
     const ha = new MockHAConnection()
@@ -452,6 +453,85 @@ describe(MODEL_ID, () => {
 
         assert.equal(thinq.outbox.length, 1)
         assert.equal(hex(thinq.outbox[0]), 'AA0EF0ED1211010000010400EBBB')
+    })
+
+    test('energy is discovered as a total-increasing Wh sensor', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_INITIAL)
+
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        assert.equal(components.energy.platform, 'sensor')
+        assert.equal(components.energy.name, 'Energy')
+        assert.equal(components.energy.device_class, 'energy')
+        assert.equal(components.energy.state_class, 'total_increasing')
+        assert.equal(components.energy.unit_of_measurement, 'Wh')
+        assert.equal(components.energy.unique_id, '$deviceid-energy')
+        assert.equal(components.energy.state_topic, '$this/energy')
+    })
+
+    test('0x10AF decodes all three counter bytes at 0.5 Wh per count', () => {
+        const { ha, dev } = makeDevice()
+        const energy = Buffer.from(SAMPLE_ENERGY)
+
+        for (const count of [0, 1, 0xff, 0x100, 0x101, 0x010001, 0xffffff]) {
+            energy.writeUIntBE(count, 2, 3)
+            dev.processAABB(energy)
+            assert.deepEqual(ha.devices[DEVICE_ID].properties, { energy: count * 0.5 })
+        }
+    })
+
+    test('0x10AF repeated samples are suppressed but within-burst increments are published', (t) => {
+        const { ha, dev } = makeDevice()
+        const publish = t.mock.method(ha, 'publishProperty')
+        const energy = Buffer.from(SAMPLE_ENERGY)
+
+        for (const count of [321, 321, 322, 323, 323]) {
+            energy.writeUIntBE(count, 2, 3)
+            dev.processAABB(energy)
+        }
+
+        assert.deepEqual(
+            publish.mock.calls.map((call) => call.arguments),
+            [
+                [DEVICE_ID, 'energy', 160.5],
+                [DEVICE_ID, 'energy', 161],
+                [DEVICE_ID, 'energy', 161.5],
+            ],
+        )
+    })
+
+    test('0x10AF preserves appliance resets and does not depend on adapter history', () => {
+        const { ha, dev } = makeDevice()
+        dev.processAABB(SAMPLE_ENERGY)
+        assert.equal(ha.devices[DEVICE_ID].properties.energy, 128.5)
+
+        const reset = Buffer.from(SAMPLE_ENERGY)
+        reset.writeUIntBE(0, 2, 3)
+        dev.processAABB(reset)
+        assert.equal(ha.devices[DEVICE_ID].properties.energy, 0)
+
+        reset.writeUIntBE(6, 2, 3)
+        dev.processAABB(reset)
+        assert.equal(ha.devices[DEVICE_ID].properties.energy, 3)
+
+        const restarted = makeDevice()
+        restarted.dev.processAABB(reset)
+        assert.equal(restarted.ha.devices[DEVICE_ID].properties.energy, 3)
+    })
+
+    test('0x10AF ignores incomplete and unsupported frames', () => {
+        const { ha, dev } = makeDevice()
+        for (let length = 0; length < SAMPLE_ENERGY.length; length++) {
+            dev.processAABB(SAMPLE_ENERGY.subarray(0, length))
+        }
+        dev.processAABB(Buffer.concat([SAMPLE_ENERGY, Buffer.from([0])]))
+        for (const offset of [0, 1]) {
+            const invalid = Buffer.from(SAMPLE_ENERGY)
+            invalid[offset] = 0xff
+            dev.processAABB(invalid)
+        }
+
+        assert.equal(ha.devices[DEVICE_ID], undefined)
     })
 
     test('HA write fridge_setpoint=4C creates a 96-byte setting frame', () => {

--- a/tests/cloud/devices/2REBGLUB_2P__.test.ts
+++ b/tests/cloud/devices/2REBGLUB_2P__.test.ts
@@ -65,6 +65,7 @@ const SAMPLE_DELTA_DOOR_OPEN_TO_CLOSED = buf(
 )
 
 const SAMPLE_DOOR_USAGE = buf('10C5000401000200000A03000300000E11001E00006413003C000096')
+const SAMPLE_DOOR_ALARM = buf('107200080A00000000000000000000')
 
 function makeDevice() {
     const ha = new MockHAConnection()
@@ -387,6 +388,58 @@ describe(MODEL_ID, () => {
 
         // Valid AA..BB frame, but the inner packet type is not 0x10EB or 0x10EC.
         thinq.emit('data', buf('AA08109901020304BB'))
+
+        assert.equal(ha.devices[DEVICE_ID], undefined)
+    })
+
+    test('open door alarm is discovered as an MQTT event', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_INITIAL)
+
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        assert.equal(components.open_door_alarm.platform, 'event')
+        assert.equal(components.open_door_alarm.name, 'Open door alarm')
+        assert.equal(components.open_door_alarm.unique_id, '$deviceid-open_door_alarm')
+        assert.equal(components.open_door_alarm.state_topic, '$this/open_door_alarm')
+        assert.deepEqual(components.open_door_alarm.event_types, ['triggered'])
+        assert.equal(components.open_door_alarm.device_class, undefined)
+    })
+
+    test('0x1072 publishes every alarm without retention or rediscovery replay', (t) => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', SAMPLE_INITIAL)
+        const publish = t.mock.method(ha.asConnection(), 'publishProperty')
+
+        dev.processAABB(SAMPLE_DOOR_ALARM)
+        dev.processAABB(SAMPLE_DOOR_ALARM)
+        dev.processAABB(buf('1072001C0A00000000000000000000'))
+        dev.publishConfig()
+
+        const alarms = publish.mock.calls.filter((call) => call.arguments[1] === 'open_door_alarm')
+        assert.equal(alarms.length, 3)
+        for (const call of alarms) {
+            assert.deepEqual(call.arguments, [
+                DEVICE_ID,
+                'open_door_alarm',
+                '{"event_type":"triggered"}',
+                { retain: false },
+            ])
+        }
+        assert.equal(dev.publishCache.open_door_alarm, undefined)
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('0x1072 ignores incomplete and unsupported frames', () => {
+        const { ha, dev } = makeDevice()
+        for (let length = 0; length < SAMPLE_DOOR_ALARM.length; length++) {
+            dev.processAABB(SAMPLE_DOOR_ALARM.subarray(0, length))
+        }
+        dev.processAABB(Buffer.concat([SAMPLE_DOOR_ALARM, Buffer.from([0])]))
+        for (const offset of [0, 1]) {
+            const invalid = Buffer.from(SAMPLE_DOOR_ALARM)
+            invalid[offset] = 0xff
+            dev.processAABB(invalid)
+        }
 
         assert.equal(ha.devices[DEVICE_ID], undefined)
     })

--- a/tests/cloud/devices/2REBGLUB_2P__.test.ts
+++ b/tests/cloud/devices/2REBGLUB_2P__.test.ts
@@ -12,7 +12,7 @@ const META: Metadata = {
     swVersion: '1.0',
 }
 
-// Real packet captures from an LG GBBS322CEV refrigerator.
+// Real packet captures from an LG GBBS322CEV refrigerator, also validated with an LG GBBS322BEV.
 // ThinQ2 model ID: 2REBGLUB_2P__
 // Device type: 101
 //
@@ -25,7 +25,7 @@ const META: Metadata = {
 
 // Fridge=3C, freezer=-20C, door closed,
 // Express Cool OFF, Express Freeze OFF,
-// drawer mode Cheese, unit Celsius.
+// Fresh Converter+ Cheese mode, unit Celsius.
 const SAMPLE_INITIAL = buf(
     'AA6610EB02050601FFFFFF0201FFFFFF00FFFFFF0000FFFFFFFFFFFFFFFF010101FF02FFFFFFFFFFFFFFFFFF01FF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0078FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0005FFFFFFFFFF01010101000EBB',
 )
@@ -36,7 +36,7 @@ const SAMPLE_DOOR_OPEN = buf(
 )
 
 // Fridge=3C, freezer=-23C, door open,
-// Express Freeze ON, drawer mode Cheese.
+// Express Freeze ON, Fresh Converter+ Cheese mode.
 const SAMPLE_EXPRESS_FREEZE_ON = buf(
     'AA6610EB02050902FFFFFF0101FFFFFF00FFFFFF0000FFFFFFFFFFFFFFFF010103FF02FFFFFFFFFFFFFFFFFF01FF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0078FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0005FFFFFFFFFF01010000000BBB',
 )
@@ -48,12 +48,12 @@ const SAMPLE_EXPRESS_COOL_ON = buf(
     'AA6610EB02050601FFFFFF0101FFFFFF00FFFFFF0100FFFFFFFFFFFFFFFF010103FF02FFFFFFFFFFFFFFFFFF01FF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0078FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0005FFFFFFFFFF01010000000EBB',
 )
 
-// Drawer mode Fish, raw value 1.
+// Fresh Converter+ Fish mode, raw value 1.
 const SAMPLE_DRAWER_FISH = buf(
     'AA6610EB02050601FFFFFF0101FFFFFF00FFFFFF0000FFFFFFFFFFFFFFFF010103FF02FFFFFFFFFFFFFFFFFF01FF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0078FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0005FFFFFFFFFF010101010108BB',
 )
 
-// Drawer mode Meat, raw value 2.
+// Fresh Converter+ Meat mode, raw value 2.
 const SAMPLE_DRAWER_MEAT = buf(
     'AA6610EB02050601FFFFFF0101FFFFFF00FFFFFF0000FFFFFFFFFFFFFFFF010103FF02FFFFFFFFFFFFFFFFFF01FF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0078FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0005FFFFFFFFFF01010101020BBB',
 )
@@ -101,15 +101,17 @@ describe(MODEL_ID, () => {
         assert.ok(components.express_cool, 'express_cool component')
         assert.ok(components.express_freeze, 'express_freeze component')
         assert.ok(components.drawer_mode, 'drawer_mode component')
-        assert.ok(components.drawer_mode_raw, 'drawer_mode_raw component')
+        assert.equal(components.drawer_mode.name, 'Fresh Converter+ (Drawer temperature)')
+        assert.equal(components.drawer_mode.device_class, 'enum')
+        assert.deepEqual(components.drawer_mode.options, ['Cheese (2 °C)', 'Fish (0 °C)', 'Meat (-3 °C)'])
+        assert.equal(components.drawer_mode_raw, undefined)
 
         assert.equal(dev.properties.fridge_setpoint, 3)
         assert.equal(dev.properties.freezer_setpoint, -20)
         assert.equal(dev.properties.door, 'OFF')
         assert.equal(dev.properties.express_cool, 'OFF')
         assert.equal(dev.properties.express_freeze, 'OFF')
-        assert.equal(dev.properties.drawer_mode, 'Cheese')
-        assert.equal(dev.properties.drawer_mode_raw, '0')
+        assert.equal(dev.properties.drawer_mode, 'Cheese (2 °C)')
     })
 
     test('0x10EB full status decodes an open door', () => {
@@ -149,37 +151,41 @@ describe(MODEL_ID, () => {
         assert.equal(props.door, 'ON')
     })
 
-    test('drawer mode raw 0 is decoded as Cheese', () => {
+    test('Fresh Converter+ raw value 0 is decoded as Cheese at 2 °C', () => {
         const { ha, thinq } = makeDevice()
 
         thinq.emit('data', SAMPLE_INITIAL)
 
         const props = ha.devices[DEVICE_ID].properties
 
-        assert.equal(props.drawer_mode_raw, '0')
-        assert.equal(props.drawer_mode, 'Cheese')
+        assert.equal(props.drawer_mode, 'Cheese (2 °C)')
     })
 
-    test('drawer mode raw 1 is decoded as Fish', () => {
+    test('Fresh Converter+ raw value 1 is decoded as Fish at 0 °C', () => {
         const { ha, thinq } = makeDevice()
 
         thinq.emit('data', SAMPLE_DRAWER_FISH)
 
         const props = ha.devices[DEVICE_ID].properties
 
-        assert.equal(props.drawer_mode_raw, '1')
-        assert.equal(props.drawer_mode, 'Fish')
+        assert.equal(props.drawer_mode, 'Fish (0 °C)')
     })
 
-    test('drawer mode raw 2 is decoded as Meat', () => {
+    test('Fresh Converter+ raw value 2 is decoded as Meat at -3 °C', () => {
         const { ha, thinq } = makeDevice()
 
         thinq.emit('data', SAMPLE_DRAWER_MEAT)
 
         const props = ha.devices[DEVICE_ID].properties
 
-        assert.equal(props.drawer_mode_raw, '2')
-        assert.equal(props.drawer_mode, 'Meat')
+        assert.equal(props.drawer_mode, 'Meat (-3 °C)')
+    })
+
+    test('unsupported Fresh Converter+ values use the Home Assistant enum fallback', () => {
+        const { dev } = makeDevice()
+
+        assert.equal(dev.drawerModeName(0xff), 'unknown')
+        assert.equal(dev.drawerModeName(3), 'unknown')
     })
 
     test('0x10EC delta decodes only the current status block', () => {
@@ -194,8 +200,7 @@ describe(MODEL_ID, () => {
         assert.equal(props.door, 'OFF')
         assert.equal(props.express_cool, 'OFF')
         assert.equal(props.express_freeze, 'OFF')
-        assert.equal(props.drawer_mode, 'Cheese')
-        assert.equal(props.drawer_mode_raw, '0')
+        assert.equal(props.drawer_mode, 'Cheese (2 °C)')
     })
 
     test('frames not matching the AA..BB envelope are ignored', () => {

--- a/tests/cloud/devices/2REBGLUB_2P__.test.ts
+++ b/tests/cloud/devices/2REBGLUB_2P__.test.ts
@@ -205,6 +205,58 @@ describe(MODEL_ID, () => {
         assert.equal(props.drawer_mode, 'Cheese (2 °C)')
     })
 
+    test('thermal state components use the agreed enum values', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_INITIAL)
+
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        for (const name of ['fridge_thermal_state', 'freezer_thermal_state']) {
+            assert.equal(components[name].platform, 'sensor')
+            assert.equal(components[name].device_class, 'enum')
+            assert.deepEqual(components[name].options, ['settled', 'unknown', 'disturbed', 'unsettled'])
+            assert.equal(components[name].unique_id, `$deviceid-${name}`)
+            assert.equal(components[name].state_topic, `$this/${name}`)
+        }
+    })
+
+    test('0x10EB decodes thermal states for each compartment', () => {
+        const { ha, dev } = makeDevice()
+        const status = Buffer.from(SAMPLE_INITIAL.subarray(2, -2))
+        const states = new Map([
+            [1, 'settled'],
+            [2, 'unknown'],
+            [3, 'disturbed'],
+            [5, 'unsettled'],
+            [0xff, 'unknown'],
+            [4, 'unknown'],
+        ])
+
+        for (const [fridge, fridgeName] of states) {
+            for (const [freezer, freezerName] of states) {
+                status[2 + 27] = fridge
+                status[2 + 28] = freezer
+                dev.processAABB(status)
+
+                assert.equal(ha.devices[DEVICE_ID].properties.fridge_thermal_state, fridgeName)
+                assert.equal(ha.devices[DEVICE_ID].properties.freezer_thermal_state, freezerName)
+            }
+        }
+    })
+
+    test('0x10EC thermal states come from the current block only', () => {
+        const { ha, dev } = makeDevice()
+        const status = Buffer.from(SAMPLE_DELTA_DOOR_OPEN_TO_CLOSED.subarray(2, -2))
+        status[2 + 27] = 5
+        status[2 + 28] = 2
+        status[2 + 96 + 27] = 1
+        status[2 + 96 + 28] = 3
+
+        dev.processAABB(status)
+
+        assert.equal(ha.devices[DEVICE_ID].properties.fridge_thermal_state, 'settled')
+        assert.equal(ha.devices[DEVICE_ID].properties.freezer_thermal_state, 'disturbed')
+    })
+
     test('frames not matching the AA..BB envelope are ignored', () => {
         const { ha, thinq } = makeDevice()
 

--- a/tests/cloud/devices/2REBGLUB_2P__.test.ts
+++ b/tests/cloud/devices/2REBGLUB_2P__.test.ts
@@ -64,6 +64,8 @@ const SAMPLE_DELTA_DOOR_OPEN_TO_CLOSED = buf(
     'AAC610EC02050601FFFFFF0101FFFFFF00FFFFFF0000FFFFFFFFFFFFFFFF010101FF02FFFFFFFFFFFFFFFFFF01FF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0078FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0005FFFFFFFFFF010101010002050601FFFFFF0201FFFFFF00FFFFFF0000FFFFFFFFFFFFFFFF010101FF02FFFFFFFFFFFFFFFFFF01FF00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0078FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0005FFFFFFFFFF01010101005EBB',
 )
 
+const SAMPLE_DOOR_USAGE = buf('10C5000401000200000A03000300000E11001E00006413003C000096')
+
 function makeDevice() {
     const ha = new MockHAConnection()
     const thinq = new MockThinq2Device(DEVICE_ID, META)
@@ -207,6 +209,123 @@ describe(MODEL_ID, () => {
         const { ha, thinq } = makeDevice()
 
         thinq.emit('data', buf('001122'))
+
+        assert.equal(ha.devices[DEVICE_ID], undefined)
+    })
+
+    test('door usage components expose cumulative counts and seconds', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_INITIAL)
+
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        for (const name of ['door_openings', 'door_time', 'freezer_openings', 'freezer_time']) {
+            assert.equal(components[name].platform, 'sensor')
+            assert.equal(components[name].state_class, 'total_increasing')
+            assert.equal(components[name].unique_id, `$deviceid-${name}`)
+            assert.equal(components[name].state_topic, `$this/${name}`)
+        }
+        for (const name of ['door_time', 'freezer_time']) {
+            assert.equal(components[name].device_class, 'duration')
+            assert.equal(components[name].unit_of_measurement, 's')
+        }
+        for (const name of ['door_openings', 'freezer_openings']) {
+            assert.equal(components[name].device_class, undefined)
+            assert.equal(components[name].unit_of_measurement, undefined)
+        }
+    })
+
+    test('0x10C5 publishes cumulative door usage, not interval values', () => {
+        const { ha, dev } = makeDevice()
+        dev.processAABB(SAMPLE_DOOR_USAGE)
+
+        assert.deepEqual(ha.devices[DEVICE_ID].properties, {
+            door_openings: 10,
+            door_time: 100,
+            freezer_openings: 4,
+            freezer_time: 50,
+        })
+    })
+
+    test('0x10C5 repeated reports do not add to totals', (t) => {
+        const { ha, dev } = makeDevice()
+        const publish = t.mock.method(ha, 'publishProperty')
+
+        for (let i = 0; i < 11; i++) dev.processAABB(SAMPLE_DOOR_USAGE)
+
+        assert.equal(publish.mock.callCount(), 4)
+        assert.equal(ha.devices[DEVICE_ID].properties.door_openings, 10)
+        assert.equal(ha.devices[DEVICE_ID].properties.freezer_openings, 4)
+    })
+
+    test('0x10C5 preserves 24-bit totals across skipped reports and adapter recreation', () => {
+        const first = makeDevice()
+        first.dev.processAABB(SAMPLE_DOOR_USAGE)
+
+        const next = Buffer.from(SAMPLE_DOOR_USAGE)
+        next[2] = 47
+        next.writeUIntBE(0x010203, 7, 3)
+        next.writeUIntBE(0x020304, 13, 3)
+        next.writeUIntBE(0x030405, 19, 3)
+        next.writeUIntBE(0x040506, 25, 3)
+        first.dev.processAABB(next)
+
+        const restarted = makeDevice()
+        restarted.dev.processAABB(next)
+
+        const expected = {
+            door_openings: 0x010203,
+            door_time: 0x030405,
+            freezer_openings: 0x010101,
+            freezer_time: 0x010101,
+        }
+        assert.deepEqual(first.ha.devices[DEVICE_ID].properties, expected)
+        assert.deepEqual(restarted.ha.devices[DEVICE_ID].properties, expected)
+    })
+
+    test('0x10C5 publishes the appliance accounting-window reset', () => {
+        const { ha, dev } = makeDevice()
+        dev.processAABB(SAMPLE_DOOR_USAGE)
+
+        const reset = Buffer.from(SAMPLE_DOOR_USAGE)
+        reset[2] = 96
+        for (const offset of [5, 11, 17, 23]) reset.fill(0, offset, offset + 5)
+        dev.processAABB(reset)
+
+        assert.deepEqual(ha.devices[DEVICE_ID].properties, {
+            door_openings: 0,
+            door_time: 0,
+            freezer_openings: 0,
+            freezer_time: 0,
+        })
+    })
+
+    test('0x10C5 publishes freezer differences without adjusting decreases or negative values', () => {
+        const { ha, dev } = makeDevice()
+        dev.processAABB(SAMPLE_DOOR_USAGE)
+
+        const next = Buffer.from(SAMPLE_DOOR_USAGE)
+        next.writeUIntBE(11, 7, 3)
+        dev.processAABB(next)
+        assert.equal(ha.devices[DEVICE_ID].properties.freezer_openings, 3)
+
+        next.writeUIntBE(15, 7, 3)
+        next.writeUIntBE(151, 19, 3)
+        dev.processAABB(next)
+        assert.equal(ha.devices[DEVICE_ID].properties.freezer_openings, -1)
+        assert.equal(ha.devices[DEVICE_ID].properties.freezer_time, -1)
+    })
+
+    test('0x10C5 ignores incomplete or unsupported record layouts', () => {
+        const { ha, dev } = makeDevice()
+        for (let length = 0; length < SAMPLE_DOOR_USAGE.length; length++) {
+            dev.processAABB(SAMPLE_DOOR_USAGE.subarray(0, length))
+        }
+        dev.processAABB(Buffer.concat([SAMPLE_DOOR_USAGE, Buffer.from([0])]))
+        for (const offset of [0, 1, 3, 4, 10, 16, 22]) {
+            const invalid = Buffer.from(SAMPLE_DOOR_USAGE)
+            invalid[offset] = 0xff
+            dev.processAABB(invalid)
+        }
 
         assert.equal(ha.devices[DEVICE_ID], undefined)
     })


### PR DESCRIPTION
This continues [#142](https://github.com/anszom/rethink/pull/142). Thanks @Skarabaen for the GBBS322CEV support. My GBBS322BEV appears very similar and reports the same ThinQ2 model ID, `2REBGLUB_2P__`, and device type 101.

I based [my fork’s branch](https://github.com/yo3gnd/rethink/tree/add-lg-gbbs322bev-support) on your [d049e45](https://github.com/Skarabaen/rethink/commit/d049e455117008d89999133fe95cd0f183270130), adding six commits through [29a9bbd](https://github.com/yo3gnd/rethink/commit/29a9bbdc26e65510711515dc6079daac22b0d27a). Your original commits remain intact; merging this branch would include both your CEV support and these additions.

@anszom, I’ve addressed your review points: README entries, Fresh Converter+ naming, enum and `unknown` handling, and removal of the raw drawer entity and redundant checks. Drawer modes now include their nominal temperatures.

The additions expose door-opening counts and durations, fridge/freezer thermal states, open-door alarm events and energy at 0.5 Wh/count. Alarms are non-retained and dropped while MQTT is offline; discovery explicitly removes the retired raw sensor. Appliance command frames are unchanged.

I’m also a ham (not the refrigerator kind), and our community takes EMC/RFI rather seriously. My unit is dead quiet on the 20m band and above. A welcome non-feature I'd like to document in this odd corner of the Internet.