### PR TITLE
Add support for the AS309DWA air purifier (AIR_910604_WW)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The following appliances are currently supported in rethink:
     - 👍 WKEX200HBA (WTL_FXU_BDV_NA_01), WashTower - mostly working
 - Dehumidifiers
     - 👍 MD19GQGE0, Smart Dehumidifier - mostly working
+- Air Purifiers:
+    - 🫤 AS309DWA (AIR_910604_WW), LG PuriCare Air Purifier - power, operating mode, fan speeds, circulation rotation, indicator light, air sanitization and sleep timer are controllable; air-quality sensors and filter life are reported
 - Range Hoods:
     - 👍 HCED3015D (STUDIO_HOOD), Generic identifier and probably works with multiple models. Working.
 - Stylers:

--- a/cloud/devices/AIR_910604_WW.ts
+++ b/cloud/devices/AIR_910604_WW.ts
@@ -98,7 +98,7 @@ export default class Device extends TLVDevice {
     }
 
     isValuesResponse(tlvArray: TLV.TLV[]) {
-        return tlvArray.some(({ t }) => t === TAG_POWER)
+        return tlvArray.length >= 10 && tlvArray.some(({ t }) => t === TAG_POWER)
     }
 
     valuesReceived() {

--- a/cloud/devices/AIR_910604_WW.ts
+++ b/cloud/devices/AIR_910604_WW.ts
@@ -1,0 +1,339 @@
+import TLVDevice from './tlv_device'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { DeviceDiscovery, type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import { Enum } from '@/util/enum'
+import * as TLV from '@/util/tlv'
+import HADevice from './base'
+
+/**
+ * LG PuriCare air purifier AIR_910604_WW (deviceType 402).
+ *
+ * The tag-name baseline, filter semantics and the write quirks below were
+ * cross-checked against the earlier exact-model work in sosohage2/rethink-korea
+ * commits c3cf559 and 387be48. That work's correction not to publish the
+ * appliance's internal temperature (0x1fd) and humidity (0x336) as room
+ * measurements is retained: neither tracks the room.
+ *
+ * Every writable field here was driven from the app and the resulting command
+ * frame captured, so the values written are the ones LG itself sends:
+ *
+ *   0x1f7  power                 0/1
+ *   0x1f9  operating mode        13 clean booster, 14 single, 15 dual, 16 auto
+ *   0x1fa  main fan speed        2 low, 4 medium, 6 high, 7 turbo, 8 auto
+ *   0x326  clean booster fan     same levels
+ *   0x327  circulation rotation  0/1
+ *   0x24e  clean indicator       0/1
+ *   0x360  air sterilization     0/1
+ *   0x21a  sleep timer           minutes, counts down
+ *
+ * Two appliance quirks, both observed rather than worked around:
+ *
+ * 1. A write that arrives while the unit is off is acknowledged and then
+ *    ignored. Sending the power tag alongside does work and starts the unit
+ *    directly in the requested state, so mode and fan writes force power on and
+ *    attach it.
+ * 2. While the operating mode is auto the appliance drives the fan itself and a
+ *    bare fan write is ignored. Nothing is done about this - silently changing
+ *    the user's mode to make a fan request stick would be worse.
+ *
+ * Setting the sleep timer also switches the clean indicator off; the appliance
+ * reports both tags in one frame. That is its own behaviour, not something done
+ * here.
+ */
+const MODES = new Enum([
+    ['clean_booster', 13],
+    ['single_clean', 14],
+    ['dual_clean', 15],
+    ['auto', 16],
+] as [string, number][])
+
+const FAN_SPEEDS = new Enum([
+    ['low', 2],
+    ['medium', 4],
+    ['high', 6],
+    ['turbo', 7],
+    ['auto', 8],
+] as [string, number][])
+
+const TAG_POWER = 0x1f7
+const TAG_MODE = 0x1f9
+const TAG_FAN = 0x1fa
+const TAG_BOOSTER_FAN = 0x326
+const TAG_ROTATION = 0x327
+const TAG_INDICATOR = 0x24e
+const TAG_STERILIZE = 0x360
+const TAG_SLEEP_TIMER = 0x21a
+
+export default class Device extends TLVDevice {
+    meta: Metadata
+    configDone = false
+
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        this.meta = meta
+        // The field map is fixed for this exact model and the appliance reports
+        // its state unprompted, so nothing needs to be asked for. Writes still
+        // go out normally; this only suppresses polling.
+        if (this.query_caps_timeout != undefined) {
+            clearInterval(this.query_caps_timeout)
+            this.query_caps_timeout = undefined
+        }
+        // Publish discovery immediately so a connection that only sees delta
+        // frames is still usable.
+        this.valuesReceived()
+    }
+
+    queryCaps() {
+        // Capabilities are not queried; the exact-model field map is fixed.
+    }
+
+    query() {
+        // State arrives unprompted, so no values query is sent.
+    }
+
+    start() {
+        // No periodic refresh timer.
+    }
+
+    isValuesResponse(tlvArray: TLV.TLV[]) {
+        return tlvArray.some(({ t }) => t === TAG_POWER)
+    }
+
+    valuesReceived() {
+        if (this.configDone) return
+        this.configDone = true
+        this.initConfig()
+    }
+
+    initConfig() {
+        const config: DeviceDiscovery = allowExtendedType({
+            ...HADevice.config(this.meta, { name: 'LG PuriCare Air Purifier' }),
+            components: {
+                fan: {
+                    platform: 'fan',
+                    unique_id: '$deviceid-fan',
+                    name: null,
+                    icon: 'mdi:air-purifier',
+                    preset_modes: FAN_SPEEDS.options,
+                },
+                mode: {
+                    platform: 'select',
+                    unique_id: '$deviceid-mode',
+                    name: 'Mode',
+                    icon: 'mdi:tune-variant',
+                    options: MODES.options,
+                },
+                clean_booster_fan_speed: {
+                    platform: 'select',
+                    unique_id: '$deviceid-clean_booster_fan_speed',
+                    name: 'Clean booster fan speed',
+                    icon: 'mdi:fan',
+                    options: FAN_SPEEDS.options,
+                },
+                sleep_timer: {
+                    platform: 'number',
+                    unique_id: '$deviceid-sleep_timer',
+                    name: 'Sleep timer',
+                    icon: 'mdi:sleep',
+                    device_class: 'duration',
+                    unit_of_measurement: 'min',
+                    min: 0,
+                    max: 720,
+                    step: 10,
+                    mode: 'box',
+                },
+                pm1: {
+                    platform: 'sensor',
+                    unique_id: '$deviceid-pm1',
+                    name: 'PM1.0',
+                    device_class: 'pm1',
+                    unit_of_measurement: 'µg/m³',
+                    state_class: 'measurement',
+                    suggested_display_precision: 0,
+                },
+                pm25: {
+                    platform: 'sensor',
+                    unique_id: '$deviceid-pm25',
+                    name: 'PM2.5',
+                    device_class: 'pm25',
+                    unit_of_measurement: 'µg/m³',
+                    state_class: 'measurement',
+                    suggested_display_precision: 0,
+                },
+                pm10: {
+                    platform: 'sensor',
+                    unique_id: '$deviceid-pm10',
+                    name: 'PM10',
+                    device_class: 'pm10',
+                    unit_of_measurement: 'µg/m³',
+                    state_class: 'measurement',
+                    suggested_display_precision: 0,
+                },
+                air_quality: {
+                    platform: 'sensor',
+                    unique_id: '$deviceid-air_quality',
+                    name: 'Air quality index',
+                    icon: 'mdi:weather-hazy',
+                    state_class: 'measurement',
+                },
+                odor: {
+                    platform: 'sensor',
+                    unique_id: '$deviceid-odor',
+                    name: 'Odor index',
+                    icon: 'mdi:scent',
+                    state_class: 'measurement',
+                },
+                error: {
+                    platform: 'sensor',
+                    unique_id: '$deviceid-error',
+                    name: 'Error code',
+                    icon: 'mdi:alert',
+                    entity_category: 'diagnostic',
+                },
+                filter_life: {
+                    platform: 'sensor',
+                    unique_id: '$deviceid-filter_life',
+                    name: 'Filter life',
+                    icon: 'mdi:air-filter',
+                    unit_of_measurement: '%',
+                    state_class: 'measurement',
+                },
+                top_filter_life: {
+                    platform: 'sensor',
+                    unique_id: '$deviceid-top_filter_life',
+                    name: 'Top filter life',
+                    icon: 'mdi:air-filter',
+                    unit_of_measurement: '%',
+                    state_class: 'measurement',
+                },
+            },
+        })
+
+        // Power is the fan entity's own on/off. Turning on restores the last
+        // mode and fan speed in the same frame, matching what the app sends.
+        this.addField(config, {
+            id: TAG_POWER,
+            name: '',
+            comp: 'fan',
+            read_xform: (raw) => (raw ? 'ON' : 'OFF'),
+            write_xform: (val) => (val === 'ON' ? 1 : 0),
+            write_attach: (raw) => (raw ? [TAG_MODE, TAG_FAN] : []),
+        })
+
+        // Main fan speed drives the fan entity's preset slot.
+        this.addField(config, {
+            id: TAG_FAN,
+            name: 'preset_mode',
+            comp: 'fan',
+            read_xform: (raw) => FAN_SPEEDS.map(raw) ?? 'None',
+            write_xform: (val) => {
+                this.raw_clip_state[TAG_POWER] = 1 // quirk 1
+                return FAN_SPEEDS.unmap(val)
+            },
+            write_attach: [TAG_POWER, TAG_MODE],
+        })
+
+        // Operating mode gets its own select: the fan platform's single preset
+        // slot is already taken by the speed.
+        this.addField(config, {
+            id: TAG_MODE,
+            name: '',
+            comp: 'mode',
+            read_xform: (raw) => MODES.map(raw) ?? 'None',
+            write_xform: (val) => {
+                this.raw_clip_state[TAG_POWER] = 1 // quirk 1
+                return MODES.unmap(val)
+            },
+            write_attach: [TAG_POWER, TAG_FAN],
+        })
+
+        // The clean booster's circulation fan is reported and driven separately
+        // from the main fan speed.
+        this.addField(config, {
+            id: TAG_BOOSTER_FAN,
+            name: '',
+            comp: 'clean_booster_fan_speed',
+            read_xform: (raw) => FAN_SPEEDS.map(raw) ?? 'None',
+            write_xform: (val) => {
+                this.raw_clip_state[TAG_POWER] = 1 // quirk 1
+                return FAN_SPEEDS.unmap(val)
+            },
+            write_attach: [TAG_POWER],
+        })
+
+        this.addSwitch(
+            config,
+            'circulation_rotation',
+            TAG_ROTATION,
+            'Circulation fan rotation',
+            'mdi:rotate-3d-variant',
+        )
+        this.addSwitch(config, 'clean_indicator', TAG_INDICATOR, 'Clean indicator', 'mdi:lightbulb')
+        this.addSwitch(config, 'air_sanitization', TAG_STERILIZE, 'Air sanitization', 'mdi:shield-sun')
+
+        // Reported in minutes and counting down, so the entity shows the live
+        // remaining time rather than what was requested.
+        // The explicit write_xform is required: TLVDevice.setProperty leaves the
+        // value undefined when a field has none, and then drops the write.
+        this.addField(config, {
+            id: TAG_SLEEP_TIMER,
+            name: '',
+            comp: 'sleep_timer',
+            write_xform: (val) => Number(val),
+        })
+
+        const readonly = (id: number, comp: string) => this.addField(config, { id, name: '', comp, writable: false })
+
+        readonly(0x333, 'pm1')
+        readonly(0x334, 'pm25')
+        readonly(0x335, 'pm10')
+        readonly(0x240, 'air_quality')
+        readonly(0x241, 'odor')
+        readonly(0x221, 'error')
+
+        // LG calls 0x355/0x363 "useTime", but physical-app comparison proved
+        // they are hours remaining. Publish remaining / maximum as a percent.
+        this.addFilterLife(config, 'filter_life', 0x355, 0x356)
+        this.addFilterLife(config, 'top_filter_life', 0x363, 0x364)
+
+        this.setConfig(config)
+
+        // The first full frame arrived before fields were registered.
+        for (const [id, value] of Object.entries(this.raw_clip_state)) {
+            this.processKeyValue(Number(id), value)
+        }
+    }
+
+    private addSwitch(config: DeviceDiscovery, comp: string, id: number, name: string, icon: string) {
+        config.components[comp] = allowExtendedType({
+            platform: 'switch',
+            unique_id: `$deviceid-${comp}`,
+            name,
+            icon,
+        })
+        this.addField(config, {
+            id,
+            name: '',
+            comp,
+            read_xform: (raw) => (raw ? 'ON' : 'OFF'),
+            write_xform: (val) => (val === 'ON' ? 1 : 0),
+        })
+    }
+
+    private addFilterLife(config: DeviceDiscovery, comp: string, remainTag: number, maxTag: number) {
+        const recompute = () => {
+            const remain = this.raw_clip_state[remainTag]
+            const max = this.raw_clip_state[maxTag]
+            if (remain != null && max != null && max > 0) {
+                const percent = Math.max(0, Math.min(100, Math.round((remain / max) * 100)))
+                this.HA.publishProperty(this.id, `${comp}-`, percent)
+            }
+            return false
+        }
+
+        this.addField(config, { id: remainTag, name: '', comp, writable: false, read_callback: recompute })
+        this.addField(config, { id: maxTag, name: 'max', comp, writable: false, read_callback: recompute }, false)
+    }
+}

--- a/cloud/devices/AIR_910604_WW.ts
+++ b/cloud/devices/AIR_910604_WW.ts
@@ -192,21 +192,41 @@ export default class Device extends TLVDevice {
                     icon: 'mdi:alert',
                     entity_category: 'diagnostic',
                 },
-                filter_life: {
+                filter_remaining_time: {
                     platform: 'sensor',
-                    unique_id: '$deviceid-filter_life',
-                    name: 'Filter life',
+                    unique_id: '$deviceid-filter_remaining_time',
+                    name: 'Filter remaining time',
                     icon: 'mdi:air-filter',
-                    unit_of_measurement: '%',
-                    state_class: 'measurement',
+                    device_class: 'duration',
+                    unit_of_measurement: 'h',
+                    entity_category: 'diagnostic',
                 },
-                top_filter_life: {
+                filter_life_time: {
                     platform: 'sensor',
-                    unique_id: '$deviceid-top_filter_life',
-                    name: 'Top filter life',
+                    unique_id: '$deviceid-filter_life_time',
+                    name: 'Filter life time',
                     icon: 'mdi:air-filter',
-                    unit_of_measurement: '%',
-                    state_class: 'measurement',
+                    device_class: 'duration',
+                    unit_of_measurement: 'h',
+                    entity_category: 'diagnostic',
+                },
+                top_filter_remaining_time: {
+                    platform: 'sensor',
+                    unique_id: '$deviceid-top_filter_remaining_time',
+                    name: 'Top filter remaining time',
+                    icon: 'mdi:air-filter',
+                    device_class: 'duration',
+                    unit_of_measurement: 'h',
+                    entity_category: 'diagnostic',
+                },
+                top_filter_life_time: {
+                    platform: 'sensor',
+                    unique_id: '$deviceid-top_filter_life_time',
+                    name: 'Top filter life time',
+                    icon: 'mdi:air-filter',
+                    device_class: 'duration',
+                    unit_of_measurement: 'h',
+                    entity_category: 'diagnostic',
                 },
             },
         })
@@ -294,9 +314,12 @@ export default class Device extends TLVDevice {
         readonly(0x221, 'error')
 
         // LG calls 0x355/0x363 "useTime", but physical-app comparison proved
-        // they are hours remaining. Publish remaining / maximum as a percent.
-        this.addFilterLife(config, 'filter_life', 0x355, 0x356)
-        this.addFilterLife(config, 'top_filter_life', 0x363, 0x364)
+        // they are hours remaining. Keep the two raw hour counters for each
+        // filter instead of publishing a derived percentage.
+        readonly(0x355, 'filter_remaining_time')
+        readonly(0x356, 'filter_life_time')
+        readonly(0x363, 'top_filter_remaining_time')
+        readonly(0x364, 'top_filter_life_time')
 
         this.setConfig(config)
 
@@ -320,20 +343,5 @@ export default class Device extends TLVDevice {
             read_xform: (raw) => (raw ? 'ON' : 'OFF'),
             write_xform: (val) => (val === 'ON' ? 1 : 0),
         })
-    }
-
-    private addFilterLife(config: DeviceDiscovery, comp: string, remainTag: number, maxTag: number) {
-        const recompute = () => {
-            const remain = this.raw_clip_state[remainTag]
-            const max = this.raw_clip_state[maxTag]
-            if (remain != null && max != null && max > 0) {
-                const percent = Math.max(0, Math.min(100, Math.round((remain / max) * 100)))
-                this.HA.publishProperty(this.id, `${comp}-`, percent)
-            }
-            return false
-        }
-
-        this.addField(config, { id: remainTag, name: '', comp, writable: false, read_callback: recompute })
-        this.addField(config, { id: maxTag, name: 'max', comp, writable: false, read_callback: recompute }, false)
     }
 }

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -22,6 +22,7 @@ import RV13B6BSD_D_US_WIFI from './devices/RV13B6BSD_D_US_WIFI'
 import RV13B6ES_D_US_WIFI from './devices/RV13B6ES_D_US_WIFI'
 import WTL_FXU_BDV_NA_01 from './devices/WTL_FXU_BDV_NA_01'
 import DHUM_056905_WW from './devices/DHUM_056905_WW'
+import AIR_910604_WW from './devices/AIR_910604_WW'
 import ST_B_E4H01Y_APL from './devices/ST_B_E4H01Y_APL'
 import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
@@ -69,6 +70,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     // Wrinkle Care sits in a different bitfield, so it needs its own handler rather than an alias
     WTL_FXU_BDV_NA_01, // LG WashTower
     DHUM_056905_WW,
+    AIR_910604_WW,
     ST_B_E4H01Y_APL,
 }
 

--- a/tests/cloud/devices/AIR_910604_WW.test.ts
+++ b/tests/cloud/devices/AIR_910604_WW.test.ts
@@ -147,7 +147,18 @@ describe(MODEL_ID, () => {
         assert.deepEqual(components.clean_booster_fan_speed.options, ['low', 'medium', 'high', 'turbo', 'auto'])
         assert.equal(components.humidity, undefined, 'internal humidity is not room humidity')
         // Sensors stay strictly read-only even though the appliance is writable.
-        for (const name of ['pm1', 'pm25', 'pm10', 'air_quality', 'odor', 'error', 'filter_life']) {
+        for (const name of [
+            'pm1',
+            'pm25',
+            'pm10',
+            'air_quality',
+            'odor',
+            'error',
+            'filter_remaining_time',
+            'filter_life_time',
+            'top_filter_remaining_time',
+            'top_filter_life_time',
+        ]) {
             for (const key of Object.keys(components[name])) {
                 assert.ok(!key.endsWith('command_topic'), `${name}.${key} must not exist`)
             }
@@ -168,32 +179,26 @@ describe(MODEL_ID, () => {
         assert.equal(ha.getProperty(DEVICE_ID, 'air_quality', 'state'), 1)
         assert.equal(ha.getProperty(DEVICE_ID, 'odor', 'state'), 1)
         assert.equal(ha.getProperty(DEVICE_ID, 'error', 'state'), 0)
-        assert.equal(ha.getProperty(DEVICE_ID, 'filter_life', 'state'), 1) // 34 / 4000
-        assert.equal(ha.getProperty(DEVICE_ID, 'top_filter_life', 'state'), 80) // 3189 / 4000
+        assert.equal(ha.getProperty(DEVICE_ID, 'filter_remaining_time', 'state'), 34)
+        assert.equal(ha.getProperty(DEVICE_ID, 'filter_life_time', 'state'), 4000)
+        assert.equal(ha.getProperty(DEVICE_ID, 'top_filter_remaining_time', 'state'), 3189)
+        assert.equal(ha.getProperty(DEVICE_ID, 'top_filter_life_time', 'state'), 4000)
+        assert.equal(components.filter_life, undefined, 'derived percentage is not published')
+        assert.equal(components.top_filter_life, undefined, 'derived percentage is not published')
 
         assert.equal(thinq.outbox.length, 0)
         assert.equal(thinq.sent.length, 0)
         dev.drop()
     })
 
-    test('filter life recomputes as remaining and maximum arrive, clamped and guarded', () => {
+    test('filter counters publish raw remaining and lifetime hours', () => {
         const { ha, thinq, dev } = makeDevice()
         thinq.emit('data', buf(BASE_HEX))
 
-        // Remaining alone, before a new maximum, must not divide by a stale zero.
-        dev.processKeyValue(0x356, 0)
         dev.processKeyValue(0x355, 500)
-        assert.equal(ha.getProperty(DEVICE_ID, 'filter_life', 'state'), 1, 'zero maximum is ignored')
-
+        assert.equal(ha.getProperty(DEVICE_ID, 'filter_remaining_time', 'state'), 500)
         dev.processKeyValue(0x356, 1000)
-        assert.equal(ha.getProperty(DEVICE_ID, 'filter_life', 'state'), 50)
-
-        // A remaining value above the maximum clamps to 100 rather than overshooting.
-        dev.processKeyValue(0x355, 4000)
-        assert.equal(ha.getProperty(DEVICE_ID, 'filter_life', 'state'), 100)
-
-        dev.processKeyValue(0x355, 0)
-        assert.equal(ha.getProperty(DEVICE_ID, 'filter_life', 'state'), 0)
+        assert.equal(ha.getProperty(DEVICE_ID, 'filter_life_time', 'state'), 1000)
 
         assert.equal(thinq.outbox.length, 0)
         assert.equal(thinq.sent.length, 0)
@@ -355,7 +360,7 @@ describe(MODEL_ID, () => {
         thinq.emit('data', buf(BASE_HEX))
         thinq.resetRecorder()
 
-        for (const prop of ['pm25-', 'air_quality-', 'error-', 'filter_life-']) {
+        for (const prop of ['pm25-', 'air_quality-', 'error-', 'filter_remaining_time-']) {
             dev.setProperty(prop, '42')
         }
         thinq.emit('data', buf(TRUNCATED_HEX))

--- a/tests/cloud/devices/AIR_910604_WW.test.ts
+++ b/tests/cloud/devices/AIR_910604_WW.test.ts
@@ -112,6 +112,19 @@ describe(MODEL_ID, () => {
         }
     })
 
+    test('a power-only notification is not a full values response', () => {
+        const { dev } = makeDevice()
+        assert.equal(dev.isValuesResponse([{ t: 0x1f7, v: 1 }]), false)
+        assert.equal(
+            dev.isValuesResponse([
+                { t: 0x1f7, v: 1 },
+                ...Array.from({ length: 9 }, (_, i) => ({ t: 0x200 + i, v: i })),
+            ]),
+            true,
+        )
+        dev.drop()
+    })
+
     test('discovery is immediate and a delta-first connection publishes state', () => {
         const { ha, thinq, dev } = makeDevice()
         assert.ok(ha.devices[DEVICE_ID]?.config)

--- a/tests/cloud/devices/AIR_910604_WW.test.ts
+++ b/tests/cloud/devices/AIR_910604_WW.test.ts
@@ -1,0 +1,370 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/AIR_910604_WW'
+import Bridge from '@/cloud/ha_bridge'
+import crc16 from '@/util/crc16'
+import * as TLV from '@/util/tlv'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'AIR_910604_WW'
+const META: Metadata = { modelId: MODEL_ID, modelName: 'TEST', swVersion: '1.0' }
+
+// Real AIR_910604_WW A7 frames captured from the owner's physical unit.
+// Full state: power on, single clean, clean-booster fan auto, rotation on,
+// clean indicator and air sanitization on, PM1/PM2.5/PM10=8, humidity=30%.
+const BASE_HEX =
+    '000004000000A7020464627DC17E4E7E887F007F807F5050868086C087008980D7C0D801D840D88087809381' +
+    'CD48CD08CCC890419001CD901E8840D55022D5A00FA0D8E00C75D9200FA0CE80AB00C988C9C1CA00B5D010' +
+    'B600B648B5CDB600B648B5CFB600B648B5CEB60EB64EAFAA'
+
+// Owner-labelled real transition frames.
+const POWER_OFF_HEX = '000004000000A702048C0A7DC09380AC600100AC84ACD5'
+const POWER_ON_HEX = '000004000000A702048F0A7DC19381AC600100AC80BA8C'
+const CLEAN_BOOSTER_HEX = '000004000000A7020455027E4D9A6B'
+const SINGLE_CLEAN_HEX = '000004000000A7020430027E4E4F9F'
+const DUAL_CLEAN_HEX =
+    '000004000000A7020425627DC17E4F7E887F007F807F5050868086C087008980D7C0D801D840D88087809381' +
+    'CD48CD08CCC890419001CD901E8840D55022D5A00FA0D8E00C75D9200FA0CE80AB00C988C9C1CA00B5D010' +
+    'B600B648B5CDB600B648B5CFB600B648B5CEB60EB64E6B03'
+const AUTO_HEX = '000004000000A702044E037E5010B0FC'
+const BOOSTER_HIGH_HEX = '000004000000A702046702C986B457'
+const BOOSTER_TURBO_HEX = '000004000000A702046B02C987EB44'
+// Prior exact-model capture: main fan low plus the remembered-per-mode rows.
+const MAIN_FAN_LOW_HEX = '000004000000A702047B147E82B5CDB600B642B5CFB600B642B5CEB60EB64E5078'
+const ROTATION_OFF_HEX = '000004000000A702046D02C9C0F4FE'
+const ROTATION_ON_HEX = '000004000000A702046E02C9C17F03'
+const INDICATOR_OFF_HEX = '000004000000A7020480029380E022'
+const INDICATOR_ON_HEX = '000004000000A70204820293811D6B'
+const SANITIZATION_OFF_HEX = '000004000000A702048402D8006A6D'
+const SANITIZATION_ON_HEX = '000004000000A702048502D8010CF8'
+const SLEEP_120_HEX = '000004000000A702048605869078938038E2'
+const SLEEP_119_HEX = '000004000000A702048A038690774AA4'
+const SLEEP_CANCEL_HEX = '000004000000A702048B04868093817146'
+const TRUNCATED_HEX = '000004000000A7020464627DC17E4E7E88'
+
+// Command frames the LG app itself sent, captured on the same unit. Each write
+// below must reproduce the TLVs of one of these.
+const CMD_MODE_SINGLE = '01010400000065020100027e4e56d7' // 0x1f9 = 14
+const CMD_MODE_BOOSTER = '01010400000065020100027e4d66b4' // 0x1f9 = 13
+const CMD_BOOSTER_MEDIUM = '0101040000006502010002c984a94b' // 0x326 = 4
+const CMD_BOOSTER_TURBO = '0101040000006502010002c9879928' // 0x326 = 7
+const CMD_ROTATION_OFF = '0101040000006502010002c9c0a10b' // 0x327 = 0
+const CMD_ROTATION_ON = '0101040000006502010002c9c1b12a' // 0x327 = 1
+const CMD_INDICATOR_OFF = '0101040000006502010002938008bb' // 0x24e = 0
+const CMD_INDICATOR_ON = '01010400000065020100029381189a' // 0x24e = 1
+const CMD_STERILIZE_OFF = '0101040000006502010002d8004805' // 0x360 = 0
+const CMD_STERILIZE_ON = '0101040000006502010002d8015824' // 0x360 = 1
+const CMD_SLEEP_CANCEL = '01010400000065020100028680f43d' // 0x21a = 0
+
+/** TLVs of a captured toDevice command frame, as {tag: value}. */
+function commandTlvs(hex: string): Record<number, number> {
+    const b = Buffer.from(hex, 'hex')
+    const out: Record<number, number> = {}
+    for (const { t, v } of TLV.parse(b.subarray(11, 11 + b[10]))) out[t] = v
+    return out
+}
+
+/** TLVs the handler actually put on the wire, as {tag: value}. */
+function sentTlvs(thinq: MockThinq2Device): Record<number, number> {
+    assert.equal(thinq.outbox.length, 1, 'exactly one frame should be sent')
+    const b = thinq.outbox[0]
+    const out: Record<number, number> = {}
+    for (const { t, v } of TLV.parse(b.subarray(11, 11 + b[10]))) out[t] = v
+    return out
+}
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('every declared capture fixture has a valid envelope length and CRC', () => {
+        for (const frame of [
+            BASE_HEX,
+            POWER_OFF_HEX,
+            POWER_ON_HEX,
+            CLEAN_BOOSTER_HEX,
+            SINGLE_CLEAN_HEX,
+            DUAL_CLEAN_HEX,
+            AUTO_HEX,
+            BOOSTER_HIGH_HEX,
+            BOOSTER_TURBO_HEX,
+            MAIN_FAN_LOW_HEX,
+            ROTATION_OFF_HEX,
+            ROTATION_ON_HEX,
+            INDICATOR_OFF_HEX,
+            INDICATOR_ON_HEX,
+            SANITIZATION_OFF_HEX,
+            SANITIZATION_ON_HEX,
+            SLEEP_120_HEX,
+            SLEEP_119_HEX,
+            SLEEP_CANCEL_HEX,
+        ]) {
+            const packet = Buffer.from(frame, 'hex')
+            assert.equal(packet[6], 0xa7, frame)
+            assert.equal(packet[10], packet.length - 13, frame)
+            assert.equal(crc16(packet.subarray(2)), 0, frame)
+        }
+    })
+
+    test('discovery is immediate and a delta-first connection publishes state', () => {
+        const { ha, thinq, dev } = makeDevice()
+        assert.ok(ha.devices[DEVICE_ID]?.config)
+        thinq.emit('data', buf(DUAL_CLEAN_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'mode', 'state'), 'dual_clean')
+        assert.equal(thinq.outbox.length, 0)
+        dev.drop()
+    })
+
+    test('bridge registry selects this handler for the exact model id', () => {
+        const ha = new MockHAConnection()
+        const thinq = new MockThinq2Device(DEVICE_ID, META)
+        const bridge = new Bridge(ha.asConnection())
+        bridge.newDevice(thinq)
+        thinq.emit('data', buf(BASE_HEX))
+        assert.ok(ha.devices[DEVICE_ID]?.config)
+        assert.equal(ha.getProperty(DEVICE_ID, 'mode', 'state'), 'single_clean')
+        assert.equal(thinq.outbox.length, 0)
+        assert.equal(thinq.sent.length, 0)
+        thinq.emit('close')
+    })
+
+    test('real full frame publishes discovery and initial state', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', buf(BASE_HEX))
+
+        const device = ha.devices[DEVICE_ID]
+        assert.ok(device, 'HA configuration published')
+        const components = device.config!.components as Record<string, Record<string, unknown>>
+
+        assert.deepEqual(components.mode.options, ['clean_booster', 'single_clean', 'dual_clean', 'auto'])
+        assert.deepEqual(components.fan.preset_modes, ['low', 'medium', 'high', 'turbo', 'auto'])
+        assert.deepEqual(components.clean_booster_fan_speed.options, ['low', 'medium', 'high', 'turbo', 'auto'])
+        assert.equal(components.humidity, undefined, 'internal humidity is not room humidity')
+        // Sensors stay strictly read-only even though the appliance is writable.
+        for (const name of ['pm1', 'pm25', 'pm10', 'air_quality', 'odor', 'error', 'filter_life']) {
+            for (const key of Object.keys(components[name])) {
+                assert.ok(!key.endsWith('command_topic'), `${name}.${key} must not exist`)
+            }
+        }
+
+        assert.equal(ha.getProperty(DEVICE_ID, 'fan', 'state'), 'ON')
+        assert.equal(ha.getProperty(DEVICE_ID, 'mode', 'state'), 'single_clean')
+        assert.equal(ha.getProperty(DEVICE_ID, 'fan', 'preset_mode_state'), 'auto')
+        assert.equal(ha.getProperty(DEVICE_ID, 'clean_booster_fan_speed', 'state'), 'auto')
+        assert.equal(ha.getProperty(DEVICE_ID, 'circulation_rotation', 'state'), 'ON')
+        assert.equal(ha.getProperty(DEVICE_ID, 'clean_indicator', 'state'), 'ON')
+        assert.equal(ha.getProperty(DEVICE_ID, 'air_sanitization', 'state'), 'ON')
+        assert.equal(ha.getProperty(DEVICE_ID, 'sleep_timer', 'state'), 0)
+        assert.equal(ha.getProperty(DEVICE_ID, 'pm1', 'state'), 8)
+        assert.equal(ha.getProperty(DEVICE_ID, 'pm25', 'state'), 8)
+        assert.equal(ha.getProperty(DEVICE_ID, 'pm10', 'state'), 8)
+        assert.equal(ha.getProperty(DEVICE_ID, 'humidity', 'state'), undefined)
+        assert.equal(ha.getProperty(DEVICE_ID, 'air_quality', 'state'), 1)
+        assert.equal(ha.getProperty(DEVICE_ID, 'odor', 'state'), 1)
+        assert.equal(ha.getProperty(DEVICE_ID, 'error', 'state'), 0)
+        assert.equal(ha.getProperty(DEVICE_ID, 'filter_life', 'state'), 1) // 34 / 4000
+        assert.equal(ha.getProperty(DEVICE_ID, 'top_filter_life', 'state'), 80) // 3189 / 4000
+
+        assert.equal(thinq.outbox.length, 0)
+        assert.equal(thinq.sent.length, 0)
+        dev.drop()
+    })
+
+    test('filter life recomputes as remaining and maximum arrive, clamped and guarded', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', buf(BASE_HEX))
+
+        // Remaining alone, before a new maximum, must not divide by a stale zero.
+        dev.processKeyValue(0x356, 0)
+        dev.processKeyValue(0x355, 500)
+        assert.equal(ha.getProperty(DEVICE_ID, 'filter_life', 'state'), 1, 'zero maximum is ignored')
+
+        dev.processKeyValue(0x356, 1000)
+        assert.equal(ha.getProperty(DEVICE_ID, 'filter_life', 'state'), 50)
+
+        // A remaining value above the maximum clamps to 100 rather than overshooting.
+        dev.processKeyValue(0x355, 4000)
+        assert.equal(ha.getProperty(DEVICE_ID, 'filter_life', 'state'), 100)
+
+        dev.processKeyValue(0x355, 0)
+        assert.equal(ha.getProperty(DEVICE_ID, 'filter_life', 'state'), 0)
+
+        assert.equal(thinq.outbox.length, 0)
+        assert.equal(thinq.sent.length, 0)
+        dev.drop()
+    })
+
+    test('owner-labelled mode transitions decode without inventing unsupported modes', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', buf(BASE_HEX))
+        for (const [frame, expected] of [
+            [CLEAN_BOOSTER_HEX, 'clean_booster'],
+            [SINGLE_CLEAN_HEX, 'single_clean'],
+            [DUAL_CLEAN_HEX, 'dual_clean'],
+            [AUTO_HEX, 'auto'],
+        ] as const) {
+            thinq.emit('data', buf(frame))
+            assert.equal(ha.getProperty(DEVICE_ID, 'mode', 'state'), expected)
+        }
+        dev.drop()
+    })
+
+    test('clean-booster fan high and turbo deltas decode', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', buf(BASE_HEX))
+        thinq.emit('data', buf(BOOSTER_HIGH_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'clean_booster_fan_speed', 'state'), 'high')
+        thinq.emit('data', buf(BOOSTER_TURBO_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'clean_booster_fan_speed', 'state'), 'turbo')
+        dev.drop()
+    })
+
+    test('main fan state uses 0x1fa independently of clean-booster fan 0x326', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', buf(BASE_HEX))
+        thinq.emit('data', buf(MAIN_FAN_LOW_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'fan', 'preset_mode_state'), 'low')
+        assert.equal(ha.getProperty(DEVICE_ID, 'clean_booster_fan_speed', 'state'), 'auto')
+        dev.drop()
+    })
+
+    test('circulation rotation, indicator, and sanitization round trips decode', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', buf(BASE_HEX))
+        for (const [frame, component, expected] of [
+            [ROTATION_OFF_HEX, 'circulation_rotation', 'OFF'],
+            [ROTATION_ON_HEX, 'circulation_rotation', 'ON'],
+            [INDICATOR_OFF_HEX, 'clean_indicator', 'OFF'],
+            [INDICATOR_ON_HEX, 'clean_indicator', 'ON'],
+            [SANITIZATION_OFF_HEX, 'air_sanitization', 'OFF'],
+            [SANITIZATION_ON_HEX, 'air_sanitization', 'ON'],
+        ] as const) {
+            thinq.emit('data', buf(frame))
+            assert.equal(ha.getProperty(DEVICE_ID, component, 'state'), expected)
+        }
+        dev.drop()
+    })
+
+    test('sleep timer is minutes, counts down, and restores the indicator on cancel', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', buf(BASE_HEX))
+        thinq.emit('data', buf(SLEEP_120_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'sleep_timer', 'state'), 120)
+        assert.equal(ha.getProperty(DEVICE_ID, 'clean_indicator', 'state'), 'OFF')
+        thinq.emit('data', buf(SLEEP_119_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'sleep_timer', 'state'), 119)
+        thinq.emit('data', buf(SLEEP_CANCEL_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'sleep_timer', 'state'), 0)
+        assert.equal(ha.getProperty(DEVICE_ID, 'clean_indicator', 'state'), 'ON')
+        dev.drop()
+    })
+
+    test('short delta frames preserve omitted state and power round trip decodes', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', buf(BASE_HEX))
+        thinq.emit('data', buf(POWER_OFF_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'fan', 'state'), 'OFF')
+        assert.equal(ha.getProperty(DEVICE_ID, 'mode', 'state'), 'single_clean')
+        assert.equal(ha.getProperty(DEVICE_ID, 'pm1', 'state'), 8)
+        thinq.emit('data', buf(POWER_ON_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'fan', 'state'), 'ON')
+        dev.drop()
+    })
+
+    test('each single-tag write reproduces the frame the app itself sent', () => {
+        for (const [prop, value, captured] of [
+            ['clean_booster_fan_speed-', 'medium', CMD_BOOSTER_MEDIUM],
+            ['clean_booster_fan_speed-', 'turbo', CMD_BOOSTER_TURBO],
+            ['circulation_rotation-', 'OFF', CMD_ROTATION_OFF],
+            ['circulation_rotation-', 'ON', CMD_ROTATION_ON],
+            ['clean_indicator-', 'OFF', CMD_INDICATOR_OFF],
+            ['clean_indicator-', 'ON', CMD_INDICATOR_ON],
+            ['air_sanitization-', 'OFF', CMD_STERILIZE_OFF],
+            ['air_sanitization-', 'ON', CMD_STERILIZE_ON],
+            ['sleep_timer-', '0', CMD_SLEEP_CANCEL],
+        ] as const) {
+            const { thinq, dev } = makeDevice()
+            thinq.emit('data', buf(BASE_HEX))
+            thinq.resetRecorder()
+
+            dev.setProperty(prop, value)
+            const want = commandTlvs(captured)
+            const got = sentTlvs(thinq)
+            for (const [tag, v] of Object.entries(want)) {
+                assert.equal(got[Number(tag)], v, `${prop}=${value} tag 0x${Number(tag).toString(16)}`)
+            }
+            dev.drop()
+        }
+    })
+
+    test('mode and fan writes force power on, because the unit ignores them while off', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.emit('data', buf(BASE_HEX))
+
+        // Mode: reproduces the app's mode tag and attaches power + fan.
+        thinq.resetRecorder()
+        dev.setProperty('mode-', 'single_clean')
+        let got = sentTlvs(thinq)
+        assert.equal(got[0x1f9], commandTlvs(CMD_MODE_SINGLE)[0x1f9])
+        assert.equal(got[0x1f7], 1, 'power is attached so the write is not ignored')
+
+        thinq.resetRecorder()
+        dev.setProperty('mode-', 'clean_booster')
+        got = sentTlvs(thinq)
+        assert.equal(got[0x1f9], commandTlvs(CMD_MODE_BOOSTER)[0x1f9])
+
+        // Main fan speed does the same.
+        thinq.resetRecorder()
+        dev.setProperty('fan-preset_mode', 'high')
+        got = sentTlvs(thinq)
+        assert.equal(got[0x1fa], 6)
+        assert.equal(got[0x1f7], 1)
+
+        dev.drop()
+    })
+
+    test('power on restores mode and fan in one frame; power off does not', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.emit('data', buf(BASE_HEX))
+
+        thinq.resetRecorder()
+        dev.setProperty('fan-', 'ON')
+        let got = sentTlvs(thinq)
+        assert.equal(got[0x1f7], 1)
+        assert.equal(got[0x1f9], 14, 'last mode is restored')
+        assert.equal(got[0x1fa], 8, 'last fan speed is restored')
+
+        thinq.resetRecorder()
+        dev.setProperty('fan-', 'OFF')
+        got = sentTlvs(thinq)
+        assert.equal(got[0x1f7], 0)
+        assert.equal(got[0x1f9], undefined, 'nothing is attached when switching off')
+        assert.equal(got[0x1fa], undefined)
+
+        dev.drop()
+    })
+
+    test('sensors are not writable and malformed frames change nothing', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', buf(BASE_HEX))
+        thinq.resetRecorder()
+
+        for (const prop of ['pm25-', 'air_quality-', 'error-', 'filter_life-']) {
+            dev.setProperty(prop, '42')
+        }
+        thinq.emit('data', buf(TRUNCATED_HEX))
+        thinq.emit('data', Buffer.from([0, 1, 2, 3]))
+
+        assert.equal(thinq.outbox.length, 0, 'no sensor write reaches the wire')
+        assert.equal(thinq.sent.length, 0)
+        assert.equal(ha.getProperty(DEVICE_ID, 'fan', 'state'), 'ON')
+        assert.equal(ha.getProperty(DEVICE_ID, 'pm25', 'state'), 8)
+        dev.drop()
+    })
+})


### PR DESCRIPTION
## Summary

Adds support for the LG PuriCare **AS309DWA** air purifier (ThinQ model `AIR_910604_WW`, `deviceType` 402), registers it in the Home Assistant bridge, and documents it in the README.

The appliance uses the `0xA7` TLV protocol and sends both full state reports and short changed-tag notifications.

## Home Assistant entities

Controllable:

- `fan` — power and main fan speed (low / medium / high / turbo / auto)
- `select` — operating mode: Clean Booster, single clean, dual clean, auto
- `select` — Clean Booster circulation fan speed
- `switch` — circulation fan rotation, clean indicator light, air sterilization
- `number` — sleep timer in minutes

Reported only:

- appliance air-quality and odour indices
- PM1.0 / PM2.5 / PM10
- remaining time and rated lifetime for both filters, reported directly in hours
- diagnostic error code

Temperature (`0x1fd`) and humidity (`0x336`) are deliberately omitted because prior exact-model testing found that neither tracks room conditions.

## Protocol findings

Each writable tag was confirmed by operating the physical unit and matching the resulting command frame. Tests assert that writes reproduce the captured TLVs.

| Tag | Meaning | Values |
|---|---|---|
| `0x1f7` | power | 0 / 1 |
| `0x1f9` | mode | 13 Clean Booster, 14 single clean, 15 dual clean, 16 auto |
| `0x1fa` | main fan | 2 low, 4 medium, 6 high, 7 turbo, 8 auto |
| `0x326` | Clean Booster fan | same levels |
| `0x327` | circulation rotation | 0 / 1 |
| `0x24e` | clean indicator | 0 / 1 |
| `0x360` | air sterilization | 0 / 1 |
| `0x21a` | sleep timer | minutes, counts down |
| `0x240` / `0x241` | air-quality / odour index | read-only |
| `0x333` / `0x334` / `0x335` | PM1.0 / PM2.5 / PM10 | read-only |
| `0x355` / `0x356` | lower filter remaining / rated lifetime | hours |
| `0x363` / `0x364` | top filter remaining / rated lifetime | hours |
| `0x221` | error code | read-only |

The product UI names mode 13 “Clean Booster” and mode 14 “Single clean”, so those names are used instead of the generic model-metadata labels.

## Appliance quirks

1. A write received while the unit is off is acknowledged and ignored. Mode and fan writes therefore attach the power tag and start the unit in the requested state. Switching off attaches nothing.
2. In auto mode the appliance controls the fan itself and ignores a bare fan write. The handler does not silently change the operating mode.
3. Setting the sleep timer switches the clean indicator off. This is appliance behavior and is only reported by the handler.

## Passive state handling

Bridge-side captures confirm that the purifier sends A7 state frames and changed-tag notifications without a preceding values query. The normal `0x1f5=1` capabilities query produced no response for this exact model, so the handler uses its captured, fixed field map and does not poll.

`isValuesResponse()` includes the same minimum-TLV-count guard used by `RAC_056905_WW`, preventing a power-only notification from being classified as a full values response.

## Prior exact-model work

The field-name baseline, main-fan captures, filter semantics, and appliance quirks were cross-checked against:

- https://github.com/sosohage2/rethink-korea/commit/c3cf55975c913e206586b7e883b88fe12687a70c
- https://github.com/sosohage2/rethink-korea/commit/387be48a1be28b02dd9691daf58b903a78435287

This PR additionally contributes newly captured Clean Booster fan (`0x326`) and circulation rotation (`0x327`) controls, product-UI mode names, and delta-first discovery.

## Tests

Real captured fixtures are validated for envelope length and CRC. The suite covers:

- all four modes and independent main/Clean Booster fan speeds
- power, rotation, indicator, sterilization, and sleep timer state/write paths
- raw filter remaining/rated lifetime values in hours for both filters
- delta-first discovery and preservation of omitted state
- malformed frames and read-only sensor behavior
- bridge routing for the exact model ID
- `isValuesResponse()` rejection of short power notifications

Verified locally: `npm run check`, `npm run build`, `npm test` (**481/481**).