### PR TITLE
Add device alias for LG F2V5PS0W (F_V7_Y___W.B__QEUK) washer

### DIFF
--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -50,6 +50,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['STUDIO_HOOD']: Dev_STUDIO_HOOD,
     ['Y_V8_Y___W.B32QEUK']: Y_V8_Y___W_B32QEUK,
     ['F_V7_Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK, // NOTE: we reuse F_V8_Y___W_B_2QEUK as the models appear to be compatible
+    ['F_V7_Y___W.B__QEUK']: F_V8_Y___W_B_2QEUK, // LG F2V5PS0W front-load washer - confirmed working, status/course/spin/temp/energy/remaining_time all decode correctly against a real unit
     ['F_V8_Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK,
     ['Y_V8_F___W.B_2QEUK']: Y_V8_F___W_B_2QEUK,
     ['F_V__Y___W.B_2QEUK']: F_V8_Y___W_B_2QEUK, // NOTE: we reuse F_V8_Y___W_B_2QEUK as the models appear to be compatible


### PR DESCRIPTION
My LG F2V5PS0W front-load washer reports ThinQ model ID `F_V7_Y___W.B__QEUK`, which
isn't in `t2deviceTypes` (logs `thinq2 device type F_V7_Y___W.B__QEUK unknown`).

A near-identical sibling, `F_V7_Y___W.B_2QEUK` (differs by one character), is already
aliased to the `F_V8_Y___W_B_2QEUK` decoder with a comment noting the models "appear
to be compatible"

I aliased my model to the same decoder and ran a full real wash cycle against it - all fields decoded correctly throughout the cycle:

- `status`: Washing → Rinsing → Spinning → End transitions tracked correctly
- `remaining_time`: counted down accurately in real time (e.g. 69 → 68 → 67 minutes
  matching the wall clock)
- `course`, `spin`, `temp` - displayed correctly
- `energy`: incremented in Wh as expected
- lock/option binary sensors also behaved correctly

This adds the alias with a comment documenting the confirmed retail model (LG
F2V5PS0W) for discoverability, following the convention used elsewhere in this file
for retail model numbers.
