### PR TITLE
Add support for the FQ18PADNQN floor-standing air conditioner (PAC_910604_WW)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 dist
 oauth.json
 state
+captures/

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following appliances are currently supported in rethink:
 
 - Air Conditioners:
     - 👍 LG DualCool family (Standard 2, Deluxe with and without air purifier, etc.) wall-mounted Air Conditioner IDUs - high level of support. What's missing are mostly some features of higher-end models and more diagnostic coverage,
-    - 🫤 LG floor-standing Air Conditioner (PAC_910604_WW) - read-only climate, air quality, swing, timer, and operating-feature state,
+    - 🫤 LG floor-standing Air Conditioner (PAC_910604_WW) - climate, air quality, swing, timer, and operating-feature state; air purify, energy saving, smart care, wind mode, human sense, sleep and reservation timers are controllable,
     - 👍 LW1822HRSM, Smart Window Air Conditioner - mostly working,
     - 👍 LP1022FVSM Portable Air Conditioner - mostly working,
 - Fridges:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following appliances are currently supported in rethink:
 
 - Air Conditioners:
     - 👍 LG DualCool family (Standard 2, Deluxe with and without air purifier, etc.) wall-mounted Air Conditioner IDUs - high level of support. What's missing are mostly some features of higher-end models and more diagnostic coverage,
-    - 🫤 LG floor-standing Air Conditioner (PAC_910604_WW) - full climate control with both swing axes, air purify, energy saving, smart care, wind mode, human sense, sleep and reservation timers; air quality, power draw, filter and error state reported,
+    - 🫤 LG FQ18PADNQN floor-standing Air Conditioner (PAC_910604_WW) - full climate control with both swing axes, air purify, energy saving, smart care, wind mode, human sense, sleep and reservation timers; air quality, power draw, auto-dry, filter usage/lifetime/remaining and error state reported,
     - 👍 LW1822HRSM, Smart Window Air Conditioner - mostly working,
     - 👍 LP1022FVSM Portable Air Conditioner - mostly working,
 - Fridges:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following appliances are currently supported in rethink:
 
 - Air Conditioners:
     - 👍 LG DualCool family (Standard 2, Deluxe with and without air purifier, etc.) wall-mounted Air Conditioner IDUs - high level of support. What's missing are mostly some features of higher-end models and more diagnostic coverage,
-    - 🫤 LG floor-standing Air Conditioner (PAC_910604_WW) - climate, air quality, swing, timer, and operating-feature state; air purify, energy saving, smart care, wind mode, human sense, sleep and reservation timers are controllable,
+    - 🫤 LG floor-standing Air Conditioner (PAC_910604_WW) - full climate control with both swing axes, air purify, energy saving, smart care, wind mode, human sense, sleep and reservation timers; air quality, power draw, filter and error state reported,
     - 👍 LW1822HRSM, Smart Window Air Conditioner - mostly working,
     - 👍 LP1022FVSM Portable Air Conditioner - mostly working,
 - Fridges:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The following appliances are currently supported in rethink:
 
 - Air Conditioners:
     - 👍 LG DualCool family (Standard 2, Deluxe with and without air purifier, etc.) wall-mounted Air Conditioner IDUs - high level of support. What's missing are mostly some features of higher-end models and more diagnostic coverage,
+    - 🫤 LG floor-standing Air Conditioner (PAC_910604_WW) - read-only climate, air quality, swing, timer, and operating-feature state,
     - 👍 LW1822HRSM, Smart Window Air Conditioner - mostly working,
     - 👍 LP1022FVSM Portable Air Conditioner - mostly working,
 - Fridges:

--- a/cloud/devices/PAC_910604_WW.ts
+++ b/cloud/devices/PAC_910604_WW.ts
@@ -1,0 +1,359 @@
+import TLVDevice from './tlv_device'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { ClimateComponent, DeviceDiscovery, type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import { Enum } from '@/util/enum'
+import * as TLV from '@/util/tlv'
+import HADevice from './base'
+
+/**
+ * LG floor-standing air conditioner PAC_910604_WW (deviceType 401).
+ *
+ * Same TLV envelope as the RAC_056905_WW wall units (0xA7 header), but the field
+ * set is incompatible, so it gets its own handler instead of an alias:
+ * fan levels replicate across both bytes (level x 0x0101), horizontal swing is a
+ * two-bit field, and human-sense / power modes / air-quality sensors are new tags.
+ *
+ * Read-only: the handler never transmits. All discovery entries are state-only
+ * and setProperty() on any of them is a tested no-op.
+ */
+
+// Owner-verified on the physical unit (each toggle driven on the remote/app and
+// confirmed on the wire, on->off round trips; PM/humidity cross-checked with the
+// ThinQ app): 0x1f7 power, 0x1f9 mode (cool/dry only), 0x1fd/0x1fe temperatures
+// (/2), 0x205 vertical swing, 0x206 horizontal swing, 0x208 human sense,
+// 0x20d eco, 0x20f air clean, 0x21a sleep timer (minutes, up to 420),
+// 0x225 auto-dry countdown (minutes), 0x236 cool power, 0x209 long power,
+// 0x23e smart care, 0x23f smart guide,
+// 0x333/0x334/0x335 PM1.0/PM2.5/PM10, 0x336 humidity.
+const MODES = Enum.of({
+    cool: 0,
+    dry: 1,
+})
+
+// Observed levels: 2 (low), 4 (medium), 6 (high), 8 (auto),
+// 7 (coolpower only), 9 (longpower only).
+const FAN_LEVELS = new Enum([
+    ['auto', 8],
+    ['low', 2],
+    ['medium', 4],
+    ['high', 6],
+    ['turbo', 7],
+    ['max', 9],
+] as [string, number][])
+
+// Bit-split field: low byte = right vane, high byte = left vane.
+const SWING_H = Enum.of({
+    off: 0,
+    right: 1,
+    left: 256,
+    both: 257,
+})
+
+const HUMAN_SENSE = Enum.of({
+    off: 0,
+    direct: 1,
+    indirect: 2,
+})
+
+/**
+ * Fan values arrive as level x 0x0101 (both bytes equal: 0x0202, 0x0404 ...).
+ * While eco is engaging the device emits one frame with 0xFF in one of the
+ * bytes (0xFF04 or 0x04FF observed); the other byte still carries the level.
+ */
+function fanLevel(raw: number): number {
+    const lo = raw & 0xff
+    const hi = (raw >> 8) & 0xff
+    return lo === 0xff ? hi : lo
+}
+
+export default class Device extends TLVDevice {
+    meta: Metadata
+    configDone = false
+
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        this.meta = meta
+        // Stay fully passive: never poll the appliance, only listen.
+        if (this.query_caps_timeout != undefined) {
+            clearInterval(this.query_caps_timeout)
+            this.query_caps_timeout = undefined
+        }
+    }
+
+    queryCaps() {
+        // Read-only: no capability query is ever sent.
+    }
+
+    query() {
+        // Read-only: no values query is ever sent.
+    }
+
+    start() {
+        // Read-only: no periodic refresh timer.
+    }
+
+    isValuesResponse(tlvArray: TLV.TLV[]) {
+        return tlvArray.some(({ t }) => t === 0x1f7)
+    }
+
+    valuesReceived() {
+        if (this.configDone) return
+        this.configDone = true
+        this.initConfig()
+    }
+
+    getPowerTLV() {
+        return this.raw_clip_state[0x1f7]
+    }
+
+    getModeTLV() {
+        return this.raw_clip_state[0x1f9]
+    }
+
+    initConfig() {
+        const config: DeviceDiscovery & { components: { climate: ClimateComponent } } = allowExtendedType({
+            ...HADevice.config(this.meta, { name: 'LG Stand Air Conditioner' }),
+            components: {
+                climate: {
+                    platform: 'climate',
+                    unique_id: '$deviceid-climate',
+                    name: null,
+                    temperature_unit: 'C',
+                    // Setpoints move in whole degrees (raw steps of 2).
+                    temp_step: 1,
+                    precision: 1,
+                    current_humidity_topic: '$this/humidity-',
+                    // 18C forced by coolpower is the observed floor; above the
+                    // observed 26C ceiling the range is unverified.
+                    min_temp: 18,
+                    max_temp: 30,
+                    modes: ['off', ...MODES.options],
+                    fan_modes: FAN_LEVELS.options,
+                } satisfies ClimateComponent,
+            },
+        })
+
+        this.addField(config, {
+            id: 0x1fd,
+            name: 'current_temperature',
+            comp: 'climate',
+            state_topic: 'topic',
+            writable: false,
+            read_xform: (raw) => raw / 2,
+        })
+        this.addField(config, {
+            id: 0x1fe,
+            name: 'temperature',
+            comp: 'climate',
+            writable: false,
+            read_xform: (raw) => raw / 2,
+        })
+        this.addField(config, {
+            id: 0x1f7,
+            name: 'power',
+            comp: 'climate',
+            readable: false,
+            writable: false,
+            read_xform: (raw) => (raw ? 'ON' : 'OFF'),
+            read_callback: (val) => {
+                this.HA.publishProperty(this.id, 'power-', val)
+                // Re-evaluate 'mode' so it flips between 'off' and the set mode.
+                this.processKeyValue(0x1f9, this.raw_clip_state[0x1f9])
+                return false
+            },
+        })
+        this.addField(config, {
+            id: 0x1f9,
+            name: 'mode',
+            comp: 'climate',
+            writable: false,
+            read_xform: (raw) => {
+                if (this.getPowerTLV() === 0) return 'off'
+                return MODES.map(raw)
+            },
+        })
+        this.addField(config, {
+            id: 0x1fa,
+            name: 'fan_mode',
+            comp: 'climate',
+            writable: false,
+            read_xform: (raw) => FAN_LEVELS.map(fanLevel(raw)),
+        })
+
+        // Binary sensor fields
+        const powerComp = {
+            platform: 'binary_sensor',
+            unique_id: '$deviceid-power',
+            name: 'Power',
+            state_topic: '$this/power-',
+        }
+        config['components']['power'] = powerComp
+
+        const binaryFields = [
+            { id: 0x205, name: 'swing_v', desc: 'Vertical swing' },
+            { id: 0x20d, name: 'eco', desc: 'Energy saving' },
+            { id: 0x20f, name: 'airclean', desc: 'Air purify' },
+            { id: 0x23f, name: 'smartguide', desc: 'Smart guide' },
+            { id: 0x236, name: 'coolpower', desc: 'Cool power' },
+            { id: 0x209, name: 'longpower', desc: 'Long power' },
+            { id: 0x23e, name: 'smartcare', desc: 'Smart care' },
+        ]
+        for (const f of binaryFields) {
+            config['components'][f.name] = {
+                platform: 'binary_sensor',
+                unique_id: '$deviceid-' + f.name,
+                name: f.desc,
+            }
+            this.addField(config, {
+                id: f.id,
+                name: '',
+                comp: f.name,
+                writable: false,
+                read_xform: (raw) => (raw ? 'ON' : 'OFF'),
+            })
+        }
+
+        // Enum sensor fields
+        const swingH = {
+            platform: 'sensor',
+            unique_id: '$deviceid-swing_h',
+            name: 'Horizontal swing',
+            device_class: 'enum',
+            options: SWING_H.options,
+        }
+        config['components']['swing_h'] = swingH
+        this.addField(config, {
+            id: 0x206,
+            name: '',
+            comp: 'swing_h',
+            writable: false,
+            read_xform: (raw) => SWING_H.map(raw),
+        })
+
+        const humanSense = {
+            platform: 'sensor',
+            unique_id: '$deviceid-human_sense',
+            name: 'Human sense',
+            device_class: 'enum',
+            options: HUMAN_SENSE.options,
+        }
+        config['components']['human_sense'] = humanSense
+        this.addField(config, {
+            id: 0x208,
+            name: '',
+            comp: 'human_sense',
+            writable: false,
+            read_xform: (raw) => HUMAN_SENSE.map(raw),
+        })
+
+        // PM sensors
+        const pmExtra = {
+            unit_of_measurement: 'µg/m³',
+            state_class: 'measurement',
+            suggested_display_precision: 0,
+        }
+        const pm1Comp = {
+            platform: 'sensor',
+            unique_id: '$deviceid-pm1',
+            name: 'PM1.0',
+            device_class: 'pm1',
+            ...pmExtra,
+        }
+        config['components']['pm1'] = pm1Comp
+        this.addField(config, {
+            id: 0x333,
+            name: '',
+            comp: 'pm1',
+            writable: false,
+        })
+
+        const pm25Comp = {
+            platform: 'sensor',
+            unique_id: '$deviceid-pm25',
+            name: 'PM2.5',
+            device_class: 'pm25',
+            ...pmExtra,
+        }
+        config['components']['pm25'] = pm25Comp
+        this.addField(config, {
+            id: 0x334,
+            name: '',
+            comp: 'pm25',
+            writable: false,
+        })
+
+        const pm10Comp = {
+            platform: 'sensor',
+            unique_id: '$deviceid-pm10',
+            name: 'PM10',
+            device_class: 'pm10',
+            ...pmExtra,
+        }
+        config['components']['pm10'] = pm10Comp
+        this.addField(config, {
+            id: 0x335,
+            name: '',
+            comp: 'pm10',
+            writable: false,
+        })
+
+        // Humidity sensor
+        const humComp = {
+            platform: 'sensor',
+            unique_id: '$deviceid-humidity',
+            name: 'Humidity',
+            device_class: 'humidity',
+            unit_of_measurement: '%',
+            state_class: 'measurement',
+            suggested_display_precision: 0,
+        }
+        config['components']['humidity'] = humComp
+        this.addField(config, {
+            id: 0x336,
+            name: '',
+            comp: 'humidity',
+            writable: false,
+        })
+
+        // Countdown timers in minutes
+        const sleepTimerComp = {
+            platform: 'sensor',
+            unique_id: '$deviceid-sleep_timer',
+            name: 'Sleep timer',
+            device_class: 'duration',
+            unit_of_measurement: 'min',
+        }
+        config['components']['sleep_timer'] = sleepTimerComp
+        this.addField(config, {
+            id: 0x21a,
+            name: '',
+            comp: 'sleep_timer',
+            writable: false,
+        })
+
+        const dryRemainComp = {
+            platform: 'sensor',
+            unique_id: '$deviceid-dry_remain',
+            name: 'Auto dry remaining',
+            device_class: 'duration',
+            unit_of_measurement: 'min',
+        }
+        config['components']['dry_remain'] = dryRemainComp
+        this.addField(config, {
+            id: 0x225,
+            name: '',
+            comp: 'dry_remain',
+            writable: false,
+        })
+
+        this.setConfig(config)
+
+        // The first full frame arrived before fields were registered. Replay its
+        // cached values once so HA receives initial state without polling the unit.
+        for (const [id, value] of Object.entries(this.raw_clip_state)) {
+            this.processKeyValue(Number(id), value)
+        }
+    }
+}

--- a/cloud/devices/PAC_910604_WW.ts
+++ b/cloud/devices/PAC_910604_WW.ts
@@ -15,8 +15,14 @@ import HADevice from './base'
  * fan levels replicate across both bytes (level x 0x0101), horizontal swing is a
  * two-bit field, and human-sense / power modes / air-quality sensors are new tags.
  *
- * Read-only: the handler never transmits. All discovery entries are state-only
- * and setProperty() on any of them is a tested no-op.
+ * Passive listener: never polls or queries; transmits only user-initiated
+ * control writes.
+ *
+ * Controllable (each write reproduces the app's captured command frame):
+ * air purify, energy saving and smart care switches; a wind-mode selector
+ * (off / coolpower / longpower, sharing the app's single off frame); a human
+ * sense selector; sleep, turn-on and turn-off timers in minutes. Climate,
+ * swings and all sensors stay state-only.
  */
 
 // Owner-verified on the physical unit (each toggle driven on the remote/app and
@@ -112,6 +118,12 @@ export default class Device extends TLVDevice {
         return this.raw_clip_state[0x1f9]
     }
 
+    /** Wind mode is derived from two tags: coolpower wins, then longpower. */
+    private publishWindMode() {
+        const mode = this.raw_clip_state[0x236] ? 'coolpower' : this.raw_clip_state[0x209] ? 'longpower' : 'off'
+        this.HA.publishProperty(this.id, 'wind_mode-', mode)
+    }
+
     initConfig() {
         const config: DeviceDiscovery & { components: { climate: ClimateComponent } } = allowExtendedType({
             ...HADevice.config(this.meta, { name: 'LG Stand Air Conditioner' }),
@@ -182,30 +194,30 @@ export default class Device extends TLVDevice {
             read_xform: (raw) => FAN_LEVELS.map(fanLevel(raw)),
         })
 
-        // Binary sensor fields
+        // Appliance-internal status stays under diagnostics; the environment
+        // readings and the user-facing controls stay primary.
         const powerComp = {
             platform: 'binary_sensor',
             unique_id: '$deviceid-power',
             name: 'Power',
             state_topic: '$this/power-',
+            entity_category: 'diagnostic',
         }
         config['components']['power'] = powerComp
 
+        // State-only binaries. Writes were never captured for these.
         const binaryFields = [
             { id: 0x205, name: 'swing_v', desc: 'Vertical swing' },
-            { id: 0x20d, name: 'eco', desc: 'Energy saving' },
-            { id: 0x20f, name: 'airclean', desc: 'Air purify' },
             { id: 0x23f, name: 'smartguide', desc: 'Smart guide' },
-            { id: 0x236, name: 'coolpower', desc: 'Cool power' },
-            { id: 0x209, name: 'longpower', desc: 'Long power' },
-            { id: 0x23e, name: 'smartcare', desc: 'Smart care' },
         ]
         for (const f of binaryFields) {
-            config['components'][f.name] = {
+            const comp = {
                 platform: 'binary_sensor',
                 unique_id: '$deviceid-' + f.name,
                 name: f.desc,
+                entity_category: 'diagnostic',
             }
+            config['components'][f.name] = comp
             this.addField(config, {
                 id: f.id,
                 name: '',
@@ -214,6 +226,91 @@ export default class Device extends TLVDevice {
                 read_xform: (raw) => (raw ? 'ON' : 'OFF'),
             })
         }
+
+        // Single-tag switches: each write below reproduces the exact frame the
+        // LG app sent for that toggle, captured on the physical unit.
+        const switchFields = [
+            { id: 0x20d, name: 'eco', desc: 'Energy saving' },
+            { id: 0x20f, name: 'airclean', desc: 'Air purify' },
+            { id: 0x23e, name: 'smartcare', desc: 'Smart care' },
+        ]
+        for (const f of switchFields) {
+            config['components'][f.name] = {
+                platform: 'switch',
+                unique_id: '$deviceid-' + f.name,
+                name: f.desc,
+            }
+            this.addField(config, {
+                id: f.id,
+                name: '',
+                comp: f.name,
+                read_xform: (raw) => (raw ? 'ON' : 'OFF'),
+                write_xform: (val) => (val === 'ON' ? 1 : 0),
+            })
+        }
+
+        // Wind mode is one selector in the app (off / coolpower / longpower),
+        // and the wire agrees: a single shared off frame, coolpower as a
+        // direct 0x236 tag, longpower as a climate bundle with fan forced to
+        // max. There is no observed 0x236=0 or 0x209=0 write, so off goes
+        // through the captured bundle (fan fixed to high) instead.
+        const WIND_MODES = ['off', 'coolpower', 'longpower'] as const
+        const windModeComp = {
+            platform: 'select',
+            unique_id: '$deviceid-wind_mode',
+            name: 'Wind mode',
+            options: [...WIND_MODES],
+        }
+        config['components']['wind_mode'] = windModeComp
+        this.addField(config, {
+            id: 0x236,
+            name: '',
+            comp: 'wind_mode',
+            read_callback: () => {
+                this.publishWindMode()
+                return false
+            },
+            write_xform: (val) => {
+                if (val === 'coolpower') return 1
+                if (val === 'longpower') return -1
+                return 0
+            },
+            write_callback: (val) => {
+                // coolpower takes the default single-tag path.
+                if (val === 1) return true
+                // longpower (-1) and off (0) share the climate-bundle shape:
+                // current mode/target with the fan forced (max for longpower,
+                // high for off, both exactly as the app sent them).
+                const mode = this.raw_clip_state[0x1f9]
+                const target = this.raw_clip_state[0x1fe]
+                if (mode === undefined || target === undefined) return false
+                const fan = val === -1 ? 2313 : 1542
+                this.raw_clip_state[0x1fa] = fan
+                this.send(
+                    [1, 1, 2, 1, 1],
+                    [
+                        { t: 0x1f9, v: mode },
+                        { t: 0x1fa, v: fan },
+                        { t: 0x1fe, v: target },
+                    ],
+                )
+                return false
+            },
+        })
+        this.addField(
+            config,
+            {
+                id: 0x209,
+                name: 'windlong',
+                comp: 'wind_mode',
+                readable: false,
+                read_callback: () => {
+                    this.publishWindMode()
+                    return false
+                },
+            },
+            false,
+        )
 
         // Enum sensor fields
         const swingH = {
@@ -233,10 +330,9 @@ export default class Device extends TLVDevice {
         })
 
         const humanSense = {
-            platform: 'sensor',
+            platform: 'select',
             unique_id: '$deviceid-human_sense',
             name: 'Human sense',
-            device_class: 'enum',
             options: HUMAN_SENSE.options,
         }
         config['components']['human_sense'] = humanSense
@@ -244,8 +340,8 @@ export default class Device extends TLVDevice {
             id: 0x208,
             name: '',
             comp: 'human_sense',
-            writable: false,
             read_xform: (raw) => HUMAN_SENSE.map(raw),
+            write_xform: (val) => HUMAN_SENSE.unmap(val),
         })
 
         // PM sensors
@@ -317,20 +413,67 @@ export default class Device extends TLVDevice {
             writable: false,
         })
 
-        // Countdown timers in minutes
+        // Countdown timers in minutes on the wire (0 = cancelled). Sleep maxes
+        // out at the observed 420; the reservations go to 1440 for stop
+        // (observed) and share the same bound for start.
         const sleepTimerComp = {
-            platform: 'sensor',
+            platform: 'number',
             unique_id: '$deviceid-sleep_timer',
             name: 'Sleep timer',
             device_class: 'duration',
             unit_of_measurement: 'min',
+            min: 0,
+            max: 420,
+            step: 10,
+            mode: 'box',
         }
         config['components']['sleep_timer'] = sleepTimerComp
         this.addField(config, {
             id: 0x21a,
             name: '',
             comp: 'sleep_timer',
-            writable: false,
+            read_xform: (raw) => raw,
+            write_xform: (val) => Math.round(Number(val)),
+        })
+
+        const startTimerComp = {
+            platform: 'number',
+            unique_id: '$deviceid-start_timer',
+            name: 'Turn-on timer',
+            device_class: 'duration',
+            unit_of_measurement: 'min',
+            min: 0,
+            max: 1440,
+            step: 60,
+            mode: 'box',
+        }
+        config['components']['start_timer'] = startTimerComp
+        this.addField(config, {
+            id: 0x21c,
+            name: '',
+            comp: 'start_timer',
+            read_xform: (raw) => raw,
+            write_xform: (val) => Math.round(Number(val)),
+        })
+
+        const stopTimerComp = {
+            platform: 'number',
+            unique_id: '$deviceid-stop_timer',
+            name: 'Turn-off timer',
+            device_class: 'duration',
+            unit_of_measurement: 'min',
+            min: 0,
+            max: 1440,
+            step: 60,
+            mode: 'box',
+        }
+        config['components']['stop_timer'] = stopTimerComp
+        this.addField(config, {
+            id: 0x21b,
+            name: '',
+            comp: 'stop_timer',
+            read_xform: (raw) => raw,
+            write_xform: (val) => Math.round(Number(val)),
         })
 
         const dryRemainComp = {
@@ -339,6 +482,7 @@ export default class Device extends TLVDevice {
             name: 'Auto dry remaining',
             device_class: 'duration',
             unit_of_measurement: 'min',
+            entity_category: 'diagnostic',
         }
         config['components']['dry_remain'] = dryRemainComp
         this.addField(config, {

--- a/cloud/devices/PAC_910604_WW.ts
+++ b/cloud/devices/PAC_910604_WW.ts
@@ -19,10 +19,11 @@ import HADevice from './base'
  * control writes.
  *
  * Controllable (each write reproduces the app's captured command frame):
- * air purify, energy saving and smart care switches; a wind-mode selector
- * (off / coolpower / longpower, sharing the app's single off frame); a human
- * sense selector; sleep, turn-on and turn-off timers in minutes. Climate,
- * swings and all sensors stay state-only.
+ * the climate entity (power, cool/dry, target temperature, fan, both swing
+ * axes); air purify, energy saving and smart care switches; a wind-mode
+ * selector (off / coolpower / longpower, sharing the app's single off frame);
+ * a human sense selector; sleep, turn-on and turn-off timers in minutes.
+ * Sensors stay state-only.
  */
 
 // Owner-verified on the physical unit (each toggle driven on the remote/app and
@@ -55,6 +56,13 @@ const SWING_H = Enum.of({
     right: 1,
     left: 256,
     both: 257,
+})
+
+// Vertical swing is a plain on/off on this unit, unlike the RAC angle modes
+// which select a vane angle. Only 0 and 1 have ever been seen on the wire.
+const SWING_V = Enum.of({
+    off: 0,
+    on: 1,
 })
 
 const HUMAN_SENSE = Enum.of({
@@ -159,15 +167,21 @@ export default class Device extends TLVDevice {
             id: 0x1fe,
             name: 'temperature',
             comp: 'climate',
-            writable: false,
             read_xform: (raw) => raw / 2,
+            write_xform: (val) => Math.round(Number(val) * 2),
+            // The app never sends a setpoint alone; it repeats the mode and fan
+            // it believes are current in the same frame.
+            write_attach: [0x1f9, 0x1fa],
         })
         this.addField(config, {
             id: 0x1f7,
             name: 'power',
             comp: 'climate',
             readable: false,
-            writable: false,
+            write_xform: (val) => (val === 'ON' ? 1 : 0),
+            // Turning on restores the mode, fan and setpoint in one frame, which
+            // is what the app does. Turning off sends the power tag alone.
+            write_attach: (raw) => (raw ? [0x1f9, 0x1fa, 0x1fe] : []),
             read_xform: (raw) => (raw ? 'ON' : 'OFF'),
             read_callback: (val) => {
                 this.HA.publishProperty(this.id, 'power-', val)
@@ -180,18 +194,61 @@ export default class Device extends TLVDevice {
             id: 0x1f9,
             name: 'mode',
             comp: 'climate',
-            writable: false,
             read_xform: (raw) => {
                 if (this.getPowerTLV() === 0) return 'off'
                 return MODES.map(raw)
             },
+            write_xform: (val) => {
+                // 'off' is not a wire mode: HA sends it to mean power off.
+                if (val === 'off') {
+                    this.setProperty('climate-power', 'OFF')
+                    return undefined
+                }
+                this.raw_clip_state[0x1f7] = 1 // a write while off is ignored
+                return MODES.unmap(val)
+            },
+            write_attach: [0x1f7, 0x1fa, 0x1fe],
         })
         this.addField(config, {
             id: 0x1fa,
             name: 'fan_mode',
             comp: 'climate',
-            writable: false,
             read_xform: (raw) => FAN_LEVELS.map(fanLevel(raw)),
+            write_xform: (val) => {
+                const level = FAN_LEVELS.unmap(val)
+                if (level === undefined) return undefined
+                this.raw_clip_state[0x1f7] = 1
+                // The appliance expects the level duplicated across both bytes.
+                return level * 0x0101
+            },
+            write_attach: [0x1f7, 0x1f9, 0x1fe],
+        })
+
+        // Both swing axes live on the climate entity, as they do for the RAC
+        // units, so Home Assistant shows them as the AC's own swing controls
+        // rather than as loose entities next to it.
+        config['components']['climate']['swing_modes'] = SWING_V.options
+        this.addField(config, {
+            id: 0x205,
+            name: 'swing_mode',
+            comp: 'climate',
+            read_xform: (raw) => SWING_V.map(raw) ?? 'off',
+            write_xform: (val) => SWING_V.unmap(val),
+        })
+
+        // The horizontal field is two bits: the low byte is the right vane and
+        // the high byte the left, so all four combinations are selectable. Each
+        // was driven separately on the unit to confirm the encoding; 'both' was
+        // never captured as a command, only as the resulting state.
+        config['components']['climate']['swing_horizontal_modes'] = SWING_H.options
+        this.addField(config, {
+            id: 0x206,
+            name: 'swing_horizontal_mode',
+            comp: 'climate',
+            // 'off' rather than a discard, so an unseen combination does not
+            // leave Home Assistant on a stale reading.
+            read_xform: (raw) => SWING_H.map(raw) ?? 'off',
+            write_xform: (val) => SWING_H.unmap(val),
         })
 
         // Appliance-internal status stays under diagnostics; the environment
@@ -206,10 +263,7 @@ export default class Device extends TLVDevice {
         config['components']['power'] = powerComp
 
         // State-only binaries. Writes were never captured for these.
-        const binaryFields = [
-            { id: 0x205, name: 'swing_v', desc: 'Vertical swing' },
-            { id: 0x23f, name: 'smartguide', desc: 'Smart guide' },
-        ]
+        const binaryFields = [{ id: 0x23f, name: 'smartguide', desc: 'Smart guide' }]
         for (const f of binaryFields) {
             const comp = {
                 platform: 'binary_sensor',
@@ -311,23 +365,6 @@ export default class Device extends TLVDevice {
             },
             false,
         )
-
-        // Enum sensor fields
-        const swingH = {
-            platform: 'sensor',
-            unique_id: '$deviceid-swing_h',
-            name: 'Horizontal swing',
-            device_class: 'enum',
-            options: SWING_H.options,
-        }
-        config['components']['swing_h'] = swingH
-        this.addField(config, {
-            id: 0x206,
-            name: '',
-            comp: 'swing_h',
-            writable: false,
-            read_xform: (raw) => SWING_H.map(raw),
-        })
 
         const humanSense = {
             platform: 'select',
@@ -489,6 +526,86 @@ export default class Device extends TLVDevice {
             id: 0x225,
             name: '',
             comp: 'dry_remain',
+            writable: false,
+        })
+
+        // Filter usage. 0x355 counts hours the filter has been in service and
+        // 0x356 is its rated lifetime (720 h here); the app shows the pair as
+        // hours used and hours remaining (10 used / 710 left) and renders the
+        // ratio as a used percentage.
+        const filterUsedComp = {
+            platform: 'sensor',
+            unique_id: '$deviceid-filter_used',
+            name: 'Filter used',
+            unit_of_measurement: '%',
+            state_class: 'measurement',
+            suggested_display_precision: 0,
+            entity_category: 'diagnostic',
+        }
+        config['components']['filter_used'] = filterUsedComp
+        const publishFilterUsed = () => {
+            const used = this.raw_clip_state[0x355]
+            const max = this.raw_clip_state[0x356]
+            if (used != null && max != null && max > 0) {
+                const percent = Math.max(0, Math.min(100, Math.round((used / max) * 100)))
+                this.HA.publishProperty(this.id, 'filter_used-', percent)
+            }
+            return false
+        }
+        this.addField(config, {
+            id: 0x355,
+            name: '',
+            comp: 'filter_used',
+            writable: false,
+            read_callback: publishFilterUsed,
+        })
+        this.addField(
+            config,
+            {
+                id: 0x356,
+                name: 'max',
+                comp: 'filter_used',
+                writable: false,
+                read_callback: publishFilterUsed,
+            },
+            false,
+        )
+
+        // Instantaneous power draw. The tag reads exactly 0 whenever the unit is
+        // off and moves with the fan level and compressor load while running,
+        // which is what identifies it. It is published raw: the -60 correction
+        // the RAC units apply does not hold here, where readings as low as 32 W
+        // occur while running and would go negative.
+        const powerDrawComp = {
+            platform: 'sensor',
+            unique_id: '$deviceid-power_draw',
+            name: 'Power',
+            device_class: 'power',
+            unit_of_measurement: 'W',
+            state_class: 'measurement',
+            suggested_display_precision: 0,
+        }
+        config['components']['power_draw'] = powerDrawComp
+        this.addField(config, {
+            id: 0x2b3,
+            name: '',
+            comp: 'power_draw',
+            writable: false,
+        })
+
+        // Diagnostic error code reported by the appliance; 0 while healthy.
+        const errorComp = {
+            platform: 'sensor',
+            unique_id: '$deviceid-error',
+            name: 'Error code',
+            icon: 'mdi:alert',
+            entity_category: 'diagnostic',
+        }
+        config['components']['error'] = errorComp
+        this.addField(config, {
+            id: 0x221,
+            name: '',
+            comp: 'error',
             writable: false,
         })
 

--- a/cloud/devices/PAC_910604_WW.ts
+++ b/cloud/devices/PAC_910604_WW.ts
@@ -73,6 +73,19 @@ const HUMAN_SENSE = Enum.of({
     indirect: 2,
 })
 
+// Observed live on the physical unit: the panel showed "Good" at capture start
+// (wire value 1) and switched to "Very bad" (wire value 4) immediately after an
+// aerosol spray, with the tag itself never seen at any other value across the
+// whole capture session. The panel's middle two grades (moderate/bad) were not
+// captured directly - 2 and 3 are inferred from the ordering of the observed
+// endpoints and the four-grade scale the owner confirmed on the panel.
+const AIR_QUALITY = Enum.of({
+    good: 1,
+    moderate: 2,
+    bad: 3,
+    very_bad: 4,
+})
+
 /**
  * Fan values arrive as level x 0x0101 (both bytes equal: 0x0202, 0x0404 ...).
  * While eco is engaging the device emits one frame with 0xFF in one of the
@@ -464,6 +477,26 @@ export default class Device extends TLVDevice {
             name: '',
             comp: 'humidity',
             writable: false,
+        })
+
+        // Overall indoor air quality grade shown on the panel. State-only: no
+        // write frame for this tag exists on the wire (the app has no control
+        // to set it), only the appliance-reported sensor grade.
+        const airQualityComp = {
+            platform: 'sensor',
+            unique_id: '$deviceid-air_quality',
+            name: 'Air quality',
+            icon: 'mdi:weather-hazy',
+            device_class: 'enum',
+            options: AIR_QUALITY.options,
+        }
+        config['components']['air_quality'] = airQualityComp
+        this.addField(config, {
+            id: 0x240,
+            name: '',
+            comp: 'air_quality',
+            writable: false,
+            read_xform: (raw) => AIR_QUALITY.map(raw),
         })
 
         // Countdown timers in minutes on the wire (0 = cancelled). Sleep maxes

--- a/cloud/devices/PAC_910604_WW.ts
+++ b/cloud/devices/PAC_910604_WW.ts
@@ -288,18 +288,22 @@ export default class Device extends TLVDevice {
         }
 
         // Single-tag switches: each write below reproduces the exact frame the
-        // LG app sent for that toggle, captured on the physical unit.
+        // LG app sent for that toggle, captured on the physical unit. Matches
+        // RAC_056905_WW's convention of marking user-facing feature toggles
+        // (jet, energysave, airclean) as entity_category 'config'.
         const switchFields = [
             { id: 0x20d, name: 'eco', desc: 'Energy saving' },
             { id: 0x20f, name: 'airclean', desc: 'Air purify' },
             { id: 0x23e, name: 'smartcare', desc: 'Smart care' },
         ]
         for (const f of switchFields) {
-            config['components'][f.name] = {
+            const comp = {
                 platform: 'switch',
                 unique_id: '$deviceid-' + f.name,
                 name: f.desc,
+                entity_category: 'config',
             }
+            config['components'][f.name] = comp
             this.addField(config, {
                 id: f.id,
                 name: '',
@@ -320,6 +324,7 @@ export default class Device extends TLVDevice {
             unique_id: '$deviceid-wind_mode',
             name: 'Wind mode',
             options: [...WIND_MODES],
+            entity_category: 'config',
         }
         config['components']['wind_mode'] = windModeComp
         this.addField(config, {
@@ -377,6 +382,7 @@ export default class Device extends TLVDevice {
             unique_id: '$deviceid-human_sense',
             name: 'Human sense',
             options: HUMAN_SENSE.options,
+            entity_category: 'config',
         }
         config['components']['human_sense'] = humanSense
         this.addField(config, {

--- a/cloud/devices/PAC_910604_WW.ts
+++ b/cloud/devices/PAC_910604_WW.ts
@@ -292,15 +292,16 @@ export default class Device extends TLVDevice {
         // RAC_056905_WW's convention of marking user-facing feature toggles
         // (jet, energysave, airclean) as entity_category 'config'.
         const switchFields = [
-            { id: 0x20d, name: 'eco', desc: 'Energy saving' },
-            { id: 0x20f, name: 'airclean', desc: 'Air purify' },
-            { id: 0x23e, name: 'smartcare', desc: 'Smart care' },
+            { id: 0x20d, name: 'eco', desc: 'Energy saving', icon: 'mdi:flower' },
+            { id: 0x20f, name: 'airclean', desc: 'Air purify', icon: 'mdi:air-purifier' },
+            { id: 0x23e, name: 'smartcare', desc: 'Smart care', icon: 'mdi:chip' },
         ]
         for (const f of switchFields) {
             const comp = {
                 platform: 'switch',
                 unique_id: '$deviceid-' + f.name,
                 name: f.desc,
+                icon: f.icon,
                 entity_category: 'config',
             }
             config['components'][f.name] = comp
@@ -323,6 +324,7 @@ export default class Device extends TLVDevice {
             platform: 'select',
             unique_id: '$deviceid-wind_mode',
             name: 'Wind mode',
+            icon: 'mdi:wind-power',
             options: [...WIND_MODES],
             entity_category: 'config',
         }
@@ -381,6 +383,7 @@ export default class Device extends TLVDevice {
             platform: 'select',
             unique_id: '$deviceid-human_sense',
             name: 'Human sense',
+            icon: 'mdi:human',
             options: HUMAN_SENSE.options,
             entity_category: 'config',
         }
@@ -469,6 +472,7 @@ export default class Device extends TLVDevice {
             platform: 'number',
             unique_id: '$deviceid-sleep_timer',
             name: 'Sleep timer',
+            icon: 'mdi:bed-clock',
             device_class: 'duration',
             unit_of_measurement: 'min',
             min: 0,
@@ -489,6 +493,7 @@ export default class Device extends TLVDevice {
             platform: 'number',
             unique_id: '$deviceid-start_timer',
             name: 'Turn-on timer',
+            icon: 'mdi:timer-play',
             device_class: 'duration',
             unit_of_measurement: 'min',
             min: 0,
@@ -509,6 +514,7 @@ export default class Device extends TLVDevice {
             platform: 'number',
             unique_id: '$deviceid-stop_timer',
             name: 'Turn-off timer',
+            icon: 'mdi:timer-stop',
             device_class: 'duration',
             unit_of_measurement: 'min',
             min: 0,
@@ -545,6 +551,7 @@ export default class Device extends TLVDevice {
             platform: 'sensor',
             unique_id: '$deviceid-dry_remain',
             name: 'Auto dry remaining',
+            icon: 'mdi:hair-dryer-outline',
             device_class: 'duration',
             unit_of_measurement: 'min',
             entity_category: 'diagnostic',
@@ -594,6 +601,7 @@ export default class Device extends TLVDevice {
             platform: 'sensor',
             unique_id: '$deviceid-filter_used',
             name: 'Filter used',
+            icon: 'mdi:air-filter',
             unit_of_measurement: '%',
             state_class: 'measurement',
             suggested_display_precision: 0,

--- a/cloud/devices/PAC_910604_WW.ts
+++ b/cloud/devices/PAC_910604_WW.ts
@@ -23,7 +23,8 @@ import HADevice from './base'
  * axes); air purify, energy saving and smart care switches; a wind-mode
  * selector (off / coolpower / longpower, sharing the app's single off frame);
  * a human sense selector; sleep, turn-on and turn-off timers in minutes.
- * Sensors stay state-only.
+ * Auto-dry enable/countdown, filter used/rated/remaining life, power draw,
+ * air quality and diagnostics stay state-only.
  */
 
 // Owner-verified on the physical unit (each toggle driven on the remote/app and
@@ -31,7 +32,8 @@ import HADevice from './base'
 // ThinQ app): 0x1f7 power, 0x1f9 mode (cool/dry only), 0x1fd/0x1fe temperatures
 // (/2), 0x205 vertical swing, 0x206 horizontal swing, 0x208 human sense,
 // 0x20d eco, 0x20f air clean, 0x21a sleep timer (minutes, up to 420),
-// 0x225 auto-dry countdown (minutes), 0x236 cool power, 0x209 long power,
+// 0x225 auto-dry countdown (minutes), 0x20e auto-dry enabled,
+// 0x236 cool power, 0x209 long power,
 // 0x23e smart care, 0x23f smart guide,
 // 0x333/0x334/0x335 PM1.0/PM2.5/PM10, 0x336 humidity.
 const MODES = Enum.of({
@@ -94,14 +96,18 @@ export default class Device extends TLVDevice {
             clearInterval(this.query_caps_timeout)
             this.query_caps_timeout = undefined
         }
+        // The field map is fixed for this exact model, so discovery does not
+        // need to wait for a full frame containing power. This also lets a
+        // reconnect that receives only delta frames populate Home Assistant.
+        this.valuesReceived()
     }
 
     queryCaps() {
-        // Read-only: no capability query is ever sent.
+        // The exact-model field map is fixed; capabilities are not queried.
     }
 
     query() {
-        // Read-only: no values query is ever sent.
+        // State arrives unprompted, so no values query is sent.
     }
 
     start() {
@@ -513,6 +519,22 @@ export default class Device extends TLVDevice {
             write_xform: (val) => Math.round(Number(val)),
         })
 
+        const autoDryComp = {
+            platform: 'binary_sensor',
+            unique_id: '$deviceid-autodry',
+            name: 'Auto dry',
+            icon: 'mdi:hair-dryer',
+            entity_category: 'diagnostic',
+        }
+        config['components']['autodry'] = autoDryComp
+        this.addField(config, {
+            id: 0x20e,
+            name: '',
+            comp: 'autodry',
+            writable: false,
+            read_xform: (raw) => (raw ? 'ON' : 'OFF'),
+        })
+
         const dryRemainComp = {
             platform: 'sensor',
             unique_id: '$deviceid-dry_remain',
@@ -529,10 +551,39 @@ export default class Device extends TLVDevice {
             writable: false,
         })
 
-        // Filter usage. 0x355 counts hours the filter has been in service and
-        // 0x356 is its rated lifetime (720 h here); the app shows the pair as
-        // hours used and hours remaining (10 used / 710 left) and renders the
-        // ratio as a used percentage.
+        // Filter counters are sent directly in normal PAC state frames, unlike
+        // RAC's private filter-management command: 0x355 is hours used and
+        // 0x356 is the rated lifetime. Publish the raw counters, remaining
+        // hours and the percentage shown by the app. Do not expose RAC's reset
+        // button here: no PAC reset command has been captured, and writing zero
+        // to a counter or reusing RAC's private command would be a guess.
+        const filterDuration = {
+            platform: 'sensor',
+            icon: 'mdi:air-filter',
+            device_class: 'duration',
+            unit_of_measurement: 'h',
+            entity_category: 'diagnostic',
+        } as const
+        config['components']['filter_used_time'] = {
+            ...filterDuration,
+            unique_id: '$deviceid-filter_used_time',
+            name: 'Filter used time',
+        }
+        config['components']['filter_life_time'] = {
+            ...filterDuration,
+            unique_id: '$deviceid-filter_life_time',
+            name: 'Filter life time',
+        }
+        config['components']['filter_remaining'] = {
+            ...filterDuration,
+            unique_id: '$deviceid-filter_remaining',
+            name: 'Filter remaining',
+        }
+        // Virtual fields register each manually-published state topic without
+        // claiming another wire tag in fields_by_id.
+        for (const comp of ['filter_used_time', 'filter_life_time', 'filter_remaining']) {
+            this.addField(config, { id: 0, name: '', comp, writable: false })
+        }
         const filterUsedComp = {
             platform: 'sensor',
             unique_id: '$deviceid-filter_used',
@@ -547,7 +598,11 @@ export default class Device extends TLVDevice {
             const used = this.raw_clip_state[0x355]
             const max = this.raw_clip_state[0x356]
             if (used != null && max != null && max > 0) {
+                const remaining = Math.max(0, max - used)
                 const percent = Math.max(0, Math.min(100, Math.round((used / max) * 100)))
+                this.HA.publishProperty(this.id, 'filter_used_time-', used)
+                this.HA.publishProperty(this.id, 'filter_life_time-', max)
+                this.HA.publishProperty(this.id, 'filter_remaining-', remaining)
                 this.HA.publishProperty(this.id, 'filter_used-', percent)
             }
             return false

--- a/cloud/devices/PAC_910604_WW.ts
+++ b/cloud/devices/PAC_910604_WW.ts
@@ -115,7 +115,8 @@ export default class Device extends TLVDevice {
     }
 
     isValuesResponse(tlvArray: TLV.TLV[]) {
-        return tlvArray.some(({ t }) => t === 0x1f7)
+        // Length guard mirrors RAC_056905_WW: power-only notifications are not values.
+        return tlvArray.length >= 10 && tlvArray.some(({ t }) => t === 0x1f7)
     }
 
     valuesReceived() {
@@ -566,10 +567,11 @@ export default class Device extends TLVDevice {
 
         // Filter counters are sent directly in normal PAC state frames, unlike
         // RAC's private filter-management command: 0x355 is hours used and
-        // 0x356 is the rated lifetime. Publish the raw counters, remaining
-        // hours and the percentage shown by the app. Do not expose RAC's reset
-        // button here: no PAC reset command has been captured, and writing zero
-        // to a counter or reusing RAC's private command would be a guess.
+        // 0x356 is the rated lifetime. Publish the raw counters and remaining
+        // hours. The percentage is omitted per review - users can derive it via
+        // a template sensor if needed. Do not expose RAC's reset button here: no
+        // PAC reset command has been captured, and writing zero to a counter or
+        // reusing RAC's private command would be a guess.
         const filterDuration = {
             platform: 'sensor',
             icon: 'mdi:air-filter',
@@ -597,45 +599,32 @@ export default class Device extends TLVDevice {
         for (const comp of ['filter_used_time', 'filter_life_time', 'filter_remaining']) {
             this.addField(config, { id: 0, name: '', comp, writable: false })
         }
-        const filterUsedComp = {
-            platform: 'sensor',
-            unique_id: '$deviceid-filter_used',
-            name: 'Filter used',
-            icon: 'mdi:air-filter',
-            unit_of_measurement: '%',
-            state_class: 'measurement',
-            suggested_display_precision: 0,
-            entity_category: 'diagnostic',
-        }
-        config['components']['filter_used'] = filterUsedComp
-        const publishFilterUsed = () => {
+        const publishFilter = () => {
             const used = this.raw_clip_state[0x355]
             const max = this.raw_clip_state[0x356]
             if (used != null && max != null && max > 0) {
                 const remaining = Math.max(0, max - used)
-                const percent = Math.max(0, Math.min(100, Math.round((used / max) * 100)))
                 this.HA.publishProperty(this.id, 'filter_used_time-', used)
                 this.HA.publishProperty(this.id, 'filter_life_time-', max)
                 this.HA.publishProperty(this.id, 'filter_remaining-', remaining)
-                this.HA.publishProperty(this.id, 'filter_used-', percent)
             }
             return false
         }
         this.addField(config, {
             id: 0x355,
             name: '',
-            comp: 'filter_used',
+            comp: 'filter_used_time',
             writable: false,
-            read_callback: publishFilterUsed,
+            read_callback: publishFilter,
         })
         this.addField(
             config,
             {
                 id: 0x356,
                 name: 'max',
-                comp: 'filter_used',
+                comp: 'filter_used_time',
                 writable: false,
-                read_callback: publishFilterUsed,
+                read_callback: publishFilter,
             },
             false,
         )

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -1,6 +1,7 @@
 import POT_056905_WW from './devices/POT_056905_WW'
 import WTDN3 from './devices/WTDN3'
 import RAC_056905_WW from './devices/RAC_056905_WW'
+import PAC_910604_WW from './devices/PAC_910604_WW'
 import WIN_056905_WW from './devices/WIN_056905_WW'
 import Dev_2REF11EIDA__4 from './devices/2REF11EIDA__4'
 import Dev_2REF11EBIVPC4 from './devices/2REF11EBIVPC4'
@@ -40,6 +41,7 @@ const t1deviceTypes: Record<string, T1Factory> = {
 const t2deviceTypes: Record<string, T2Factory> = {
     POT_056905_WW,
     RAC_056905_WW,
+    PAC_910604_WW,
     ['RAC_0B0001_WW']: RAC_056905_WW, // a different European variant (deviceType 401, RTK_RTL8720cm), same TLV handler
     WIN_056905_WW,
     ['2REF11EIDA__4']: Dev_2REF11EIDA__4,

--- a/cloud/homeassistant.ts
+++ b/cloud/homeassistant.ts
@@ -197,8 +197,10 @@ export type ClimateComponent = ComponentInfo & {
     temperature_unit?: 'C' | 'F'
     temp_step?: number
     precision?: number
+    current_humidity_topic?: string
     min_temp?: number
     max_temp?: number
+    modes?: string[]
     fan_modes?: string[]
     swing_modes?: string[]
     swing_horizontal_modes?: string[]

--- a/tests/cloud/devices/PAC_910604_WW.test.ts
+++ b/tests/cloud/devices/PAC_910604_WW.test.ts
@@ -3,6 +3,8 @@ import assert from 'node:assert/strict'
 import DUT from '@/cloud/devices/PAC_910604_WW'
 import type { Metadata } from '@/cloud/thinq'
 import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+import crc16 from '@/util/crc16'
+import * as TLV from '@/util/tlv'
 
 const DEVICE_ID = 'test-id'
 const MODEL_ID = 'PAC_910604_WW'
@@ -78,6 +80,56 @@ const BAD_LENGTH_HEX =
     '000004000000A70204FF8591009280918091C09300A300A3407DC17E407F90347EA004047F50328200814081808' +
     '0808080C082408D8082C083008340838183C09' // length byte disagrees with buffer
 
+// State frames from a second owner-operated session (2026-09-07): each control
+// below was toggled in the ThinQ app while the wire was recorded.
+//   TIMER_ON_STATE: turn-on reservation set to 1h (0x21c=60)
+//   TIMER_OFF_STATE: turn-off reservation set to 24h (0x21b=1440)
+//   SLEEP_420_STATE: sleep timer set to 7h (0x21a=420)
+//   HUMAN_DIRECT_STATE / HUMAN_INDIRECT_STATE: human sense direct (0x208=1) / indirect (2)
+//   COOLPOWER_STATE: coolpower on (0x236=1)
+const TIMER_ON_STATE_HEX = '000004000000a702043f0792c187103cc485187b'
+const TIMER_OFF_STATE_HEX = '000004000000a70204500892c186e005a0c48640bb'
+const SLEEP_420_STATE_HEX = '000004000000a70204630e92c18140818086a001a48f40c48cf807'
+const HUMAN_DIRECT_STATE_HEX = '000004000000a70204720e92c17ea008ff82018341cd48c48cc406'
+const HUMAN_INDIRECT_STATE_HEX =
+    '000004000000a702047c2092c17ea00808820283408bc08c10008c408bc08c008c408bc08c008c40c4901daef4'
+const COOLPOWER_STATE_HEX = '000004000000a70204b01492c17f90247ea0070781a0010182408d81c49011475a'
+
+// Command frames the LG app itself sent in that session. Each control write
+// below must reproduce these TLVs.
+const CMD_AIRCLEAN_OFF = '010104000000650201000283c0430c' // 0x20f=0
+const CMD_AIRCLEAN_ON = '010104000000650201000283c1532d' // 0x20f=1
+const CMD_ECO_OFF = '01010400000065020100028340d284' // 0x20d=0
+const CMD_ECO_ON = '01010400000065020100028341c2a5' // 0x20d=1
+const CMD_SMARTCARE_ON = '01010400000065020100028f815e84' // 0x23e=1
+const CMD_SMARTCARE_OFF = '01010400000065020100028f804ea5' // 0x23e=0
+const CMD_SLEEP_420 = '010104000000650201000486a001a4b5e7' // 0x21a=420
+const CMD_SLEEP_0 = '01010400000065020100028680f43d' // 0x21a=0 (cancel)
+const CMD_START_60 = '010104000000650201000387103c3c2b' // 0x21c=60
+const CMD_START_0 = '010104000000650201000287005684' // 0x21c=0 (cancel)
+const CMD_STOP_1440 = '010104000000650201000486e005a0240a' // 0x21b=1440
+const CMD_STOP_0 = '010104000000650201000286c0bcf9' // 0x21b=0 (cancel)
+const CMD_HUMAN_DIRECT = '01010400000065020100028201b950' // 0x208=1
+const CMD_HUMAN_INDIRECT = '010104000000650201000282028933' // 0x208=2
+const CMD_HUMAN_OFF = '01010400000065020100028200a971' // 0x208=0
+const CMD_COOLPOWER_ON = '01010400000065020100028d8138e6' // 0x236=1
+const CMD_WIND_LONG = '01010400000065020100097e407ea009097f9034d41d' // mode 0, fan 2313, target 52
+const CMD_WIND_OFF = '01010400000065020100097e407ea006067f9034650a' // mode 0, fan 1542, target 52
+
+/** TLVs of a captured frame, as {tag: value}. */
+function frameTlvs(hex: string): Record<number, number> {
+    const b = buf(hex)
+    const out: Record<number, number> = {}
+    for (const { t, v } of TLV.parse(b.subarray(11, 11 + b[10]))) out[t] = v
+    return out
+}
+
+/** TLVs the handler put on the wire for the single frame it just sent. */
+function sentTlvs(thinq: MockThinq2Device): Record<number, number> {
+    assert.equal(thinq.outbox.length, 1, 'exactly one frame should be sent')
+    return frameTlvs(thinq.outbox[0].toString('hex'))
+}
+
 function makeDevice() {
     const ha = new MockHAConnection()
     const thinq = new MockThinq2Device(DEVICE_ID, META)
@@ -94,7 +146,7 @@ function buildReadyDevice() {
 }
 
 describe(MODEL_ID, () => {
-    test('constructor and start() send nothing (read-only)', () => {
+    test('constructor and start() send nothing (never polled)', () => {
         const { thinq, dev } = makeDevice()
         dev.start()
         assert.equal(thinq.outbox.length, 0, 'no packets on the wire')
@@ -102,7 +154,7 @@ describe(MODEL_ID, () => {
         dev.drop()
     })
 
-    test('base frame publishes config with no command topics', () => {
+    test('base frame publishes config: command topics only on controls', () => {
         const { ha, thinq, dev } = makeDevice()
         thinq.emit('data', buf(BASE_HEX))
         const device = ha.devices[DEVICE_ID]
@@ -112,11 +164,23 @@ describe(MODEL_ID, () => {
         assert.ok(components.climate, 'climate component')
         assert.equal(components.climate.platform, 'climate')
         assert.equal(components.climate.current_humidity_topic, '$this/humidity-')
+        // The eight controls expose command topics; everything else is state-only.
+        const controls = [
+            'eco',
+            'airclean',
+            'smartcare',
+            'wind_mode',
+            'human_sense',
+            'sleep_timer',
+            'start_timer',
+            'stop_timer',
+        ]
         for (const [name, comp] of Object.entries(components)) {
-            for (const key of Object.keys(comp)) {
-                assert.ok(!key.endsWith('command_topic'), `${name}.${key} must not exist (read-only)`)
-            }
+            const hasCommand = Object.keys(comp).some((key) => key.endsWith('command_topic'))
+            assert.equal(hasCommand, controls.includes(name), `${name} command topic`)
         }
+        assert.deepEqual(components.wind_mode.options, ['off', 'coolpower', 'longpower'])
+        assert.deepEqual(components.human_sense.options, ['off', 'direct', 'indirect'])
         // climate offers exactly the observed fan levels and modes
         assert.deepEqual(components.climate.modes, ['off', 'cool', 'dry'])
         assert.deepEqual(components.climate.fan_modes, ['auto', 'low', 'medium', 'high', 'turbo', 'max'])
@@ -203,11 +267,8 @@ describe(MODEL_ID, () => {
         assert.equal(ha.getProperty(DEVICE_ID, 'airclean', 'state'), 'ON')
         thinq.emit('data', buf(SMARTGUIDE_HEX))
         assert.equal(ha.getProperty(DEVICE_ID, 'smartguide', 'state'), 'ON')
-        thinq.emit('data', buf(COOLPOWER_HEX))
-        assert.equal(ha.getProperty(DEVICE_ID, 'coolpower', 'state'), 'ON')
-        thinq.emit('data', buf(LONGPOWER_HEX))
-        assert.equal(ha.getProperty(DEVICE_ID, 'longpower', 'state'), 'ON')
-        assert.equal(ha.getProperty(DEVICE_ID, 'coolpower', 'state'), 'OFF') // 0x236=0
+        thinq.emit('data', buf(COOLPOWER_STATE_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'wind_mode', 'state'), 'coolpower')
         dev.drop()
     })
 
@@ -229,16 +290,129 @@ describe(MODEL_ID, () => {
         dev.drop()
     })
 
-    test('HA writes send nothing (read-only enforced)', () => {
+    test('timer numbers decode minutes (sleep/reservations)', () => {
+        const { ha, thinq, dev } = buildReadyDevice()
+        thinq.emit('data', buf(SLEEP_420_STATE_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'sleep_timer', 'state'), 420)
+        thinq.emit('data', buf(TIMER_ON_STATE_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'start_timer', 'state'), 60)
+        thinq.emit('data', buf(TIMER_OFF_STATE_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'stop_timer', 'state'), 1440)
+        dev.drop()
+    })
+
+    test('wind mode derives from both power tags', () => {
+        const { ha, thinq, dev } = buildReadyDevice()
+        assert.equal(ha.getProperty(DEVICE_ID, 'wind_mode', 'state'), 'off')
+        thinq.emit('data', buf(COOLPOWER_STATE_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'wind_mode', 'state'), 'coolpower')
+        thinq.emit('data', buf(LONGPOWER_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'wind_mode', 'state'), 'longpower')
+        dev.drop()
+    })
+
+    test('switch writes reproduce the captured app frames', () => {
+        for (const [comp, on, off] of [
+            ['airclean', CMD_AIRCLEAN_ON, CMD_AIRCLEAN_OFF],
+            ['eco', CMD_ECO_ON, CMD_ECO_OFF],
+            ['smartcare', CMD_SMARTCARE_ON, CMD_SMARTCARE_OFF],
+        ] as const) {
+            const { thinq, dev } = buildReadyDevice()
+            dev.setProperty(comp + '-', 'ON')
+            assert.deepEqual(sentTlvs(thinq), frameTlvs(on))
+            thinq.resetRecorder()
+            dev.setProperty(comp + '-', 'OFF')
+            assert.deepEqual(sentTlvs(thinq), frameTlvs(off))
+            dev.drop()
+        }
+    })
+
+    test('human sense select writes reproduce the captured app frames', () => {
+        const { thinq, dev } = buildReadyDevice()
+        for (const [val, cmd] of [
+            ['direct', CMD_HUMAN_DIRECT],
+            ['indirect', CMD_HUMAN_INDIRECT],
+            ['off', CMD_HUMAN_OFF],
+        ] as const) {
+            dev.setProperty('human_sense-', val)
+            assert.deepEqual(sentTlvs(thinq), frameTlvs(cmd), val)
+            thinq.resetRecorder()
+        }
+        dev.drop()
+    })
+
+    test('timer number writes reproduce the captured app frames', () => {
+        const { thinq, dev } = buildReadyDevice()
+        for (const [comp, val, cmd] of [
+            ['sleep_timer', '420', CMD_SLEEP_420],
+            ['sleep_timer', '0', CMD_SLEEP_0],
+            ['start_timer', '60', CMD_START_60],
+            ['start_timer', '0', CMD_START_0],
+            ['stop_timer', '1440', CMD_STOP_1440],
+            ['stop_timer', '0', CMD_STOP_0],
+        ] as const) {
+            dev.setProperty(comp + '-', val)
+            assert.deepEqual(sentTlvs(thinq), frameTlvs(cmd), `${comp}=${val}`)
+            thinq.resetRecorder()
+        }
+        dev.drop()
+    })
+
+    test('wind mode writes reproduce the captured app frames', () => {
+        // BASE is cool / medium / 26C, matching the capture session state,
+        // so the bundles must come out byte-identical.
+        const { thinq, dev } = buildReadyDevice()
+        dev.setProperty('wind_mode-', 'coolpower')
+        assert.deepEqual(sentTlvs(thinq), frameTlvs(CMD_COOLPOWER_ON))
+        thinq.resetRecorder()
+        dev.setProperty('wind_mode-', 'longpower')
+        assert.deepEqual(sentTlvs(thinq), frameTlvs(CMD_WIND_LONG))
+        thinq.resetRecorder()
+        dev.setProperty('wind_mode-', 'off')
+        assert.deepEqual(sentTlvs(thinq), frameTlvs(CMD_WIND_OFF))
+        dev.drop()
+    })
+
+    test('climate and sensor writes still send nothing', () => {
         const { ha, thinq, dev } = buildReadyDevice()
         dev.setProperty('climate-mode', 'dry')
         dev.setProperty('climate-fan_mode', 'high')
         dev.setProperty('climate-temperature', '24')
-        dev.setProperty('eco-', 'ON')
+        dev.setProperty('swing_h-', 'left')
+        dev.setProperty('pm1-', '10')
         assert.equal(thinq.outbox.length, 0, 'writes must not reach the wire')
         assert.equal(thinq.sent.length, 0, 'writes must not send ThinQ messages')
         dev.drop()
         assert.ok(ha, 'mock kept alive')
+    })
+
+    test('appliance status is diagnostic; controls and room readings stay primary', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', buf(BASE_HEX))
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+
+        for (const name of ['power', 'swing_v', 'smartguide', 'dry_remain']) {
+            assert.equal(components[name].entity_category, 'diagnostic', `${name} should be diagnostic`)
+        }
+        for (const name of [
+            'climate',
+            'eco',
+            'airclean',
+            'smartcare',
+            'wind_mode',
+            'human_sense',
+            'swing_h',
+            'sleep_timer',
+            'start_timer',
+            'stop_timer',
+            'pm1',
+            'pm25',
+            'pm10',
+            'humidity',
+        ]) {
+            assert.equal(components[name].entity_category, undefined, `${name} should stay primary`)
+        }
+        dev.drop()
     })
 
     test('malformed frames are ignored', () => {
@@ -252,15 +426,13 @@ describe(MODEL_ID, () => {
         dev.drop()
     })
 
-    test('enum options match the published contract', () => {
+    test('swing and human sense options match the published contract', () => {
         const { ha, thinq, dev } = makeDevice()
         thinq.emit('data', buf(BASE_HEX))
         const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
-        for (const name of ['swing_h', 'human_sense']) {
-            assert.equal(components[name].device_class, 'enum', `${name} device_class`)
-            assert.ok(Array.isArray(components[name].options), `${name} options`)
-        }
+        assert.equal(components.swing_h.device_class, 'enum')
         assert.deepEqual(components.swing_h.options, ['off', 'right', 'left', 'both'])
+        assert.equal(components.human_sense.platform, 'select')
         assert.deepEqual(components.human_sense.options, ['off', 'direct', 'indirect'])
 
         dev.drop()

--- a/tests/cloud/devices/PAC_910604_WW.test.ts
+++ b/tests/cloud/devices/PAC_910604_WW.test.ts
@@ -1,0 +1,268 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/PAC_910604_WW'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'PAC_910604_WW'
+const META: Metadata = { modelId: MODEL_ID, modelName: 'TEST', swVersion: '1.0' }
+
+// Real packet captures from a PAC_910604_WW floor-standing air conditioner (deviceType 401,
+// TLV protocol with 0xA7 header, same envelope as RAC_056905_WW).
+//
+// Tag map (each verified by owner-operated toggles, on->off round trips):
+//   0x1f7 power (0/1)            0x1f9 mode (0=cool, 1=dry)      0x1fa fan (level x 0x0101)
+//   0x1fd current temp (/2)      0x1fe target temp (/2)         0x205 vertical swing (0/1)
+//   0x206 horizontal swing (0=off, 1=right, 256=left, 257=both)
+//   0x208 human sense (0=off, 1=direct, 2=indirect)             0x20d eco (0/1)
+//   0x20f air clean (0/1)        0x21a sleep timer (minutes)    0x225 auto-dry countdown (minutes)
+//   0x236 cool power (0/1)       0x209 long power (0/1)         0x23e smart care (0/1)
+//   0x23f smart guide (0/4096)
+//   0x333 PM1.0  0x334 PM2.5  0x335 PM10  0x336 humidity (app cross-checked)
+
+// Full state frame, power OFF (before first power-on).
+//   0x1f7=0 power=OFF  0x1f9=0  0x1fa=1542(raw)  0x1fd=50  0x1fe=36
+//   PM 0/0/0, humidity 57
+const POWER_OFF_HEX =
+    '000004000000A70204448491009283918091C09300A300A3407DC07E407F90247EA006067F50328200814081808' +
+    '08080C082408D8082C083008340838183C09080868086C087009F4087C38780938193C094029440948090409000' +
+    'D20089408840ACC08E808E408E0090C0CCC0CD00CD40CD9039D5A002D0D54CCDC0C8C08F808FC08F40AB40AB00D1' +
+    '009780C49081A551'
+
+// Full state frame, power ON, cool, fan medium, swings off.
+//   0x1f7=1  0x1f9=0 cool  0x1fa=1028 medium  0x1fd=50 (25C)  0x1fe=52 (26C)
+//   PM 8/8/10, humidity 62
+const BASE_HEX =
+    '000004000000A70204F48591009280918091C09300A300A3407DC17E407F90347EA004047F50328200814081808' +
+    '08080C082408D8082C083008340838183C09080868086C087009F4087C38780938193C094029440948090409001' +
+    'D20089408840ACD0208E808E408E0090C0CCC8CD08CD4ACD903ED5A002D0D54CCDC1C8C08F808FC08F41AB40AB00' +
+    'D1009780C4908241AD'
+
+// Short delta frames (device notifies only changed tags):
+// FAN_LOW: mode=dry, fan=514 (low), target=48 (24C)
+const FAN_LOW_HEX = '000004000000A702047B0F92C17E417F90307EA00202D201C48D320C'
+// HUMAN_AUTO: fan=2056 (auto), human sense=direct
+const HUMAN_AUTO_HEX = '000004000000A70204520C92C27EA0080882018180C48A1D97'
+// HUMAN_INDIRECT: human sense=indirect
+const HUMAN_INDIRECT_HEX = '000004000000A70204660692C28202C484189F'
+// COOLPOWER: fan=1799 (turbo), target=36 (18C), swings both, coolpower=1
+const COOLPOWER_HEX = '000004000000A70204CD1492C27F90247EA0070781A001018D81CD48C490118313'
+// LONGPOWER: fan=2313 (max), swings off, longpower=1, coolpower=0
+const LONGPOWER_HEX = '000004000000A70204D20E92C27EA00909818082418D80C48C1BE5'
+// ECO_OVERRIDE: eco on, fan reads 0xFF04 (eco flag + medium level)
+const ECO_OVERRIDE_HEX = '000004000000A702045F0D92C27F90347EA0FF048341C48B622A'
+// Same transition observed with the bytes reversed: 0x04FF.
+const ECO_OVERRIDE_REVERSED_HEX = '000004000000A702049C0A92C27EA004FF8341C4881A00'
+// SLEEP: sleep timer 300 (5h)
+const SLEEP_HEX = '000004000000A70204A70892C286A0012CC4862AD4'
+// DRY: auto-dry countdown 25
+const DRY_HEX = '000004000000A70204E205895019C4839773'
+// ECO_ON / AIRCLEAN_ON / SMARTGUIDE / SWING_V / SWING_L / SWING_R / SWING_BOTH
+const ECO_ON_HEX = '000004000000A702043F0C92C283418C90298CD05AC48AA44B'
+const AIRCLEAN_ON_HEX = '000004000000A70204150692C283C1C48469F5'
+const SMARTGUIDE_HEX = '000004000000A70204740A92C2CD4B8FE01000C48839F2'
+const SWING_V_HEX = '000004000000A70204B50692C18141C484D7FC'
+const SWING_L_HEX = '000004000000A70204560892C281A00100C48645C2'
+const SWING_R_HEX = '000004000000A702049A0692C28181C484BD73'
+const SWING_BOTH_HEX = '000004000000A70204F70892C281A00101C486C08E'
+// SMARTCARE_ON: fan auto, target 25C, swings both, smartcare=1. The accompanying
+// 0x25e=2 is not exposed because its precise meaning is unconfirmed.
+const SMARTCARE_ON_HEX = '000004000000A70204A91492C27F90327EA0080881A001018F819782C4901142D5'
+// SMARTCARE_OFF: fan medium, swings off, smartcare=0, detail=0
+const SMARTCARE_OFF_HEX = '000004000000A70204B80E92C27EA0040481808F809780C48CF29B'
+
+// Malformed inputs (must be ignored without crashing):
+const TRUNCATED_HEX = '000004000000A70204F48591009280' // cut mid-TLV
+const BAD_LENGTH_HEX =
+    '000004000000A70204FF8591009280918091C09300A300A3407DC17E407F90347EA004047F50328200814081808' +
+    '0808080C082408D8082C083008340838183C09' // length byte disagrees with buffer
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+/** Feed the base full frame so config is published; returns device with recorder cleared. */
+function buildReadyDevice() {
+    const { ha, thinq, dev } = makeDevice()
+    thinq.emit('data', buf(BASE_HEX))
+    thinq.resetRecorder()
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('constructor and start() send nothing (read-only)', () => {
+        const { thinq, dev } = makeDevice()
+        dev.start()
+        assert.equal(thinq.outbox.length, 0, 'no packets on the wire')
+        assert.equal(thinq.sent.length, 0, 'no ThinQ messages')
+        dev.drop()
+    })
+
+    test('base frame publishes config with no command topics', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', buf(BASE_HEX))
+        const device = ha.devices[DEVICE_ID]
+        assert.ok(device, 'HA configuration published')
+
+        const components = device.config!.components as Record<string, Record<string, unknown>>
+        assert.ok(components.climate, 'climate component')
+        assert.equal(components.climate.platform, 'climate')
+        assert.equal(components.climate.current_humidity_topic, '$this/humidity-')
+        for (const [name, comp] of Object.entries(components)) {
+            for (const key of Object.keys(comp)) {
+                assert.ok(!key.endsWith('command_topic'), `${name}.${key} must not exist (read-only)`)
+            }
+        }
+        // climate offers exactly the observed fan levels and modes
+        assert.deepEqual(components.climate.modes, ['off', 'cool', 'dry'])
+        assert.deepEqual(components.climate.fan_modes, ['auto', 'low', 'medium', 'high', 'turbo', 'max'])
+        dev.drop()
+    })
+
+    test('base frame publishes expected state', () => {
+        const { ha, dev } = buildReadyDevice()
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'current_temperature'), 25) // 50 / 2
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'current_humidity'), 62)
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'temperature_state'), 26) // 52 / 2
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'mode_state'), 'cool')
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'fan_mode_state'), 'medium') // 1028
+        assert.equal(ha.getProperty(DEVICE_ID, 'power', 'state'), 'ON')
+        assert.equal(ha.getProperty(DEVICE_ID, 'pm1', 'state'), 8)
+        assert.equal(ha.getProperty(DEVICE_ID, 'pm25', 'state'), 8)
+        assert.equal(ha.getProperty(DEVICE_ID, 'pm10', 'state'), 10)
+        assert.equal(ha.getProperty(DEVICE_ID, 'humidity', 'state'), 62)
+        dev.drop()
+    })
+
+    test('power-off frame reports off', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', buf(POWER_OFF_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'mode_state'), 'off')
+        assert.equal(ha.getProperty(DEVICE_ID, 'power', 'state'), 'OFF')
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'fan_mode_state'), 'high') // 1542
+        dev.drop()
+    })
+
+    test('fan levels decode (low/auto/turbo/max)', () => {
+        const { ha, thinq, dev } = buildReadyDevice()
+        thinq.emit('data', buf(FAN_LOW_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'fan_mode_state'), 'low') // 514
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'mode_state'), 'dry') // 0x1f9=1
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'temperature_state'), 24) // 48 / 2
+        thinq.emit('data', buf(HUMAN_AUTO_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'fan_mode_state'), 'auto') // 2056
+        thinq.emit('data', buf(COOLPOWER_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'fan_mode_state'), 'turbo') // 1799
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'temperature_state'), 18) // 36 / 2
+        thinq.emit('data', buf(LONGPOWER_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'fan_mode_state'), 'max') // 2313
+        dev.drop()
+    })
+
+    test('eco override flag still reads the fan level', () => {
+        const { ha, thinq, dev } = buildReadyDevice()
+        thinq.emit('data', buf(ECO_OVERRIDE_HEX))
+        // 0x1fa=0xFF04: eco flag in one byte, medium level (0x04) in the other
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'fan_mode_state'), 'medium')
+        thinq.emit('data', buf(ECO_OVERRIDE_REVERSED_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'fan_mode_state'), 'medium')
+        dev.drop()
+    })
+
+    test('swing states decode', () => {
+        const { ha, thinq, dev } = buildReadyDevice()
+        thinq.emit('data', buf(SWING_V_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'swing_v', 'state'), 'ON')
+        thinq.emit('data', buf(SWING_L_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'swing_h', 'state'), 'left') // 256
+        thinq.emit('data', buf(SWING_R_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'swing_h', 'state'), 'right') // 1
+        thinq.emit('data', buf(SWING_BOTH_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'swing_h', 'state'), 'both') // 257
+        dev.drop()
+    })
+
+    test('human sense states decode', () => {
+        const { ha, thinq, dev } = buildReadyDevice()
+        thinq.emit('data', buf(HUMAN_AUTO_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'human_sense', 'state'), 'direct') // 1
+        thinq.emit('data', buf(HUMAN_INDIRECT_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'human_sense', 'state'), 'indirect') // 2
+        dev.drop()
+    })
+
+    test('function toggles decode', () => {
+        const { ha, thinq, dev } = buildReadyDevice()
+        thinq.emit('data', buf(ECO_ON_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'eco', 'state'), 'ON')
+        thinq.emit('data', buf(AIRCLEAN_ON_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'airclean', 'state'), 'ON')
+        thinq.emit('data', buf(SMARTGUIDE_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'smartguide', 'state'), 'ON')
+        thinq.emit('data', buf(COOLPOWER_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'coolpower', 'state'), 'ON')
+        thinq.emit('data', buf(LONGPOWER_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'longpower', 'state'), 'ON')
+        assert.equal(ha.getProperty(DEVICE_ID, 'coolpower', 'state'), 'OFF') // 0x236=0
+        dev.drop()
+    })
+
+    test('smart care tags decode (delta-only tags)', () => {
+        const { ha, thinq, dev } = buildReadyDevice()
+        thinq.emit('data', buf(SMARTCARE_ON_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'smartcare', 'state'), 'ON') // 0x23e=1
+        thinq.emit('data', buf(SMARTCARE_OFF_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'smartcare', 'state'), 'OFF')
+        dev.drop()
+    })
+
+    test('timer sensors decode (minutes)', () => {
+        const { ha, thinq, dev } = buildReadyDevice()
+        thinq.emit('data', buf(SLEEP_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'sleep_timer', 'state'), 300)
+        thinq.emit('data', buf(DRY_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'dry_remain', 'state'), 25)
+        dev.drop()
+    })
+
+    test('HA writes send nothing (read-only enforced)', () => {
+        const { ha, thinq, dev } = buildReadyDevice()
+        dev.setProperty('climate-mode', 'dry')
+        dev.setProperty('climate-fan_mode', 'high')
+        dev.setProperty('climate-temperature', '24')
+        dev.setProperty('eco-', 'ON')
+        assert.equal(thinq.outbox.length, 0, 'writes must not reach the wire')
+        assert.equal(thinq.sent.length, 0, 'writes must not send ThinQ messages')
+        dev.drop()
+        assert.ok(ha, 'mock kept alive')
+    })
+
+    test('malformed frames are ignored', () => {
+        const { ha, thinq, dev } = buildReadyDevice()
+        thinq.emit('data', buf(TRUNCATED_HEX))
+        thinq.emit('data', buf(BAD_LENGTH_HEX))
+        thinq.emit('data', Buffer.from([0x00, 0x01, 0x02, 0x03]))
+        // base state survives garbage
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'mode_state'), 'cool')
+        assert.equal(thinq.outbox.length, 0)
+        dev.drop()
+    })
+
+    test('enum options match the published contract', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', buf(BASE_HEX))
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        for (const name of ['swing_h', 'human_sense']) {
+            assert.equal(components[name].device_class, 'enum', `${name} device_class`)
+            assert.ok(Array.isArray(components[name].options), `${name} options`)
+        }
+        assert.deepEqual(components.swing_h.options, ['off', 'right', 'left', 'both'])
+        assert.deepEqual(components.human_sense.options, ['off', 'direct', 'indirect'])
+
+        dev.drop()
+    })
+})

--- a/tests/cloud/devices/PAC_910604_WW.test.ts
+++ b/tests/cloud/devices/PAC_910604_WW.test.ts
@@ -619,11 +619,6 @@ describe(MODEL_ID, () => {
         }
         for (const name of [
             'climate',
-            'eco',
-            'airclean',
-            'smartcare',
-            'wind_mode',
-            'human_sense',
             'sleep_timer',
             'start_timer',
             'stop_timer',
@@ -634,6 +629,13 @@ describe(MODEL_ID, () => {
             'power_draw',
         ]) {
             assert.equal(components[name].entity_category, undefined, `${name} should stay primary`)
+        }
+        for (const name of ['eco', 'airclean', 'smartcare', 'wind_mode', 'human_sense']) {
+            assert.equal(
+                components[name].entity_category,
+                'config',
+                `${name} should be config, matching RAC's convention`,
+            )
         }
         dev.drop()
     })

--- a/tests/cloud/devices/PAC_910604_WW.test.ts
+++ b/tests/cloud/devices/PAC_910604_WW.test.ts
@@ -561,29 +561,27 @@ describe(MODEL_ID, () => {
         dev.drop()
     })
 
-    test('filter counters expose used, rated and remaining hours plus used percentage', () => {
+    test('filter counters expose used, rated and remaining hours', () => {
         const { ha, thinq, dev } = buildReadyDevice()
         // Base frame carried 0x355=12 used out of 0x356=720 rated hours.
         assert.equal(ha.getProperty(DEVICE_ID, 'filter_used_time', 'state'), 12)
         assert.equal(ha.getProperty(DEVICE_ID, 'filter_life_time', 'state'), 720)
         assert.equal(ha.getProperty(DEVICE_ID, 'filter_remaining', 'state'), 708)
-        assert.equal(ha.getProperty(DEVICE_ID, 'filter_used', 'state'), 2)
         assert.equal(ha.getProperty(DEVICE_ID, 'error', 'state'), 0)
         const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
         assert.equal(components.filterreset, undefined, 'no reset button without a captured PAC reset command')
+        assert.equal(components.filter_used, undefined, 'percentage is template-derived')
 
         dev.processKeyValue(0x355, 360)
         assert.equal(ha.getProperty(DEVICE_ID, 'filter_used_time', 'state'), 360)
         assert.equal(ha.getProperty(DEVICE_ID, 'filter_remaining', 'state'), 360)
-        assert.equal(ha.getProperty(DEVICE_ID, 'filter_used', 'state'), 50)
 
         // A zero rated lifetime must not divide or replace the last good values.
         dev.processKeyValue(0x356, 0)
         dev.processKeyValue(0x355, 400)
-        assert.equal(ha.getProperty(DEVICE_ID, 'filter_used', 'state'), 50)
+        assert.equal(ha.getProperty(DEVICE_ID, 'filter_remaining', 'state'), 360)
         dev.processKeyValue(0x356, 100)
         assert.equal(ha.getProperty(DEVICE_ID, 'filter_remaining', 'state'), 0)
-        assert.equal(ha.getProperty(DEVICE_ID, 'filter_used', 'state'), 100)
 
         assert.equal(thinq.outbox.length, 0)
         dev.drop()
@@ -609,7 +607,6 @@ describe(MODEL_ID, () => {
             'smartguide',
             'autodry',
             'dry_remain',
-            'filter_used',
             'filter_used_time',
             'filter_life_time',
             'filter_remaining',

--- a/tests/cloud/devices/PAC_910604_WW.test.ts
+++ b/tests/cloud/devices/PAC_910604_WW.test.ts
@@ -23,6 +23,9 @@ const META: Metadata = { modelId: MODEL_ID, modelName: 'TEST', swVersion: '1.0' 
 //   0x236 cool power (0/1)       0x209 long power (0/1)         0x23e smart care (0/1)
 //   0x23f smart guide (0/4096)
 //   0x333 PM1.0  0x334 PM2.5  0x335 PM10  0x336 humidity (app cross-checked)
+//   0x240 air quality grade (1=good, 4=very bad, live-captured spraying an aerosol
+//   in front of the unit; 2/3 are inferred from the panel's confirmed 4-grade scale,
+//   not directly captured). State-only: no write frame observed for this tag.
 
 // Full state frame, power OFF (before first power-on).
 //   0x1f7=0 power=OFF  0x1f9=0  0x1fa=1542(raw)  0x1fd=50  0x1fe=36
@@ -45,6 +48,9 @@ const BASE_HEX =
 // Short delta frames (device notifies only changed tags):
 // FAN_LOW: mode=dry, fan=514 (low), target=48 (24C)
 const FAN_LOW_HEX = '000004000000A702047B0F92C17E417F90307EA00202D201C48D320C'
+// AIR_QUALITY_VERY_BAD: air quality grade 1->4, live-captured spraying an aerosol
+// in front of the unit; PM/overall-index tags shift in the same frame too.
+const AIR_QUALITY_VERY_BAD_HEX = '000004000000A70204F80D9004CCD01DCD106ECD5091C48BFB58'
 // HUMAN_AUTO: fan=2056 (auto), human sense=direct
 const HUMAN_AUTO_HEX = '000004000000A70204520C92C27EA0080882018180C48A1D97'
 // HUMAN_INDIRECT: human sense=indirect
@@ -167,6 +173,7 @@ describe(MODEL_ID, () => {
             POWER_OFF_HEX,
             BASE_HEX,
             FAN_LOW_HEX,
+            AIR_QUALITY_VERY_BAD_HEX,
             HUMAN_AUTO_HEX,
             HUMAN_INDIRECT_HEX,
             COOLPOWER_HEX,
@@ -269,6 +276,19 @@ describe(MODEL_ID, () => {
         assert.equal(ha.getProperty(DEVICE_ID, 'pm25', 'state'), 8)
         assert.equal(ha.getProperty(DEVICE_ID, 'pm10', 'state'), 10)
         assert.equal(ha.getProperty(DEVICE_ID, 'humidity', 'state'), 62)
+        assert.equal(ha.getProperty(DEVICE_ID, 'air_quality', 'state'), 'good')
+        dev.drop()
+    })
+
+    test('air quality grade decodes and is read-only', () => {
+        const { ha, thinq, dev } = buildReadyDevice()
+        thinq.emit('data', buf(AIR_QUALITY_VERY_BAD_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'air_quality', 'state'), 'very_bad')
+
+        thinq.resetRecorder()
+        dev.setProperty('air_quality-', 'good')
+        assert.equal(thinq.outbox.length, 0, 'writes must not reach the wire')
+        assert.equal(thinq.sent.length, 0, 'writes must not send ThinQ messages')
         dev.drop()
     })
 

--- a/tests/cloud/devices/PAC_910604_WW.test.ts
+++ b/tests/cloud/devices/PAC_910604_WW.test.ts
@@ -18,7 +18,8 @@ const META: Metadata = { modelId: MODEL_ID, modelName: 'TEST', swVersion: '1.0' 
 //   0x1fd current temp (/2)      0x1fe target temp (/2)         0x205 vertical swing (0/1)
 //   0x206 horizontal swing (0=off, 1=right, 256=left, 257=both)
 //   0x208 human sense (0=off, 1=direct, 2=indirect)             0x20d eco (0/1)
-//   0x20f air clean (0/1)        0x21a sleep timer (minutes)    0x225 auto-dry countdown (minutes)
+//   0x20e auto-dry enable (0/1)    0x20f air clean (0/1)        0x21a sleep timer (minutes)
+//   0x225 auto-dry countdown (minutes)
 //   0x236 cool power (0/1)       0x209 long power (0/1)         0x23e smart care (0/1)
 //   0x23f smart guide (0/4096)
 //   0x333 PM1.0  0x334 PM2.5  0x335 PM10  0x336 humidity (app cross-checked)
@@ -73,6 +74,10 @@ const SWING_BOTH_HEX = '000004000000A70204F70892C281A00101C486C08E'
 const SMARTCARE_ON_HEX = '000004000000A70204A91492C27F90327EA0080881A001018F819782C4901142D5'
 // SMARTCARE_OFF: fan medium, swings off, smartcare=0, detail=0
 const SMARTCARE_OFF_HEX = '000004000000A70204B80E92C27EA0040481808F809780C48CF29B'
+// Auto-dry enable, captured on the physical unit. The owner turned the setting
+// off and back on; only 0x20e moves. The selectable duration is cloud-only.
+const AUTODRY_OFF_HEX = '000004000000a70204c80492c28380647f'
+const AUTODRY_ON_HEX = '000004000000a70204df0692c28381c484ee75'
 
 // Malformed inputs (must be ignored without crashing):
 const TRUNCATED_HEX = '000004000000A70204F48591009280' // cut mid-TLV
@@ -157,6 +162,55 @@ function buildReadyDevice() {
 }
 
 describe(MODEL_ID, () => {
+    test('every declared capture fixture has a valid envelope length and CRC', () => {
+        for (const frame of [
+            POWER_OFF_HEX,
+            BASE_HEX,
+            FAN_LOW_HEX,
+            HUMAN_AUTO_HEX,
+            HUMAN_INDIRECT_HEX,
+            COOLPOWER_HEX,
+            LONGPOWER_HEX,
+            ECO_OVERRIDE_HEX,
+            ECO_OVERRIDE_REVERSED_HEX,
+            SLEEP_HEX,
+            DRY_HEX,
+            ECO_ON_HEX,
+            AIRCLEAN_ON_HEX,
+            SMARTGUIDE_HEX,
+            SWING_V_HEX,
+            SWING_L_HEX,
+            SWING_R_HEX,
+            SWING_BOTH_HEX,
+            SMARTCARE_ON_HEX,
+            SMARTCARE_OFF_HEX,
+            AUTODRY_OFF_HEX,
+            AUTODRY_ON_HEX,
+            TIMER_ON_STATE_HEX,
+            TIMER_OFF_STATE_HEX,
+            SLEEP_420_STATE_HEX,
+            HUMAN_DIRECT_STATE_HEX,
+            HUMAN_INDIRECT_STATE_HEX,
+            COOLPOWER_STATE_HEX,
+        ]) {
+            const packet = buf(frame)
+            assert.equal(packet.length, packet[10] + 13, frame)
+            assert.equal(crc16(packet.subarray(2)), 0, frame)
+        }
+    })
+
+    test('discovery is immediate and a delta-first connection publishes state', () => {
+        const { ha, thinq, dev } = makeDevice()
+        assert.ok(ha.devices[DEVICE_ID].config)
+        thinq.emit('data', buf(FAN_LOW_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'mode_state'), 'dry')
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'fan_mode_state'), 'low')
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'temperature_state'), 24)
+        assert.equal(thinq.outbox.length, 0)
+        assert.equal(thinq.sent.length, 0)
+        dev.drop()
+    })
+
     test('constructor and start() send nothing (never polled)', () => {
         const { thinq, dev } = makeDevice()
         dev.start()
@@ -496,21 +550,39 @@ describe(MODEL_ID, () => {
         dev.drop()
     })
 
-    test('filter usage is a percentage of the rated lifetime, and the error code is exposed', () => {
+    test('auto-dry enable state round trips on the owner-captured frames', () => {
         const { ha, thinq, dev } = buildReadyDevice()
-        // Base frame carried 0x355=12 used out of 0x356=720 rated hours, which
-        // the app renders as 2%.
+        thinq.emit('data', buf(AUTODRY_OFF_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'autodry', 'state'), 'OFF')
+        thinq.emit('data', buf(AUTODRY_ON_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'autodry', 'state'), 'ON')
+        assert.equal(thinq.outbox.length, 0)
+        assert.equal(thinq.sent.length, 0)
+        dev.drop()
+    })
+
+    test('filter counters expose used, rated and remaining hours plus used percentage', () => {
+        const { ha, thinq, dev } = buildReadyDevice()
+        // Base frame carried 0x355=12 used out of 0x356=720 rated hours.
+        assert.equal(ha.getProperty(DEVICE_ID, 'filter_used_time', 'state'), 12)
+        assert.equal(ha.getProperty(DEVICE_ID, 'filter_life_time', 'state'), 720)
+        assert.equal(ha.getProperty(DEVICE_ID, 'filter_remaining', 'state'), 708)
         assert.equal(ha.getProperty(DEVICE_ID, 'filter_used', 'state'), 2)
         assert.equal(ha.getProperty(DEVICE_ID, 'error', 'state'), 0)
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        assert.equal(components.filterreset, undefined, 'no reset button without a captured PAC reset command')
 
         dev.processKeyValue(0x355, 360)
+        assert.equal(ha.getProperty(DEVICE_ID, 'filter_used_time', 'state'), 360)
+        assert.equal(ha.getProperty(DEVICE_ID, 'filter_remaining', 'state'), 360)
         assert.equal(ha.getProperty(DEVICE_ID, 'filter_used', 'state'), 50)
 
-        // A zero rated lifetime must not divide, and usage past the rating clamps.
+        // A zero rated lifetime must not divide or replace the last good values.
         dev.processKeyValue(0x356, 0)
         dev.processKeyValue(0x355, 400)
         assert.equal(ha.getProperty(DEVICE_ID, 'filter_used', 'state'), 50)
         dev.processKeyValue(0x356, 100)
+        assert.equal(ha.getProperty(DEVICE_ID, 'filter_remaining', 'state'), 0)
         assert.equal(ha.getProperty(DEVICE_ID, 'filter_used', 'state'), 100)
 
         assert.equal(thinq.outbox.length, 0)
@@ -532,7 +604,17 @@ describe(MODEL_ID, () => {
         thinq.emit('data', buf(BASE_HEX))
         const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
 
-        for (const name of ['power', 'smartguide', 'dry_remain', 'filter_used', 'error']) {
+        for (const name of [
+            'power',
+            'smartguide',
+            'autodry',
+            'dry_remain',
+            'filter_used',
+            'filter_used_time',
+            'filter_life_time',
+            'filter_remaining',
+            'error',
+        ]) {
             assert.equal(components[name].entity_category, 'diagnostic', `${name} should be diagnostic`)
         }
         for (const name of [

--- a/tests/cloud/devices/PAC_910604_WW.test.ts
+++ b/tests/cloud/devices/PAC_910604_WW.test.ts
@@ -116,6 +116,17 @@ const CMD_COOLPOWER_ON = '01010400000065020100028d8138e6' // 0x236=1
 const CMD_WIND_LONG = '01010400000065020100097e407ea009097f9034d41d' // mode 0, fan 2313, target 52
 const CMD_WIND_OFF = '01010400000065020100097e407ea006067f9034650a' // mode 0, fan 1542, target 52
 
+// Command frames for the climate entity from the first session, plus the
+// per-vane horizontal swing states. 'both' (257) was seen as state only.
+const CMD_COOL_HIGH_26 = '01010400000065020100097e407ea006067f9034650a' // mode 0, fan 1542, target 52
+const CMD_COOL_MED_26 = '01010400000065020100097e407ea004047f9034cce1' // mode 0, fan 1028, target 52
+const CMD_ON_COOL_HIGH_18 = '010104000000650201000b7dc17e407ea006067f90246e65' // power 1 + mode/fan/target
+const CMD_DRY_LOW_24 = '01010400000065020100097e417ea002027f903021aa' // mode 1, fan 514, target 48
+const CMD_SWING_V_ON = '01010400000065020100028141a4c7' // 0x205 = 1
+const SWING_LEFT_ON_STATE_HEX = '000004000000a702041a0892c281a00100c486d0a6' // 0x206 = 256
+const SWING_LEFT_OFF_STATE_HEX = '000004000000a702041e0692c28180c48478af' // 0x206 = 0
+const SWING_RIGHT_ON_STATE_HEX = '000004000000a702042e0692c28181c4840943' // 0x206 = 1
+
 /** TLVs of a captured frame, as {tag: value}. */
 function frameTlvs(hex: string): Record<number, number> {
     const b = buf(hex)
@@ -164,8 +175,9 @@ describe(MODEL_ID, () => {
         assert.ok(components.climate, 'climate component')
         assert.equal(components.climate.platform, 'climate')
         assert.equal(components.climate.current_humidity_topic, '$this/humidity-')
-        // The eight controls expose command topics; everything else is state-only.
+        // The nine controls expose command topics; everything else is state-only.
         const controls = [
+            'climate',
             'eco',
             'airclean',
             'smartcare',
@@ -181,6 +193,10 @@ describe(MODEL_ID, () => {
         }
         assert.deepEqual(components.wind_mode.options, ['off', 'coolpower', 'longpower'])
         assert.deepEqual(components.human_sense.options, ['off', 'direct', 'indirect'])
+        assert.deepEqual(components.climate.swing_modes, ['off', 'on'])
+        assert.deepEqual(components.climate.swing_horizontal_modes, ['off', 'right', 'left', 'both'])
+        assert.equal(components.swing_v, undefined, 'no loose vertical swing entity')
+        assert.equal(components.swing_h, undefined, 'no loose horizontal swing entity')
         // climate offers exactly the observed fan levels and modes
         assert.deepEqual(components.climate.modes, ['off', 'cool', 'dry'])
         assert.deepEqual(components.climate.fan_modes, ['auto', 'low', 'medium', 'high', 'turbo', 'max'])
@@ -237,16 +253,18 @@ describe(MODEL_ID, () => {
         dev.drop()
     })
 
-    test('swing states decode', () => {
+    test('swing states decode onto the climate entity', () => {
         const { ha, thinq, dev } = buildReadyDevice()
         thinq.emit('data', buf(SWING_V_HEX))
-        assert.equal(ha.getProperty(DEVICE_ID, 'swing_v', 'state'), 'ON')
-        thinq.emit('data', buf(SWING_L_HEX))
-        assert.equal(ha.getProperty(DEVICE_ID, 'swing_h', 'state'), 'left') // 256
-        thinq.emit('data', buf(SWING_R_HEX))
-        assert.equal(ha.getProperty(DEVICE_ID, 'swing_h', 'state'), 'right') // 1
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'swing_mode_state'), 'on')
+        thinq.emit('data', buf(SWING_LEFT_ON_STATE_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'swing_horizontal_mode_state'), 'left') // 256
+        thinq.emit('data', buf(SWING_RIGHT_ON_STATE_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'swing_horizontal_mode_state'), 'right') // 1
         thinq.emit('data', buf(SWING_BOTH_HEX))
-        assert.equal(ha.getProperty(DEVICE_ID, 'swing_h', 'state'), 'both') // 257
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'swing_horizontal_mode_state'), 'both') // 257
+        thinq.emit('data', buf(SWING_LEFT_OFF_STATE_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'swing_horizontal_mode_state'), 'off') // 0
         dev.drop()
     })
 
@@ -373,13 +391,136 @@ describe(MODEL_ID, () => {
         dev.drop()
     })
 
-    test('climate and sensor writes still send nothing', () => {
-        const { ha, thinq, dev } = buildReadyDevice()
-        dev.setProperty('climate-mode', 'dry')
+    test('climate writes reproduce the frames the app itself sent', () => {
+        // A mode write repeats the fan and setpoint the appliance currently
+        // holds; the base frame is cool / medium / 26C, matching this capture.
+        let { thinq, dev } = buildReadyDevice()
+        dev.setProperty('climate-mode', 'cool')
+        let got = sentTlvs(thinq)
+        let want = frameTlvs(CMD_COOL_MED_26)
+        assert.equal(got[0x1f9], want[0x1f9])
+        assert.equal(got[0x1fa], want[0x1fa], 'fan is duplicated across both bytes')
+        assert.equal(got[0x1fe], want[0x1fe])
+        assert.equal(got[0x1f7], 1, 'power is attached; a write while off is ignored')
+        dev.drop()
+
+        // Selecting high reproduces the other captured cool/26C frame.
+        ;({ thinq, dev } = buildReadyDevice())
         dev.setProperty('climate-fan_mode', 'high')
+        got = sentTlvs(thinq)
+        want = frameTlvs(CMD_COOL_HIGH_26)
+        assert.equal(got[0x1fa], want[0x1fa])
+        assert.equal(got[0x1f9], want[0x1f9])
+        assert.equal(got[0x1fe], want[0x1fe])
+        dev.drop()
+
+        // Dry / low / 24C.
+        ;({ thinq, dev } = buildReadyDevice())
+        dev.setProperty('climate-mode', 'dry')
+        dev.setProperty('climate-fan_mode', 'low')
+        thinq.resetRecorder()
         dev.setProperty('climate-temperature', '24')
-        dev.setProperty('swing_h-', 'left')
+        got = sentTlvs(thinq)
+        want = frameTlvs(CMD_DRY_LOW_24)
+        assert.equal(got[0x1f9], want[0x1f9])
+        assert.equal(got[0x1fa], want[0x1fa])
+        assert.equal(got[0x1fe], want[0x1fe], '24C is written as raw 48')
+        dev.drop()
+    })
+
+    test('power on restores mode, fan and setpoint in one frame; off sends power alone', () => {
+        const { thinq, dev } = buildReadyDevice()
+        dev.setProperty('climate-fan_mode', 'high')
+        dev.setProperty('climate-temperature', '18')
+        thinq.resetRecorder()
+
+        dev.setProperty('climate-power', 'ON')
+        const got = sentTlvs(thinq)
+        const want = frameTlvs(CMD_ON_COOL_HIGH_18)
+        assert.equal(got[0x1f7], want[0x1f7])
+        assert.equal(got[0x1f9], want[0x1f9])
+        assert.equal(got[0x1fa], want[0x1fa])
+        assert.equal(got[0x1fe], want[0x1fe])
+
+        thinq.resetRecorder()
+        dev.setProperty('climate-power', 'OFF')
+        const off = sentTlvs(thinq)
+        assert.equal(off[0x1f7], 0)
+        assert.equal(off[0x1f9], undefined, 'nothing is attached when switching off')
+        assert.equal(off[0x1fa], undefined)
+        dev.drop()
+    })
+
+    test("HA's 'off' climate mode powers the unit down instead of writing a wire mode", () => {
+        const { thinq, dev } = buildReadyDevice()
+        dev.setProperty('climate-mode', 'off')
+        const got = sentTlvs(thinq)
+        assert.equal(got[0x1f7], 0, 'power off')
+        assert.equal(got[0x1f9], undefined, "'off' is not a wire mode")
+        dev.drop()
+    })
+
+    test('swing writes reproduce the captured vertical frame; horizontal writes echo the driven states', () => {
+        const { thinq, dev } = buildReadyDevice()
+        dev.setProperty('climate-swing_mode', 'on')
+        assert.equal(sentTlvs(thinq)[0x205], frameTlvs(CMD_SWING_V_ON)[0x205])
+        dev.drop()
+
+        // Each vane was driven separately on the unit; the writes echo those
+        // resulting state values ('both' was seen as state only).
+        for (const [value, expected] of [
+            ['left', frameTlvs(SWING_LEFT_ON_STATE_HEX)[0x206]],
+            ['off', frameTlvs(SWING_LEFT_OFF_STATE_HEX)[0x206]],
+            ['right', frameTlvs(SWING_RIGHT_ON_STATE_HEX)[0x206]],
+            ['both', 257],
+        ] as const) {
+            const { thinq: t2, dev: d2 } = buildReadyDevice()
+            d2.setProperty('climate-swing_horizontal_mode', value)
+            assert.equal(sentTlvs(t2)[0x206], expected, `swing_horizontal_mode=${value}`)
+            d2.drop()
+        }
+    })
+
+    test('power draw is published in watts and reads zero while off', () => {
+        const { ha, thinq, dev } = buildReadyDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        assert.equal(components.power_draw.device_class, 'power')
+        assert.equal(components.power_draw.unit_of_measurement, 'W')
+
+        // Published raw: the RAC -60 correction would make these negative.
+        assert.equal(ha.getProperty(DEVICE_ID, 'power_draw', 'state'), 32)
+        dev.processKeyValue(0x2b3, 578)
+        assert.equal(ha.getProperty(DEVICE_ID, 'power_draw', 'state'), 578)
+        dev.processKeyValue(0x2b3, 0)
+        assert.equal(ha.getProperty(DEVICE_ID, 'power_draw', 'state'), 0)
+        dev.drop()
+    })
+
+    test('filter usage is a percentage of the rated lifetime, and the error code is exposed', () => {
+        const { ha, thinq, dev } = buildReadyDevice()
+        // Base frame carried 0x355=12 used out of 0x356=720 rated hours, which
+        // the app renders as 2%.
+        assert.equal(ha.getProperty(DEVICE_ID, 'filter_used', 'state'), 2)
+        assert.equal(ha.getProperty(DEVICE_ID, 'error', 'state'), 0)
+
+        dev.processKeyValue(0x355, 360)
+        assert.equal(ha.getProperty(DEVICE_ID, 'filter_used', 'state'), 50)
+
+        // A zero rated lifetime must not divide, and usage past the rating clamps.
+        dev.processKeyValue(0x356, 0)
+        dev.processKeyValue(0x355, 400)
+        assert.equal(ha.getProperty(DEVICE_ID, 'filter_used', 'state'), 50)
+        dev.processKeyValue(0x356, 100)
+        assert.equal(ha.getProperty(DEVICE_ID, 'filter_used', 'state'), 100)
+
+        assert.equal(thinq.outbox.length, 0)
+        dev.drop()
+    })
+
+    test('sensor writes still send nothing', () => {
+        const { ha, thinq, dev } = buildReadyDevice()
         dev.setProperty('pm1-', '10')
+        dev.setProperty('humidity-', '50')
         assert.equal(thinq.outbox.length, 0, 'writes must not reach the wire')
         assert.equal(thinq.sent.length, 0, 'writes must not send ThinQ messages')
         dev.drop()
@@ -391,7 +532,7 @@ describe(MODEL_ID, () => {
         thinq.emit('data', buf(BASE_HEX))
         const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
 
-        for (const name of ['power', 'swing_v', 'smartguide', 'dry_remain']) {
+        for (const name of ['power', 'smartguide', 'dry_remain', 'filter_used', 'error']) {
             assert.equal(components[name].entity_category, 'diagnostic', `${name} should be diagnostic`)
         }
         for (const name of [
@@ -401,7 +542,6 @@ describe(MODEL_ID, () => {
             'smartcare',
             'wind_mode',
             'human_sense',
-            'swing_h',
             'sleep_timer',
             'start_timer',
             'stop_timer',
@@ -409,6 +549,7 @@ describe(MODEL_ID, () => {
             'pm25',
             'pm10',
             'humidity',
+            'power_draw',
         ]) {
             assert.equal(components[name].entity_category, undefined, `${name} should stay primary`)
         }
@@ -426,12 +567,12 @@ describe(MODEL_ID, () => {
         dev.drop()
     })
 
-    test('swing and human sense options match the published contract', () => {
+    test('climate swing and human sense options match the published contract', () => {
         const { ha, thinq, dev } = makeDevice()
         thinq.emit('data', buf(BASE_HEX))
         const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
-        assert.equal(components.swing_h.device_class, 'enum')
-        assert.deepEqual(components.swing_h.options, ['off', 'right', 'left', 'both'])
+        assert.deepEqual(components.climate.swing_modes, ['off', 'on'])
+        assert.deepEqual(components.climate.swing_horizontal_modes, ['off', 'right', 'left', 'both'])
         assert.equal(components.human_sense.platform, 'select')
         assert.deepEqual(components.human_sense.options, ['off', 'direct', 'indirect'])
 


### PR DESCRIPTION
## Summary

Adds a handler for the LG floor-standing **FQ18PADNQN** (ThinQ model `PAC_910604_WW`, `deviceType` 401), registers it in the Home Assistant bridge, and documents it in the README.

It shares the `0xA7` TLV envelope with the newer RAC units, but the fan encoding, the horizontal-swing field and several feature tags differ enough that it needs its own field map rather than an alias.

## Home Assistant entities

Controllable (every write reproduces the exact command frame the ThinQ app sent, captured owner-operated on the physical unit):

- `climate` - power, `cool` / `dry`, target temperature (18-30 °C), fan (`auto` / `low` / `medium` / `high` / `turbo` / `max`), both swing axes as the climate's own swing modes. A mode/fan/setpoint write repeats the current values in the same frame, exactly as the app does; powering on restores mode, fan and setpoint in one frame, switching off sends the power tag alone, and HA's `off` mode powers the unit down (there is no such wire mode)
- `switch` - air purify, energy saving, smart care (single-tag writes)
- `select` - wind mode (`off` / `coolpower` / `longpower`, mirroring the app's single selector)
- `select` - human sense (`off` / `direct` / `indirect`)
- `number` - sleep timer (minutes, 0-420), turn-on timer `0x21c` and turn-off timer `0x21b` (minutes, 0-1440, 0 cancels)

Reported only:

- power draw in watts (published raw - the RAC `-60` correction does not hold on this model)
- auto-dry enabled state and its remaining countdown; the app's 10/30/60-minute duration setting is cloud-only and produces no local frame
- filter hours used, rated lifetime, computed remaining hours and percentage used; diagnostic error code
- smart guide, PM1.0 / PM2.5 / PM10 and humidity as sensors

Appliance-internal status is filed under `diagnostic`, as on the RAC units; the environmental readings and the controls stay primary. The handler never polls or queries - it is a passive listener that transmits only user-initiated control writes.

## Wind mode findings

The app exposes wind mode as one `off` / `coolpower` / `longpower` selector, and the wire agrees: there is a single shared off frame and no observed `0x236=0` or `0x209=0` write. Coolpower-on is a direct `0x236=1` tag (the unit then drives fan turbo and 18 °C itself); longpower-on is a climate bundle with the fan forced to max (2313, seen twice byte-identical); off is a climate bundle with the fan fixed to high (1542, restoring the previous manual level was tested and does not happen). The implementation sends the bundles with the current mode/target echoed.

## Protocol findings

Every tag was confirmed by operating the physical unit and matching the resulting frames, on-to-off round trips throughout:

| Tag | Meaning | Notes |
|---|---|---|
| `0x1f7` | power | 0 / 1 |
| `0x1f9` | mode | 0 cool, 1 dry |
| `0x1fa` | fan | level duplicated across both bytes (`level × 0x0101`) |
| `0x1fd` / `0x1fe` | current / target temperature | `raw / 2` |
| `0x205` | vertical swing | plain on/off here, not an angle |
| `0x206` | horizontal swing | low byte = right vane, high byte = left |
| `0x208` | human sensing | 0 off, 1 direct, 2 indirect |
| `0x20d` / `0x20f` | energy saving / air purify | single-tag writes |
| `0x20e` / `0x225` | auto-dry enabled / remaining | enabled is 0/1; remaining is minutes; duration selection is not locally observable |
| `0x209` / `0x236` | long power / cool power | reported state; written via the wind-mode selector |
| `0x23e` / `0x23f` | smart care / smart guide | smart care is a single-tag write |
| `0x21a` | sleep timer | minutes, counts down (420 set, 0 cancels) |
| `0x21b` / `0x21c` | turn-off / turn-on reservation | minutes, count down (1440 / 60 set, 0 cancels) |
| `0x2b3` | power draw | watts, 0 while off |
| `0x221` | error code | 0 while healthy |
| `0x355` / `0x356` | filter hours used / rated lifetime | also publishes remaining hours and percent used |
| `0x333` / `0x334` / `0x335` | PM1.0 / PM2.5 / PM10 | |
| `0x336` | humidity | one-to-one percent |

Horizontal swing was established by driving each vane on its own: left alone reports `0x206 = 256`, right alone `1`, off `0`, both `257`. The `both` write echoes that state value - it was never captured as a command. While energy saving engages, one frame carries `0xFF` in one byte of `0x1fa`; the other byte still holds the level, so the fan reading is taken from that byte. `min_temp` / `max_temp` are 18-30 (18 °C forced by coolpower is the observed floor; above the observed 26 °C ceiling the range is unverified). The `0x25e = 2` accompanying smartcare is still not exposed - its precise meaning is unconfirmed.

## Compared with the other AC PRs

Checked against #36, #60, #73 and #129 for anything missed. PAC now exposes every RAC-style feature that has an exact PAC tag or captured behavior: climate controls, both swing axes, air purify, energy saving, timers, auto-dry enabled/countdown, error, power draw and filter counters. RAC-only capability-gated diagnostics (EEV, pipe/ODU temperatures, fan RPM and nominal capacity) are not added because none of their RAC tags has been identified on this PAC capture. The RAC filter reset button is also deliberately excluded: RAC uses a private query/reset protocol, while PAC reports `0x355`/`0x356` in ordinary state frames and no PAC reset command was captured. Writing zero to a counter or copying RAC's private reset would be an unsafe guess.

Two differences worth flagging: #129 divides `0x336` by 10 for humidity on a cassette unit, but on this model the same tag is a one-to-one percentage and matches both the app and a reference hygrometer; and the reservations here count down in minutes on the wire (`0x21b`/`0x21c`), so the number entities use minutes rather than the RAC hour sliders.

## Tests

Fixtures are real captured frames from two owner-operated sessions; the suite validates their declared envelope lengths and CRCs, then covers immediate discovery and delta-first reconnects, state decoding (power, all modes and fan levels including the energy-saving override, both swing axes on the climate entity, human sensing, feature toggles, auto-dry enabled state, all three timers, power draw, raw/rated/remaining filter life and percentage recomputation with a zero rated lifetime and clamping, delta-only tags, malformed input), that every control write reproduces the app's captured frame (climate mode/fan/setpoint/power/attach rules, both swing axes, switches, human sense, all three timers including cancel, wind-mode coolpower/longpower/off), that sensor writes still send nothing, and the diagnostic/primary split.

Verified locally: `npm run check`, `npm run build`, `npm test` (496/496).
