### PR TITLE
Add LG S5MPC Styler support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 dist
 oauth.json
 state
+captures/

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The following appliances are currently supported in rethink:
     - 👍 HCED3015D (STUDIO_HOOD), Generic identifier and probably works with multiple models. Working.
 - Stylers:
     - 👍 S5BBP (ST_B_E4H01Y_APL), Styler - mostly working
+    - 👍 S5MPC, Styler - course start / reserve / smart courses, remote-start state, error state, smart-diagnosis state, plus Power off
 
 The supported appliances can be used "out of the box" with HomeAssistant or another compatible MQTT consumer.  
 Appliances not listed above can still be used with the bridge mode, but they will not be translated to MQTT. Contributions are welcome!

--- a/cloud/devices/S5MPC.ts
+++ b/cloud/devices/S5MPC.ts
@@ -2,7 +2,7 @@ import { Device as Thinq2Device } from '../thinq2/device'
 import log from '@/util/logging'
 import { type Connection } from '../homeassistant'
 import { type Metadata } from '../thinq'
-import { readFileSync, writeFileSync } from 'node:fs'
+import { readFileSync, openSync, writeSync, fsyncSync, closeSync, renameSync, unlinkSync } from 'node:fs'
 import { allowExtendedType } from '@/util/casting'
 import HADevice from './base'
 import AABBDevice from './aabb_device'
@@ -378,21 +378,53 @@ export default class Device extends AABBDevice {
         // window for a torn write. Skip the write when the serialized entry
         // is identical to what was last written.
         if (serialized === this.lastSavedMemory) return
+        // Crash-safety: writing straight onto the shared file can leave a
+        // torn (truncated) JSON if the process dies mid-write, and every
+        // later restart would then boot with amnesia. Write to a temp file,
+        // fsync it, and atomically rename over the target so readers only
+        // ever see the old-complete or the new-complete file, never half.
+        const file = courseMemoryFile()
+        const tmp = `${file}.${process.pid}.tmp`
         try {
             let all: Record<string, unknown> = {}
             try {
-                all = JSON.parse(readFileSync(courseMemoryFile(), 'utf8')) as Record<string, unknown>
+                all = JSON.parse(readFileSync(file, 'utf8')) as Record<string, unknown>
             } catch {
                 // no memory file yet — create it below
             }
             all[this.id] = entry
-            writeFileSync(courseMemoryFile(), JSON.stringify(all))
+            const fd = openSync(tmp, 'w')
+            try {
+                writeSync(fd, JSON.stringify(all))
+                fsyncSync(fd)
+            } finally {
+                closeSync(fd)
+            }
+            renameSync(tmp, file)
             this.lastSavedMemory = serialized
         } catch (err) {
+            try {
+                unlinkSync(tmp)
+            } catch {
+                // best effort cleanup of the temp file
+            }
             log('status', this.id, `course memory save failed: ${err}`)
         }
     }
     private lastSavedMemory: string | undefined
+
+    // The shared AABBDevice base never checks the checksum it writes in
+    // send() — override here to verify it on receive too, so a corrupted or
+    // truncated frame on the wire cannot be decoded as a real status update.
+    // Scoped to this device only: the base class is shared with every other
+    // handler in the repo and some of those never captured a checksummed
+    // fixture, so changing it there would break unrelated devices.
+    processData(buf: Buffer) {
+        if (buf.length < 4 || buf[0] !== 0xaa || buf[buf.length - 1] !== 0xbb) return
+        const sum = buf.subarray(0, buf.length - 2).reduce((pv, cv) => pv + cv, 0)
+        if (buf[buf.length - 2] !== ((sum & 0xff) ^ 0x55)) return
+        this.processAABB(buf.subarray(2, buf.length - 2))
+    }
 
     private observeOutgoing(buf: Buffer) {
         if (buf.length < 4 || buf[0] !== 0xaa || buf[buf.length - 1] !== 0xbb) return

--- a/cloud/devices/S5MPC.ts
+++ b/cloud/devices/S5MPC.ts
@@ -370,6 +370,14 @@ export default class Device extends AABBDevice {
     }
 
     private saveMemory(): void {
+        const entry = { smart: this.selectedSmart, smartSelected: this.smartSelected }
+        const serialized = JSON.stringify(entry)
+        // Every recognised status frame calls remember(), which used to mean
+        // every poll rewrote the whole shared file even when nothing in this
+        // device's entry actually changed — needless flash wear and a wider
+        // window for a torn write. Skip the write when the serialized entry
+        // is identical to what was last written.
+        if (serialized === this.lastSavedMemory) return
         try {
             let all: Record<string, unknown> = {}
             try {
@@ -377,12 +385,14 @@ export default class Device extends AABBDevice {
             } catch {
                 // no memory file yet — create it below
             }
-            all[this.id] = { smart: this.selectedSmart, smartSelected: this.smartSelected }
+            all[this.id] = entry
             writeFileSync(courseMemoryFile(), JSON.stringify(all))
+            this.lastSavedMemory = serialized
         } catch (err) {
             log('status', this.id, `course memory save failed: ${err}`)
         }
     }
+    private lastSavedMemory: string | undefined
 
     private observeOutgoing(buf: Buffer) {
         if (buf.length < 4 || buf[0] !== 0xaa || buf[buf.length - 1] !== 0xbb) return

--- a/cloud/devices/S5MPC.ts
+++ b/cloud/devices/S5MPC.ts
@@ -603,7 +603,6 @@ export default class Device extends AABBDevice {
                         state_class: 'total_increasing',
                         suggested_display_precision: 0,
                         icon: 'mdi:lightning-bolt',
-                        entity_category: 'diagnostic',
                     }),
                 },
             }),

--- a/cloud/devices/S5MPC.ts
+++ b/cloud/devices/S5MPC.ts
@@ -661,7 +661,11 @@ export default class Device extends AABBDevice {
                 this.downloadSmartCourse(id)
                 this.publishProperty('smart_course_select', mqttValue)
                 this.publishProperty('course_select', COURSE.map(10))
-                return this.echo('smart_course', mqttValue)
+                // Publish, not echo: the download above is sent unconditionally
+                // (even while powered off), so the sensor must reflect the
+                // selection the same way smart_course_select already does.
+                // The next real state frame still overwrites it.
+                return this.publishProperty('smart_course', mqttValue)
             }
             case 'reserve_hours': {
                 const hours = Number(mqttValue)

--- a/cloud/devices/S5MPC.ts
+++ b/cloud/devices/S5MPC.ts
@@ -1,0 +1,633 @@
+import { Device as Thinq2Device } from '../thinq2/device'
+import log from '@/util/logging'
+import { type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import HADevice from './base'
+import AABBDevice from './aabb_device'
+import { Enum } from '@/util/enum'
+
+/*
+ * LG Styler (S5MPC), deviceType 203.
+ *
+ * The appliance cannot be powered on remotely (a safety lockout LG's own app
+ * honours too), and remote start itself takes no command — the app only
+ * reports it. Everything else below was driven from the app on 2026-09-07
+ * (227 wire frames, 83 LG cloud snapshots) and reproduced byte for byte.
+ *
+ * READ. `aa <len> 31 <seq> | [ <len16 BE> <record> ]… | <ck> bb`, every record
+ * 27 bytes. The trailing record is the current state; a leading one, when
+ * present, is the previous state. Frames that do not split into whole 27-byte
+ * records are not state and are ignored: the 8-byte `aa 08 31 00 24 00` ACKs,
+ * the 9-byte `aa 09 31 72 00 …` notifications that accompany remote-start
+ * transitions (seen with both 0xc8 and 0xc9, undecoded), and the 55-byte
+ * downloadable-course name list.
+ *
+ * Offsets WITHIN a 27-byte record:
+ *
+ *   0 state         — 0 POWEROFF, 1 INITIAL, 3 PAUSE, 8 RESERVED and 50
+ *                     PRESTEAM each seen on the wire while LG reported exactly
+ *                     that state. Code 6 (DIAGNOSIS) never appeared; it is in
+ *                     the table because modelJSON lists DIAGNOSIS in `Value`
+ *                     and the sibling S5BBP measures it at code 6.
+ *   1..2 remainTimeHour/Minute — e.g. `00 27` read 39 minutes in both the
+ *                     PRESTEAM and PAUSE captures; modelJSON names these exact
+ *                     fields in this order.
+ *   3..4 initialTimeHour/Minute — the same captures read `00 27` (39 minutes),
+ *                     with the field order declared by modelJSON.
+ *   5 course        — LG's course id (10 only ever appears while a smart
+ *                     course runs; it has no plain start frame).
+ *   6 error         — read 0 in all 165 records while LG reported ERROR_NO.
+ *                     Homology-inferred (the S5BBP error byte shifted by the
+ *                     2-byte shorter record prefix); no non-zero code was ever
+ *                     observed, so unknown codes are reported as `Code N`
+ *                     rather than mapped.
+ *   7 preState      — same code set as state, cross-checked the same way.
+ *   12..13 reserveTimeHour/Minute — 19/3-hour reservations and the 18:59
+ *                     countdown each read back exactly as LG reported them.
+ *   14 flagsA       — bit 0x08 is remoteStart: six ON/OFF transitions each
+ *                     arrived on this bit in the same second LG's cloud
+ *                     reported REMOTE_START_ON/OFF.
+ *   17..18 power, big-endian 16-bit — the owner confirmed the reported value
+ *                     is watts. The offset still needs a non-zero running
+ *                     capture: every record in this session read 0 while the
+ *                     cloud also reported 0.
+ *   20 smartCourse  — LG's smart-course id, cross-checked on all four
+ *                     captured smart runs (76/93/99/121).
+ *
+ * WRITE. Settings go out as
+ *
+ *   aa <len> f0 24 <controlDataType> <valueLength> <value…> <ck> bb
+ *
+ *   01 POWERON/POWEROFF          len 1   off 0 (ON never captured: the app
+ *                                       cannot switch the appliance on)
+ *   04 PAUSE                     len 1   0
+ *
+ * and course control as
+ *
+ *   start   aa 34 f0 26 | <9-byte head> <37-byte params> | ck bb
+ *   resume  aa 33 f0 26 | <course id> <44 zero bytes> | ck bb
+ *   download aa 36 f0 25 | 03 2d <9-byte zeroed head> <37-byte params> | ck bb
+ *
+ * The 9-byte head is `<id> 01 <smartId> <04|02=store> 00 00 <reserveHour> 00
+ * 00`: smartId is the smart-course id (0 for plain courses), reserveHour is
+ * the reservation delay in hours (0 = start now; LG declares 3..19). The
+ * params are the entry's own modelJSON `function` defaults in declaration
+ * order, with `TimeDry` folded into bit 0x80 of the first byte — and that
+ * rule reproduces all 20 captured start frames and all 4 captured download
+ * frames byte for byte (checked by script before this driver was written).
+ *
+ * A smart start is always sent as the download + start pair, in that order —
+ * that is exactly what the app emitted before each of the four captured
+ * smart runs.
+ */
+const RECORD_LEN = 27
+const STATE_TAG = 0x31
+
+/** Offsets WITHIN a record. */
+const OFF = {
+    state: 0,
+    remainTimeHour: 1,
+    remainTimeMinute: 2,
+    initialTimeHour: 3,
+    initialTimeMinute: 4,
+    course: 5,
+    error: 6,
+    preState: 7,
+    reserveTimeHour: 12,
+    reserveTimeMinute: 13,
+    flagsA: 14,
+    energyHigh: 17,
+    energyLow: 18,
+    smartCourse: 20,
+} as const
+
+/** byte 14 */
+const F_REMOTE_START = 0x08
+
+/** Command frame opcode: `aa <len> f0 24 …`. */
+const SET_STATE = [0xf0, 0x24]
+
+/** modelJSON `ControlWifi` controlDataType ids, as the captured frames carry them. */
+const CTRL_POWER = 0x01
+const CTRL_PAUSE = 0x04
+
+/** Course start, resume and smart-download travel under their own opcodes. */
+const RUN_COURSE = [0xf0, 0x26]
+const DOWNLOAD_COURSE = [0xf0, 0x25]
+/** Resume carries the course id and nothing else, one byte shorter than a start block. */
+const RESUME_BLOCK_LEN = 45
+/** `<id> 01 <smartId> <04|02=store> 00 00 <reserveHour> 00 00`. */
+const HEAD_LEN = 9
+/** `03 2d`, then the head with smartId set and store/reserve zeroed. */
+const DOWNLOAD_PREFIX = [0x03, 0x2d]
+
+/** `styler.state` code 0. */
+const STATE_POWEROFF = 0
+/** `styler.state` code for smart diagnosis. Never observed; see the header. */
+const STATE_DIAGNOSIS = 6
+
+/** LG's reservation range. 0 means no reservation (start now). */
+const RESERVE_MAX = 19
+
+/*
+ * `styler.state`, which is NOT positional — the running codes jump to 50 and
+ * up, as on the S5BBP. Every code below except Smart diagnosing was seen on
+ * the wire while LG's cloud reported exactly that state.
+ */
+const STATE = Enum.of({
+    'Power off': 0, // POWEROFF
+    Standby: 1, // INITIAL
+    Pause: 3, // PAUSE
+    Reserved: 8, // RESERVED
+    'Steam preparing': 50, // PRESTEAM
+    'Smart diagnosing': 6, // DIAGNOSIS — modelJSON-declared, not yet observed
+})
+
+/*
+ * modelJSON `Course`, id -> name. Labels follow the sibling S5BBP wherever
+ * the id is shared; the cloud names observed this session agree with them.
+ * Id 10 never runs on its own — it only appears as the base of smart runs.
+ */
+const COURSE = Enum.of({
+    None: 0,
+    'Styling Standard': 1,
+    'Styling Quick': 3,
+    'Styling Intensive': 5,
+    'Wool/Knit': 6,
+    'Suit/Coat': 7,
+    Functionality: 8,
+    'Smart Course Base': 10,
+    'Sterilize Standard': 11,
+    'Bedding Sterilize': 12,
+    'Auto Dry': 15,
+    'Timed Dry 30': 17,
+    'Timed Dry 60': 18,
+    'Timed Dry 90': 19,
+    'Timed Dry 120': 20,
+    'Padding Care': 28,
+    'Fine dust': 30,
+    Virus: 31,
+    'Jeans Care': 32,
+    'Fur/Leather Care': 33,
+    'Suit/Uniform Sterilize': 36,
+})
+
+/*
+ * modelJSON `SmartCourse`, id -> name. Labels are LG's own
+ * `ControlConvertingRule` vocabulary in title case (id 76 keeps LG's
+ * "Raing" spelling). Id 1 is LG's panel-pairing pseudo-course.
+ */
+const SMART_COURSE = Enum.of({
+    None: 0,
+    'Panel course': 1,
+    'Suits Uniforms': 61,
+    Scarves: 62,
+    Pants: 66,
+    Silent: 67,
+    'Coat Warmer': 68,
+    'Static Removal': 69,
+    'Stored Items': 71,
+    'Blanket Warmer': 73,
+    'Dress Shirts': 75,
+    'Snow Raing Drying': 76,
+    'Fur Leather': 78,
+    'Jeans Management': 93,
+    'Baby Clothing Sanitary': 94,
+    'Doll Sanitary': 95,
+    'Wool Delicate Dry': 96,
+    'Rainy Days': 97,
+    Uniform: 98,
+    'Padding Management': 99,
+    'Thin Padding Management': 100,
+    'Thick Padding Management': 101,
+    'Silk Care': 102,
+    'Athleisure Refresh': 112,
+    'Athleisure Dry': 113,
+    'Swimsuit Dry': 114,
+    'Golf Wear Care': 120,
+    'Golf Wear Dry': 121,
+})
+
+/*
+ * The parameter half of a start/download block: each entry's own modelJSON
+ * `function` defaults in declaration order, with `TimeDry` folded into bit
+ * 0x80 of the first byte. Generated from S5MPC.model.json by that rule and
+ * verified byte-for-byte against all 24 captured start/download frames; the
+ * suite re-checks a sample of them.
+ *
+ * Ids are LG's course ids, the same ones the state frame reports. Base 8 and
+ * 12 exist only on this model (the sibling S5BBP has no blocks for them).
+ */
+const COURSE_PARAMS: Record<number, string> = {
+    1: '02645a00000005005a05b45a01b4001ab40000000000000000000000000000000000000000', // Styling Standard
+    3: '82645a00000003005a00000001b4000eb40000000000000000000000000000000000000000', // Styling Quick
+    5: '02645a00000007005a05c85a01c80031b40000000000000000000000000000000000000000', // Styling Intensive
+    6: '82000000000004000000000001000014780000000000000000000000000000000000000000', // Wool/Knit
+    7: '82645a00000004005a04b45a01b40017780000000000000000000000000000000000000000', // Suit/Coat
+    8: '0200000000000300000000000000001400000000000000000400000300000178001a780000', // Functionality
+    11: '0200002d000006000008000003000023780000000000000000000000000000000000000000', // Sterilize Standard
+    12: '0200002d000006000008000003000028000000000000000000000000000000000000000000', // Bedding Sterilize
+    15: '0000000000000000000000000000005a780000000000000000000000000000000000000000', // Auto Dry
+    17: '8000000000000000000000000000001e780000000000000000000000000000000000000000', // Timed Dry 30
+    18: '8000000000000000000000000000003c780000000000000000000000000000000000000000', // Timed Dry 60
+    19: '8000000000000000000000000000005a780000000000000000000000000000000000000000', // Timed Dry 90
+    // Identical to Timed Dry 60 on purpose: LG's modelJSON gives course 20 a Drying1_Time
+    // default of 60, the same as course 18.
+    20: '8000000000000000000000000000003c780000000000000000000000000000000000000000', // Timed Dry 120
+    28: '82005a00000005005a05b45a01b4002eb40000000000000000000000000000000000000000', // Padding Care
+    30: '82000000000000000000000005c80000000000000000000003005a02c85a01c80028c80000', // Fine dust
+    31: '8200002d000007000008000003000043000000000000000000000000000000000000000000', // Virus
+    32: '8200002d000006000008000003000028000000000000000000000000000000000000000000', // Jeans Care
+    33: '8000000000000000000000000000001e780000000000000000000000000000000000000000', // Fur/Leather Care
+    36: '8200002d00000600000800000300002b780000000000000000000000000000000000000000', // Suit/Uniform Sterilize
+}
+
+/** Smart params the same way: `[paramsHex, baseCourseId]`. */
+const SMART_PARAMS: Record<number, [string, number]> = {
+    61: ['8200002d000006000008000003000023780000000000000000000000000000000000000000', 10],
+    62: ['82000000000004000000000001000010780000000000000000000000000000000000000000', 10],
+    66: ['02000000000006000000000001000023000000000000000004000000000001b40019b40000', 10],
+    67: ['8200000000000400000200000200002800000000000000000700000300000200003a000000', 67],
+    68: ['8000000000000000000000000000000a780000000000000000000000000000000000000000', 10],
+    69: ['82000000000002000000000001780005780000000000000000000000000000000000000000', 10],
+    71: ['82000000000005005a05a05a0178001aa00000000000000000000000000000000000000000', 10],
+    73: ['8000000000000000000000000000001e780000000000000000000000000000000000000000', 10],
+    75: ['82000000000007000002c80001000064780000000000000000000000000000000000000000', 10],
+    76: ['0200000000000300000000000100002d780000000000000000000000000000000000000000', 10],
+    78: ['8000000000000000000000000000001e780000000000000000000000000000000000000000', 78],
+    93: ['8200002d000006000008000003000028000000000000000000000000000000000000000000', 32],
+    94: ['0200002d00000500000800000300001f000000000000000000000000000000000000000000', 13],
+    95: ['0200002d000006000008000003000030000000000000000000000000000000000000000000', 14],
+    96: ['80000000000000000000000000000096780000000000000000000000000000000000000000', 16],
+    97: ['8000000000000000000000000000005a780000000000000000000000000000000000000000', 10],
+    98: ['02000000000000000000000005c80000000000000000000008005a07c85a01c80031b40000', 27],
+    99: ['82005a00000005005a05b45a01b4002eb40000000000000000000000000000000000000000', 28],
+    100: ['80000000000000000000000008b40037780000000000000000000000000008b4000ab40000', 17],
+    101: ['80000000000000000000000005b4006e780000000000000000000000000005b4001eb40000', 17],
+    102: ['82000000000001005a00000001b40014b40000000000000000000000000000000000000000', 16],
+    112: ['02005a00000003000005a00001a00017a00000000000000000000000000000000000000000', 10],
+    113: ['80000000000000000000000000000064780000000000000000000000000000000000000000', 17],
+    114: ['80000000000000000000000000000050780000000000000000000000000000000000000000', 17],
+    120: ['02005a00000003005a0000000000000fa00000000000000003005a03005a01a00017a00000', 8],
+    121: ['80000000000000000000000000000055780000000000000000000000000000000000000000', 17],
+}
+
+/** The courses the app can be told to run: every controllable id. */
+const COURSE_IDS = [1, 3, 5, 6, 7, 8, 11, 12, 15, 17, 18, 19, 20, 28, 30, 31, 32, 33, 36]
+const COURSE_OPTIONS = COURSE_IDS.map((id) => COURSE.map(id)).filter((name) => name !== undefined)
+const SMART_IDS = [
+    61, 62, 66, 67, 68, 69, 71, 73, 75, 76, 78, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 112, 113, 114, 120, 121,
+]
+const SMART_OPTIONS = SMART_IDS.map((id) => SMART_COURSE.map(id)).filter((name) => name !== undefined)
+
+export default class Device extends AABBDevice {
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+
+        const sensor = (id: string, name: string, extra: object = {}) => ({
+            platform: 'sensor',
+            unique_id: `$deviceid-${id}`,
+            state_topic: `$this/${id}`,
+            name,
+            ...extra,
+        })
+        const flag = (id: string, name: string, extra: object = {}) => ({
+            platform: 'binary_sensor',
+            unique_id: `$deviceid-${id}`,
+            state_topic: `$this/${id}`,
+            name,
+            payload_on: 'ON',
+            payload_off: 'OFF',
+            ...extra,
+        })
+        const minutes = (id: string, name: string, extra: object = {}) =>
+            sensor(id, name, {
+                device_class: 'duration',
+                unit_of_measurement: 'min',
+                state_class: 'measurement',
+                ...extra,
+            })
+        /** A reading taken from one of the tables above. */
+        const reading = (id: string, name: string, table: Enum<string>, extra: object = {}) =>
+            sensor(id, name, {
+                device_class: 'enum',
+                options: table.options,
+                ...extra,
+            })
+        /** A flag the appliance takes a command for. */
+        const toggle = (id: string, name: string, extra: object = {}) => ({
+            platform: 'switch',
+            unique_id: `$deviceid-${id}`,
+            state_topic: `$this/${id}`,
+            command_topic: `$this/${id}/set`,
+            name,
+            payload_on: 'ON',
+            payload_off: 'OFF',
+            ...extra,
+        })
+        /** A setting the appliance takes a command for, offered as LG's own labels. */
+        const choice = (id: string, name: string, options: string[], extra: object = {}) => ({
+            platform: 'select',
+            unique_id: `$deviceid-${id}`,
+            state_topic: `$this/${id}`,
+            command_topic: `$this/${id}/set`,
+            name,
+            options,
+            ...extra,
+        })
+        /** A one-shot command with no state of its own. */
+        const press = (id: string, name: string, icon: string) => ({
+            platform: 'button',
+            unique_id: `$deviceid-${id}`,
+            command_topic: `$this/${id}/set`,
+            payload_press: '',
+            name,
+            icon,
+        })
+        const hours = (id: string, name: string, extra: object = {}) => ({
+            platform: 'number',
+            unique_id: `$deviceid-${id}`,
+            state_topic: `$this/${id}`,
+            command_topic: `$this/${id}/set`,
+            name,
+            min: 0,
+            max: RESERVE_MAX,
+            step: 1,
+            unit_of_measurement: 'h',
+            ...extra,
+        })
+
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: 'LG Styler' }),
+                components: {
+                    power_off: press('power_off', 'Power off', 'mdi:power'),
+                    status: reading('status', 'Status', STATE, { icon: 'mdi:hanger' }),
+                    course: reading('course', 'Course', COURSE, { icon: 'mdi:playlist-check' }),
+                    // Choosing a course does not start it — LG's own app works the same way.
+                    course_select: choice('course_select', 'Course select', COURSE_OPTIONS, {
+                        icon: 'mdi:playlist-edit',
+                    }),
+                    smart_course: reading('smart_course', 'Smart course', SMART_COURSE, {
+                        icon: 'mdi:playlist-star',
+                    }),
+                    smart_course_select: choice('smart_course_select', 'Smart course select', SMART_OPTIONS, {
+                        icon: 'mdi:playlist-edit',
+                    }),
+                    start_course: press('start_course', 'Start course', 'mdi:play-circle-outline'),
+                    pause_course: press('pause_course', 'Pause', 'mdi:pause-circle-outline'),
+                    resume_course: press('resume_course', 'Resume', 'mdi:play-pause'),
+                    remaining_time: minutes('remaining_time', 'Remaining time', { icon: 'mdi:timer-sand' }),
+                    initial_time: minutes('initial_time', 'Initial time', { icon: 'mdi:timer-outline' }),
+                    // Start modifiers, consumed by Start course: 0 starts now,
+                    // otherwise the course begins after this many hours.
+                    // LG declares 3..19; the captures ran 3 and 19.
+                    reserve_hours: hours('reserve_hours', 'Reserve hours', {
+                        icon: 'mdi:calendar-clock',
+                        entity_category: 'config',
+                    }),
+                    store: toggle('store', 'Store', {
+                        icon: 'mdi:weather-night',
+                        entity_category: 'config',
+                    }),
+                    // LG declares Reserve_Time_H as a delay before the course
+                    // starts, not a wall-clock time; 0 means no reservation.
+                    reserve_time: minutes('reserve_time', 'Reserve time', { icon: 'mdi:calendar-clock' }),
+                    // The appliance takes no command for this: the app cannot
+                    // switch remote start on or off, it only reports it.
+                    remote_start: flag('remote_start', 'Remote start', {
+                        icon: 'mdi:cellphone-check',
+                    }),
+                    // The appliance will not start a course while an error
+                    // stands, so it gets a problem sensor of its own rather
+                    // than hiding inside a text reading nobody has an
+                    // automation on.
+                    error: flag('error', 'Error', {
+                        device_class: 'problem',
+                        icon: 'mdi:check-circle',
+                        entity_category: 'diagnostic',
+                    }),
+                    // NOT an enum: only code 0 has ever been observed, so a
+                    // closed option list would be a guess. Reports Normal, or
+                    // `Code N` for anything else.
+                    error_message: sensor('error_message', 'Error message', {
+                        icon: 'mdi:alert-circle-outline',
+                        entity_category: 'diagnostic',
+                    }),
+                    smart_diagnosis: flag('smart_diagnosis', 'Smart diagnosis', {
+                        icon: 'mdi:stethoscope',
+                        entity_category: 'diagnostic',
+                    }),
+                    // The owner confirmed this reading is instantaneous power
+                    // in watts. A non-zero capture is still needed to validate
+                    // the homology-inferred byte offset; see the header.
+                    energy: sensor('energy', 'Power', {
+                        device_class: 'power',
+                        unit_of_measurement: 'W',
+                        state_class: 'measurement',
+                        suggested_display_precision: 0,
+                        icon: 'mdi:lightning-bolt',
+                        entity_category: 'diagnostic',
+                    }),
+                },
+            }),
+        )
+
+        this.publishProperty('reserve_hours', 0)
+        this.publishProperty('store', 'OFF')
+        this.publishProperty('course_select', COURSE.map(this.selectedCourse))
+        this.publishProperty('smart_course_select', SMART_COURSE.map(this.selectedSmart))
+    }
+
+    // AABBDevice strips the leading AA/len and trailing checksum/BB, so buf
+    // here starts at the 0x31 tag: `<31> <seq> | [<len16 BE> <record>]…`.
+    processAABB(buf: Buffer) {
+        if (buf[0] !== STATE_TAG) return
+        const body = buf.subarray(2)
+        // Every chunk must be a whole 27-byte record; anything else (ACKs,
+        // the 9-byte notifications, the course-name list) is not state.
+        if (body.length === 0 || body.length % (2 + RECORD_LEN) !== 0) return
+        for (let i = 0; i < body.length; i += 2 + RECORD_LEN) {
+            if (body.readUInt16BE(i) !== RECORD_LEN) return
+        }
+
+        // The trailing record is the current state; a leading one, when
+        // present, is the previous state.
+        const record = body.subarray(body.length - RECORD_LEN)
+        const at = (o: number) => record[o]
+        const flagsA = at(OFF.flagsA)
+
+        const state = at(OFF.state)
+        const errorCode = at(OFF.error)
+        this.poweredOn = state !== STATE_POWEROFF
+        this.hasProblem = errorCode !== 0
+        const published = STATE.map(state)
+        if (published !== undefined) this.publishProperty('status', published)
+        const courseName = COURSE.map(at(OFF.course))
+        if (courseName !== undefined) this.publishProperty('course', courseName)
+        const smartName = SMART_COURSE.map(at(OFF.smartCourse))
+        if (smartName !== undefined) this.publishProperty('smart_course', smartName)
+
+        // Track whatever the appliance is actually running, so both selects
+        // open on the right choice.
+        if (at(OFF.smartCourse) !== 0 && SMART_IDS.includes(at(OFF.smartCourse))) {
+            this.selectedSmart = at(OFF.smartCourse)
+            this.selectedBase = SMART_PARAMS[this.selectedSmart]?.[1] ?? this.selectedBase
+            this.smartSelected = true
+            this.publishProperty('smart_course_select', SMART_COURSE.map(this.selectedSmart))
+            this.publishProperty('course_select', COURSE.map(this.selectedBase))
+        } else if (COURSE_IDS.includes(at(OFF.course))) {
+            this.selectedCourse = at(OFF.course)
+            this.selectedBase = this.selectedCourse
+            this.smartSelected = false
+            this.publishProperty('course_select', COURSE.map(this.selectedCourse))
+        }
+
+        this.publishProperty('remaining_time', at(OFF.remainTimeHour) * 60 + at(OFF.remainTimeMinute))
+        this.publishProperty('initial_time', at(OFF.initialTimeHour) * 60 + at(OFF.initialTimeMinute))
+        this.publishProperty('reserve_time', at(OFF.reserveTimeHour) * 60 + at(OFF.reserveTimeMinute))
+
+        this.publishProperty('remote_start', (flagsA & F_REMOTE_START) !== 0 ? 'ON' : 'OFF')
+        this.publishProperty('error', this.hasProblem ? 'ON' : 'OFF')
+        this.publishProperty('error_message', errorCode === 0 ? 'Normal' : `Code ${errorCode}`)
+        this.publishProperty('smart_diagnosis', state === STATE_DIAGNOSIS ? 'ON' : 'OFF')
+        this.publishProperty('energy', (at(OFF.energyHigh) << 8) | at(OFF.energyLow))
+    }
+
+    /** What Start course will run. `smartSelected` says which select won last. */
+    private selectedCourse = COURSE_IDS[0]
+    private selectedSmart = 66
+    private smartSelected = false
+    /** Base id of the last start (smart runs resume under their base id). */
+    private selectedBase = COURSE_IDS[0]
+    private reserveHours = 0
+    private store = false
+    /** Last state the appliance itself reported. `undefined` means no state frame has arrived. */
+    private poweredOn: boolean | undefined
+    private hasProblem: boolean | undefined
+
+    /** `<id> 01 <smart> <04|02> 00 00 <reserve> 00 00` + entry params. */
+    private courseBlock(id: number, smart: number): Buffer {
+        const params = smart !== 0 ? SMART_PARAMS[smart]?.[0] : COURSE_PARAMS[id]
+        if (params === undefined) return Buffer.alloc(0)
+        const head = [id, 0x01, smart, 0x04 | (this.store ? 0x02 : 0), 0x00, 0x00, this.reserveHours, 0x00, 0x00]
+        return Buffer.concat([Buffer.from(head), Buffer.from(params, 'hex')])
+    }
+
+    /** `aa 34 f0 26 | <course block> | ck bb`. */
+    private runCourse(id: number, smart: number) {
+        const block = this.courseBlock(id, smart)
+        if (block.length === 0) return log('status', this.id, `Course cannot start ${smart !== 0 ? smart : id}`)
+        this.send(Buffer.concat([Buffer.from(RUN_COURSE), block]))
+    }
+
+    /** Smart starts go out as the download + start pair, exactly as the app sends them. */
+    private runSmartCourse(smart: number) {
+        const entry = SMART_PARAMS[smart]
+        if (entry === undefined) return log('status', this.id, `Course cannot start ${smart}`)
+        const base = entry[1]
+        const block = this.courseBlock(base, smart)
+        if (block.length === 0) return log('status', this.id, `Course cannot start ${smart}`)
+        const zeroHead = Buffer.from(block.subarray(0, HEAD_LEN))
+        zeroHead[3] = 0x00
+        zeroHead[6] = 0x00
+        this.send(
+            Buffer.concat([
+                Buffer.from(DOWNLOAD_COURSE),
+                Buffer.from(DOWNLOAD_PREFIX),
+                zeroHead,
+                block.subarray(HEAD_LEN),
+            ]),
+        )
+        this.runCourse(base, smart)
+    }
+
+    /** Resume carries the course id and nothing else. */
+    private resumeCourse(id: number) {
+        const block = Buffer.alloc(RESUME_BLOCK_LEN)
+        block[0] = id
+        this.send(Buffer.concat([Buffer.from(RUN_COURSE), block]))
+    }
+
+    /**
+     * Build and send a command frame: `aa <len> f0 24 <type> <len> <value…> <ck> bb`.
+     *
+     * The base class's `send` supplies the AA/length prefix and the checksum,
+     * so what goes in is `f0 24` plus the body — which reproduces the captured
+     * frames byte for byte.
+     */
+    private setControl(type: number, ...values: number[]) {
+        this.send(Buffer.from([...SET_STATE, type, values.length, ...values]))
+    }
+
+    /*
+     * Publish what was just asked for, without waiting for the appliance to
+     * say it. A course start can go a while without a confirming state frame,
+     * so waiting makes every control feel broken and invites a second press.
+     * The next real frame overwrites whatever is published here, so the
+     * appliance still has the last word. Known refusals are not echoed: the
+     * appliance takes nothing while powered off, and no course while an error
+     * stands.
+     */
+    private echo(prop: string, value: string | number | undefined) {
+        if (this.poweredOn !== true) return
+        if ((prop === 'course' || prop === 'smart_course') && this.hasProblem !== false) return
+        this.publishProperty(prop, value)
+    }
+
+    setProperty(prop: string, mqttValue: string) {
+        const onOff = () => (mqttValue === 'ON' ? 1 : 0)
+        switch (prop) {
+            case 'power_off':
+                // Power off is the exception: this unit keeps sending state
+                // frames while off, so the next real frame confirms the press
+                // — nothing is echoed.
+                return this.setControl(CTRL_POWER, 0)
+            case 'course_select': {
+                const id = COURSE.unmap(mqttValue)
+                if (id === undefined || !COURSE_IDS.includes(id))
+                    return log('status', this.id, `Unknown course ${mqttValue}`)
+                this.selectedCourse = id
+                this.selectedBase = id
+                this.smartSelected = false
+                // Nothing goes to the appliance until Start course — this is a choice, not a command.
+                return this.publishProperty('course_select', mqttValue)
+            }
+            case 'smart_course_select': {
+                const id = SMART_COURSE.unmap(mqttValue)
+                if (id === undefined || !SMART_IDS.includes(id))
+                    return log('status', this.id, `Unknown smart course ${mqttValue}`)
+                this.selectedSmart = id
+                this.smartSelected = true
+                return this.publishProperty('smart_course_select', mqttValue)
+            }
+            case 'reserve_hours': {
+                const hours = Number(mqttValue)
+                if (!Number.isInteger(hours) || hours < 0 || hours > RESERVE_MAX)
+                    return log('status', this.id, `Reserve hours out of range ${mqttValue}`)
+                this.reserveHours = hours
+                return this.publishProperty('reserve_hours', hours)
+            }
+            case 'store':
+                this.store = mqttValue === 'ON'
+                return this.publishProperty('store', mqttValue === 'ON' ? 'ON' : 'OFF')
+            case 'start_course':
+                if (this.smartSelected) {
+                    const entry = SMART_PARAMS[this.selectedSmart]
+                    this.selectedBase = entry?.[1] ?? this.selectedBase
+                    this.runSmartCourse(this.selectedSmart)
+                    return this.echo('smart_course', SMART_COURSE.map(this.selectedSmart))
+                }
+                this.runCourse(this.selectedCourse, 0)
+                // The course itself, so the dashboard shows what was asked for straight away.
+                return this.echo('course', COURSE.map(this.selectedCourse))
+            case 'pause_course':
+                return this.setControl(CTRL_PAUSE, 0)
+            case 'resume_course':
+                return this.resumeCourse(this.selectedBase)
+            default:
+                log('status', this.id, `Item does not support writing ${prop}`)
+        }
+    }
+}

--- a/cloud/devices/S5MPC.ts
+++ b/cloud/devices/S5MPC.ts
@@ -834,7 +834,10 @@ export default class Device extends AABBDevice {
             }
             case 'reserve_hours': {
                 const hours = Number(mqttValue)
-                if (!Number.isInteger(hours) || hours < 0 || hours > RESERVE_MAX)
+                // LG declares reservation as 0 (start now) or 3..19 hours; 1
+                // and 2 are outside the model's own range and have never
+                // been captured.
+                if (!Number.isInteger(hours) || (hours !== 0 && (hours < 3 || hours > RESERVE_MAX)))
                     return log('status', this.id, `Reserve hours out of range ${mqttValue}`)
                 this.reserveHours = hours
                 return this.publishProperty('reserve_hours', hours)

--- a/cloud/devices/S5MPC.ts
+++ b/cloud/devices/S5MPC.ts
@@ -553,11 +553,30 @@ export default class Device extends AABBDevice {
 
     /** Smart starts go out as the download + start pair, exactly as the app sends them. */
     private runSmartCourse(smart: number) {
+        if (this.downloadSmartCourse(smart)) {
+            const entry = SMART_PARAMS[smart]
+            this.runCourse(entry![1], smart)
+        }
+    }
+
+    /**
+     * Send only the download half for a smart course, without starting it.
+     * Selecting a smart course downloads it to the appliance straight away —
+     * the same select-then-start split the washer uses — so the appliance
+     * (and its next state frame) reflects the choice before Start course.
+     * Returns false when the course has no captured download.
+     */
+    private downloadSmartCourse(smart: number): boolean {
         const entry = SMART_PARAMS[smart]
-        if (entry === undefined) return log('status', this.id, `Course cannot start ${smart}`)
-        const base = entry[1]
-        const block = this.courseBlock(base, smart)
-        if (block.length === 0) return log('status', this.id, `Course cannot start ${smart}`)
+        if (entry === undefined) {
+            log('status', this.id, `Course cannot start ${smart}`)
+            return false
+        }
+        const block = this.courseBlock(entry[1], smart)
+        if (block.length === 0) {
+            log('status', this.id, `Course cannot start ${smart}`)
+            return false
+        }
         const zeroHead = Buffer.from(block.subarray(0, HEAD_LEN))
         zeroHead[3] = 0x00
         zeroHead[6] = 0x00
@@ -569,7 +588,7 @@ export default class Device extends AABBDevice {
                 block.subarray(HEAD_LEN),
             ]),
         )
-        this.runCourse(base, smart)
+        return true
     }
 
     /** Resume carries the course id and nothing else. */
@@ -636,7 +655,13 @@ export default class Device extends AABBDevice {
                     return log('status', this.id, `Unknown smart course ${mqttValue}`)
                 this.selectedSmart = id
                 this.smartSelected = true
-                return this.publishProperty('smart_course_select', mqttValue)
+                // Download straight away so the appliance holds the course before
+                // Start course — the washer's select-then-start split. The
+                // download bytes are the same ones Start course would send first.
+                this.downloadSmartCourse(id)
+                this.publishProperty('smart_course_select', mqttValue)
+                this.publishProperty('course_select', COURSE.map(10))
+                return this.echo('smart_course', mqttValue)
             }
             case 'reserve_hours': {
                 const hours = Number(mqttValue)

--- a/cloud/devices/S5MPC.ts
+++ b/cloud/devices/S5MPC.ts
@@ -490,8 +490,14 @@ export default class Device extends AABBDevice {
         if (published !== undefined) this.publishProperty('status', published)
         const courseName = COURSE.map(at(OFF.course))
         if (courseName !== undefined) this.publishProperty('course', courseName)
-        const smartName = SMART_COURSE.map(at(OFF.smartCourse))
-        if (smartName !== undefined) this.publishProperty('smart_course', smartName)
+        const smartId = at(OFF.smartCourse)
+        const smartName = SMART_COURSE.map(smartId)
+        // A zero smart id while off/idle means "not running", not "no course":
+        // the styler only reports the id while a smart course actually runs.
+        // So a polled idle frame must not wipe a course the user just armed —
+        // only a real nonzero id, or leaving smart mode, clears it.
+        if (smartName !== undefined && (smartId !== 0 || !this.smartSelected))
+            this.publishProperty('smart_course', smartName)
 
         // Track whatever the appliance is actually running, so both selects
         // open on the right choice. While a smart course runs, course_select

--- a/cloud/devices/S5MPC.ts
+++ b/cloud/devices/S5MPC.ts
@@ -296,6 +296,27 @@ const SMART_IDS = [
 ]
 const SMART_OPTIONS = SMART_IDS.map((id) => SMART_COURSE.map(id)).filter((name) => name !== undefined)
 
+// Bridge mode tunnels the app's own downloads straight to the physical
+// appliance through send_packet(), bypassing setProperty entirely — the
+// same gap fixed for RH16_T_KR. The transmitted body is deterministic per
+// smart id regardless of reserveHours/store (both are zeroed before
+// sending), so it can be matched back to a smart id the same way an
+// HA-initiated download would build it.
+const DOWNLOAD_BODY_BY_SMART_ID = new Map(
+    Object.entries(SMART_PARAMS).map(([id, [params]]) => {
+        const smart = Number(id)
+        const base = SMART_PARAMS[smart][1]
+        const head = [base, 0x01, smart, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+        const body = Buffer.concat([
+            Buffer.from(DOWNLOAD_COURSE),
+            Buffer.from(DOWNLOAD_PREFIX),
+            Buffer.from(head),
+            Buffer.from(params, 'hex'),
+        ]).toString('hex')
+        return [body, smart]
+    }),
+)
+
 export default class Device extends AABBDevice {
     /**
      * Last user selection per device id, surviving handler rebuilds. The
@@ -310,8 +331,30 @@ export default class Device extends AABBDevice {
         Device.remembered.set(this.id, { smart: this.selectedSmart, smartSelected: this.smartSelected })
     }
 
+    private observeOutgoing(buf: Buffer) {
+        if (buf.length < 4 || buf[0] !== 0xaa || buf[buf.length - 1] !== 0xbb) return
+        const inner = buf.subarray(2, buf.length - 2).toString('hex')
+        const smart = DOWNLOAD_BODY_BY_SMART_ID.get(inner)
+        if (smart === undefined) return
+        if (this.selectedSmart === smart && this.smartSelected) return
+        this.selectedSmart = smart
+        this.selectedBase = SMART_PARAMS[smart]?.[1] ?? this.selectedBase
+        this.smartSelected = true
+        this.remember()
+        this.publishProperty('smart_course_select', SMART_COURSE.map(smart))
+        this.publishProperty('course_select', COURSE.map(10))
+        this.publishProperty('smart_course', SMART_COURSE.map(smart))
+    }
+
     constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
         super(HA, thinq)
+        // Bridge mode replays app-issued commands straight to the physical
+        // appliance via send_packet(), which fires 'sendData' regardless of
+        // whether the frame originated from our own setProperty or from the
+        // tunnel. Only downloads matching one of our known bodies are
+        // recognised here; every other command already round-trips through
+        // the wire status frames this class already parses.
+        thinq.on('sendData', (buf: Buffer) => this.observeOutgoing(buf))
 
         const sensor = (id: string, name: string, extra: object = {}) => ({
             platform: 'sensor',

--- a/cloud/devices/S5MPC.ts
+++ b/cloud/devices/S5MPC.ts
@@ -615,6 +615,16 @@ export default class Device extends AABBDevice {
         // what the F24VDD washer never does — so only speak on a real
         // nonzero id and leave the last value untouched otherwise.
         if (smartId !== 0 && smartName !== undefined) this.publishProperty('smart_course', smartName)
+        else if (smartId === 0 && this.smartSelected) {
+            // Idle with an armed download: re-assert the installed selection
+            // so a stale value converges — the washer re-reports its download
+            // on every status frame.
+            const armed = SMART_COURSE.map(this.selectedSmart)
+            if (armed !== undefined) {
+                this.publishProperty('smart_course_select', armed)
+                this.publishProperty('smart_course', armed)
+            }
+        }
 
         // Track whatever the appliance is actually running, so both selects
         // open on the right choice. While a smart course runs, course_select

--- a/cloud/devices/S5MPC.ts
+++ b/cloud/devices/S5MPC.ts
@@ -172,7 +172,7 @@ const COURSE = Enum.of({
     'Wool/Knit': 6,
     'Suit/Coat': 7,
     Functionality: 8,
-    'Smart Course Base': 10,
+    'Downloaded Course': 10,
     'Sterilize Standard': 11,
     'Bedding Sterilize': 12,
     'Auto Dry': 15,
@@ -290,7 +290,7 @@ const SMART_PARAMS: Record<number, [string, number]> = {
 
 /** The courses the app can be told to run: every controllable id. */
 const COURSE_IDS = [1, 3, 5, 6, 7, 8, 11, 12, 15, 17, 18, 19, 20, 28, 30, 31, 32, 33, 36]
-const COURSE_OPTIONS = COURSE_IDS.map((id) => COURSE.map(id)).filter((name) => name !== undefined)
+const COURSE_OPTIONS = [...COURSE_IDS, 10].map((id) => COURSE.map(id)).filter((name) => name !== undefined)
 const SMART_IDS = [
     61, 62, 66, 67, 68, 69, 71, 73, 75, 76, 78, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 112, 113, 114, 120, 121,
 ]
@@ -494,13 +494,17 @@ export default class Device extends AABBDevice {
         if (smartName !== undefined) this.publishProperty('smart_course', smartName)
 
         // Track whatever the appliance is actually running, so both selects
-        // open on the right choice.
+        // open on the right choice. While a smart course runs, course_select
+        // shows the "Downloaded Course" placeholder rather than the smart
+        // course's underlying base id — Course select and Smart course select
+        // are separate choices, and this placeholder is what routes Start
+        // course to the smart course, matching the write-side convention.
         if (at(OFF.smartCourse) !== 0 && SMART_IDS.includes(at(OFF.smartCourse))) {
             this.selectedSmart = at(OFF.smartCourse)
             this.selectedBase = SMART_PARAMS[this.selectedSmart]?.[1] ?? this.selectedBase
             this.smartSelected = true
             this.publishProperty('smart_course_select', SMART_COURSE.map(this.selectedSmart))
-            this.publishProperty('course_select', COURSE.map(this.selectedBase))
+            this.publishProperty('course_select', COURSE.map(10))
         } else if (COURSE_IDS.includes(at(OFF.course))) {
             this.selectedCourse = at(OFF.course)
             this.selectedBase = this.selectedCourse
@@ -611,8 +615,15 @@ export default class Device extends AABBDevice {
                 return this.setControl(CTRL_POWER, 0)
             case 'course_select': {
                 const id = COURSE.unmap(mqttValue)
-                if (id === undefined || !COURSE_IDS.includes(id))
-                    return log('status', this.id, `Unknown course ${mqttValue}`)
+                if (id === undefined) return log('status', this.id, `Unknown course ${mqttValue}`)
+                if (id === 10) {
+                    // "Downloaded Course": id 10 never runs on its own — selecting it
+                    // and pressing Start course runs whatever Smart course select is
+                    // currently set to, the same relationship the panel itself uses.
+                    this.smartSelected = true
+                    return this.publishProperty('course_select', mqttValue)
+                }
+                if (!COURSE_IDS.includes(id)) return log('status', this.id, `Unknown course ${mqttValue}`)
                 this.selectedCourse = id
                 this.selectedBase = id
                 this.smartSelected = false

--- a/cloud/devices/S5MPC.ts
+++ b/cloud/devices/S5MPC.ts
@@ -490,8 +490,8 @@ export default class Device extends AABBDevice {
                         icon: 'mdi:playlist-edit',
                     }),
                     start_course: press('start_course', 'Start course', 'mdi:play-circle-outline'),
-                    pause_course: press('pause_course', 'Pause', 'mdi:pause-circle-outline'),
-                    resume_course: press('resume_course', 'Resume', 'mdi:play-pause'),
+                    pause: press('pause', 'Pause', 'mdi:pause-circle-outline'),
+                    resume: press('resume', 'Resume', 'mdi:play-pause'),
                     remaining_time: minutes('remaining_time', 'Remaining time', { icon: 'mdi:timer-sand' }),
                     initial_time: minutes('initial_time', 'Initial time', { icon: 'mdi:timer-outline' }),
                     // Start modifiers, consumed by Start course: 0 starts now,
@@ -831,9 +831,9 @@ export default class Device extends AABBDevice {
                 this.runCourse(this.selectedCourse, 0)
                 // The course itself, so the dashboard shows what was asked for straight away.
                 return this.echo('course', COURSE.map(this.selectedCourse))
-            case 'pause_course':
+            case 'pause':
                 return this.setControl(CTRL_PAUSE, 0)
-            case 'resume_course':
+            case 'resume':
                 return this.resumeCourse(this.selectedBase)
             default:
                 log('status', this.id, `Item does not support writing ${prop}`)

--- a/cloud/devices/S5MPC.ts
+++ b/cloud/devices/S5MPC.ts
@@ -627,9 +627,15 @@ export default class Device extends AABBDevice {
         const published = STATE.map(state)
         if (published !== undefined) this.publishProperty('status', published)
         const courseName = COURSE.map(at(OFF.course))
-        if (courseName !== undefined) this.publishProperty('course', courseName)
         const smartId = at(OFF.smartCourse)
         const smartName = SMART_COURSE.map(smartId)
+        // washer/dryer convention: `course` reports the "Downloaded Course"
+        // placeholder while a smart course is actually running (matching
+        // course_select's own placeholder), not the underlying base id —
+        // `smart_course` keeps showing the real smart course name
+        // independently, the same split as the other two devices.
+        if (smartId !== 0 && smartName !== undefined) this.publishProperty('course', COURSE.map(10))
+        else if (courseName !== undefined) this.publishProperty('course', courseName)
         // A zero smart id while off/idle means "not running", not "no course":
         // the styler only reports the id while a smart course actually runs.
         // Publishing map(0) ('None', which HA shows as unknown) here would

--- a/cloud/devices/S5MPC.ts
+++ b/cloud/devices/S5MPC.ts
@@ -297,6 +297,19 @@ const SMART_IDS = [
 const SMART_OPTIONS = SMART_IDS.map((id) => SMART_COURSE.map(id)).filter((name) => name !== undefined)
 
 export default class Device extends AABBDevice {
+    /**
+     * Last user selection per device id, surviving handler rebuilds. The
+     * bridge drops and recreates this handler on every reconnect (e.g. when
+     * the LG app takes over the session), and the fresh instance used to
+     * publish its defaults — wiping an armed smart course back to Pants.
+     */
+    private static remembered = new Map<string, { smart: number; smartSelected: boolean }>()
+
+    /** Persist the current selection so the next rebuild can restore it. */
+    private remember() {
+        Device.remembered.set(this.id, { smart: this.selectedSmart, smartSelected: this.smartSelected })
+    }
+
     constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
         super(HA, thinq)
 
@@ -459,6 +472,21 @@ export default class Device extends AABBDevice {
 
         this.publishProperty('reserve_hours', 0)
         this.publishProperty('store', 'OFF')
+        // A reconnect rebuilds this handler from defaults, which used to wipe
+        // whatever the user had armed (back to Pants). Restore the last user
+        // selection for this device instead, so app-driven reconnects and
+        // transient drops don't lose it.
+        const remembered = Device.remembered.get(this.id)
+        if (remembered !== undefined) {
+            this.selectedSmart = remembered.smart
+            this.smartSelected = remembered.smartSelected
+            if (remembered.smartSelected) {
+                this.publishProperty('course_select', COURSE.map(10))
+                this.publishProperty('smart_course_select', SMART_COURSE.map(this.selectedSmart))
+                this.publishProperty('smart_course', SMART_COURSE.map(this.selectedSmart))
+                return
+            }
+        }
         this.publishProperty('course_select', COURSE.map(this.selectedCourse))
         this.publishProperty('smart_course_select', SMART_COURSE.map(this.selectedSmart))
     }
@@ -509,12 +537,14 @@ export default class Device extends AABBDevice {
             this.selectedSmart = at(OFF.smartCourse)
             this.selectedBase = SMART_PARAMS[this.selectedSmart]?.[1] ?? this.selectedBase
             this.smartSelected = true
+            this.remember()
             this.publishProperty('smart_course_select', SMART_COURSE.map(this.selectedSmart))
             this.publishProperty('course_select', COURSE.map(10))
         } else if (COURSE_IDS.includes(at(OFF.course))) {
             this.selectedCourse = at(OFF.course)
             this.selectedBase = this.selectedCourse
             this.smartSelected = false
+            this.remember()
             this.publishProperty('course_select', COURSE.map(this.selectedCourse))
         }
 
@@ -646,12 +676,14 @@ export default class Device extends AABBDevice {
                     // and pressing Start course runs whatever Smart course select is
                     // currently set to, the same relationship the panel itself uses.
                     this.smartSelected = true
+                    this.remember()
                     return this.publishProperty('course_select', mqttValue)
                 }
                 if (!COURSE_IDS.includes(id)) return log('status', this.id, `Unknown course ${mqttValue}`)
                 this.selectedCourse = id
                 this.selectedBase = id
                 this.smartSelected = false
+                this.remember()
                 // Nothing goes to the appliance until Start course — this is a choice, not a command.
                 return this.publishProperty('course_select', mqttValue)
             }
@@ -661,6 +693,7 @@ export default class Device extends AABBDevice {
                     return log('status', this.id, `Unknown smart course ${mqttValue}`)
                 this.selectedSmart = id
                 this.smartSelected = true
+                this.remember()
                 // Download straight away so the appliance holds the course before
                 // Start course — the washer's select-then-start split. The
                 // download bytes are the same ones Start course would send first.

--- a/cloud/devices/S5MPC.ts
+++ b/cloud/devices/S5MPC.ts
@@ -132,16 +132,25 @@ const RESERVE_MAX = 19
 
 /*
  * `styler.state`, which is NOT positional — the running codes jump to 50 and
- * up, as on the S5BBP. Every code below except Smart diagnosing was seen on
- * the wire while LG's cloud reported exactly that state.
+ * up. The complete table is shared with the measured ST_B_E4H01Y_APL mapping,
+ * and every symbolic state is also declared by S5MPC.model.json. Labels use
+ * the common washer/dryer vocabulary for equivalent top-level states.
  */
 const STATE = Enum.of({
     'Power off': 0, // POWEROFF
     Standby: 1, // INITIAL
+    Running: 2, // RUNNING
     Pause: 3, // PAUSE
+    Complete: [4, 58, 59], // COMPLETE RUNNINGEND END_REMOTE_MAINTAIN_ON
+    Error: 5, // ERROR
+    'Smart diagnosis': 6, // DIAGNOSIS
+    Storing: 7, // NIGHTDRY
     Reserved: 8, // RESERVED
+    'Power-save running': 9, // SLEEP
     'Steam preparing': 50, // PRESTEAM
-    'Smart diagnosing': 6, // DIAGNOSIS — modelJSON-declared, not yet observed
+    Refreshing: [51, 52, 53], // PREHEAT STEAM STAY
+    Drying: [54, 55, 56], // COOLING DRYING ENDCOOLING
+    Sterilizing: 57, // STERILIZE
 })
 
 /*
@@ -363,6 +372,7 @@ export default class Device extends AABBDevice {
                 ...HADevice.config(meta, { name: 'LG Styler' }),
                 components: {
                     power_off: press('power_off', 'Power off', 'mdi:power'),
+                    power: flag('power', 'Power', { icon: 'mdi:power' }),
                     status: reading('status', 'Status', STATE, { icon: 'mdi:hanger' }),
                     course: reading('course', 'Course', COURSE, { icon: 'mdi:playlist-check' }),
                     // Choosing a course does not start it — LG's own app works the same way.
@@ -416,6 +426,7 @@ export default class Device extends AABBDevice {
                         entity_category: 'diagnostic',
                     }),
                     smart_diagnosis: flag('smart_diagnosis', 'Smart diagnosis', {
+                        device_class: 'problem',
                         icon: 'mdi:stethoscope',
                         entity_category: 'diagnostic',
                     }),
@@ -462,6 +473,7 @@ export default class Device extends AABBDevice {
         const errorCode = at(OFF.error)
         this.poweredOn = state !== STATE_POWEROFF
         this.hasProblem = errorCode !== 0
+        this.publishProperty('power', this.poweredOn ? 'ON' : 'OFF')
         const published = STATE.map(state)
         if (published !== undefined) this.publishProperty('status', published)
         const courseName = COURSE.map(at(OFF.course))

--- a/cloud/devices/S5MPC.ts
+++ b/cloud/devices/S5MPC.ts
@@ -47,7 +47,12 @@ import { Enum } from '@/util/enum'
  *                     countdown each read back exactly as LG reported them.
  *   14 flagsA       — bit 0x08 is remoteStart: six ON/OFF transitions each
  *                     arrived on this bit in the same second LG's cloud
- *                     reported REMOTE_START_ON/OFF.
+ *                     reported REMOTE_START_ON/OFF. Bit 0x01 is childLock:
+ *                     toggling the physical panel's child-lock button flipped
+ *                     only this bit (0x20 <-> 0x21 with flagsA otherwise 0x20)
+ *                     in the very next frame, captured 2026-09-08. LG's app
+ *                     has no control for this — it is panel-only — so it is
+ *                     exposed read-only.
  *   17..18 power, big-endian 16-bit — the owner confirmed the reported value
  *                     is watts. The offset still needs a non-zero running
  *                     capture: every record in this session read 0 while the
@@ -104,6 +109,7 @@ const OFF = {
 
 /** byte 14 */
 const F_REMOTE_START = 0x08
+const F_CHILD_LOCK = 0x01
 
 /** Command frame opcode: `aa <len> f0 24 …`. */
 const SET_STATE = [0xf0, 0x24]
@@ -409,6 +415,12 @@ export default class Device extends AABBDevice {
                     remote_start: flag('remote_start', 'Remote start', {
                         icon: 'mdi:cellphone-check',
                     }),
+                    // Panel-only feature: the physical button toggles it, LG's
+                    // app has no control for it, so it is read-only here too.
+                    child_lock: flag('child_lock', 'Child lock', {
+                        icon: 'mdi:lock',
+                        entity_category: 'diagnostic',
+                    }),
                     // The appliance will not start a course while an error
                     // stands, so it gets a problem sensor of its own rather
                     // than hiding inside a text reading nobody has an
@@ -501,6 +513,7 @@ export default class Device extends AABBDevice {
         this.publishProperty('reserve_time', at(OFF.reserveTimeHour) * 60 + at(OFF.reserveTimeMinute))
 
         this.publishProperty('remote_start', (flagsA & F_REMOTE_START) !== 0 ? 'ON' : 'OFF')
+        this.publishProperty('child_lock', (flagsA & F_CHILD_LOCK) !== 0 ? 'ON' : 'OFF')
         this.publishProperty('error', this.hasProblem ? 'ON' : 'OFF')
         this.publishProperty('error_message', errorCode === 0 ? 'Normal' : `Code ${errorCode}`)
         this.publishProperty('smart_diagnosis', state === STATE_DIAGNOSIS ? 'ON' : 'OFF')

--- a/cloud/devices/S5MPC.ts
+++ b/cloud/devices/S5MPC.ts
@@ -540,12 +540,11 @@ export default class Device extends AABBDevice {
                         icon: 'mdi:stethoscope',
                         entity_category: 'diagnostic',
                     }),
-                    // The owner confirmed this reading is instantaneous power
                     // This-cycle cumulative energy (Wh, x1) at record+17/+18.
                     // Validated 2026-09-11: a full steam cycle reported 0 in
                     // this field until completion, then 0x0251 = 593Wh,
                     // matching the ThinQ app's daily 593Wh exactly.
-                    energy: sensor('energy', 'Power', {
+                    energy: sensor('energy', 'Energy', {
                         device_class: 'energy',
                         unit_of_measurement: 'Wh',
                         state_class: 'total_increasing',

--- a/cloud/devices/S5MPC.ts
+++ b/cloud/devices/S5MPC.ts
@@ -565,10 +565,11 @@ export default class Device extends AABBDevice {
         const smartName = SMART_COURSE.map(smartId)
         // A zero smart id while off/idle means "not running", not "no course":
         // the styler only reports the id while a smart course actually runs.
-        // So a polled idle frame must not wipe a course the user just armed —
-        // only a real nonzero id, or leaving smart mode, clears it.
-        if (smartName !== undefined && (smartId !== 0 || !this.smartSelected))
-            this.publishProperty('smart_course', smartName)
+        // Publishing map(0) ('None', which HA shows as unknown) here would
+        // wipe HA's last displayed course on every rethink restart, exactly
+        // what the F24VDD washer never does — so only speak on a real
+        // nonzero id and leave the last value untouched otherwise.
+        if (smartId !== 0 && smartName !== undefined) this.publishProperty('smart_course', smartName)
 
         // Track whatever the appliance is actually running, so both selects
         // open on the right choice. While a smart course runs, course_select

--- a/cloud/devices/S5MPC.ts
+++ b/cloud/devices/S5MPC.ts
@@ -2,6 +2,7 @@ import { Device as Thinq2Device } from '../thinq2/device'
 import log from '@/util/logging'
 import { type Connection } from '../homeassistant'
 import { type Metadata } from '../thinq'
+import { readFileSync, writeFileSync } from 'node:fs'
 import { allowExtendedType } from '@/util/casting'
 import HADevice from './base'
 import AABBDevice from './aabb_device'
@@ -88,6 +89,12 @@ import { Enum } from '@/util/enum'
  */
 const RECORD_LEN = 27
 const STATE_TAG = 0x31
+
+// Persistent course memory shared with the dryer driver (see remember()).
+// Same file, keyed by device id. Overridable for tests.
+function courseMemoryFile(): string {
+    return process.env.RETHINK_MEMORY_FILE ?? '/app/data/rethink-course-memory.json'
+}
 
 /** Offsets WITHIN a record. */
 const OFF = {
@@ -329,6 +336,41 @@ export default class Device extends AABBDevice {
     /** Persist the current selection so the next rebuild can restore it. */
     private remember() {
         Device.remembered.set(this.id, { smart: this.selectedSmart, smartSelected: this.smartSelected })
+        this.saveMemory()
+    }
+
+    // Disk-backed course memory. The static remembered map dies with the
+    // process, but the appliance keeps its installed download — and reports
+    // id 0 while off/idle, so without disk the F24VDD washer convention
+    // ("smart_course always shows the installed download, never Unknown")
+    // would break on every restart. Same file as the dryer driver, keyed by
+    // device id; failures never throw.
+    private loadMemory(): { smart: number; smartSelected: boolean } | undefined {
+        try {
+            const all = JSON.parse(readFileSync(courseMemoryFile(), 'utf8')) as Record<string, unknown>
+            const entry = all[this.id]
+            if (typeof entry !== 'object' || entry === null) return undefined
+            const { smart, smartSelected } = entry as { smart?: unknown; smartSelected?: unknown }
+            if (typeof smart !== 'number' || typeof smartSelected !== 'boolean') return undefined
+            return { smart, smartSelected }
+        } catch {
+            return undefined
+        }
+    }
+
+    private saveMemory(): void {
+        try {
+            let all: Record<string, unknown> = {}
+            try {
+                all = JSON.parse(readFileSync(courseMemoryFile(), 'utf8')) as Record<string, unknown>
+            } catch {
+                // no memory file yet — create it below
+            }
+            all[this.id] = { smart: this.selectedSmart, smartSelected: this.smartSelected }
+            writeFileSync(courseMemoryFile(), JSON.stringify(all))
+        } catch (err) {
+            log('status', this.id, `course memory save failed: ${err}`)
+        }
     }
 
     private observeOutgoing(buf: Buffer) {
@@ -518,8 +560,11 @@ export default class Device extends AABBDevice {
         // A reconnect rebuilds this handler from defaults, which used to wipe
         // whatever the user had armed (back to Pants). Restore the last user
         // selection for this device instead, so app-driven reconnects and
-        // transient drops don't lose it.
-        const remembered = Device.remembered.get(this.id)
+        // transient drops don't lose it. Same-process reconnects hit the
+        // static map; real restarts fall back to the disk memory file, so
+        // smart_course keeps showing the installed download like the F24VDD
+        // washer (which re-reports it on every status frame).
+        const remembered = Device.remembered.get(this.id) ?? this.loadMemory()
         if (remembered !== undefined) {
             this.selectedSmart = remembered.smart
             this.smartSelected = remembered.smartSelected

--- a/cloud/devices/S5MPC.ts
+++ b/cloud/devices/S5MPC.ts
@@ -182,17 +182,28 @@ const COURSE = Enum.of({
     'Downloaded Course': 10,
     'Sterilize Standard': 11,
     'Bedding Sterilize': 12,
+    // 13/14/16/27/67/78 are never run on their own — they only appear as the
+    // base course of a SmartCourse (see SMART_COURSE below) — so they have
+    // no captured standalone start frame and stay out of COURSE_IDS, but the
+    // read side needs the label so a running smart course reports its base
+    // course instead of a raw code.
+    'Baby Clothing Sanitary': 13, // SmartCourse 94
+    'Doll Sanitary': 14, // SmartCourse 95
     'Auto Dry': 15,
+    'Wool/Delicate Dry': 16, // SmartCourse 96, also base of Silk Care (102)
     'Timed Dry 30': 17,
     'Timed Dry 60': 18,
     'Timed Dry 90': 19,
     'Timed Dry 120': 20,
+    'Uniform Management': 27, // SmartCourse 98
     'Padding Care': 28,
     'Fine dust': 30,
     Virus: 31,
     'Jeans Care': 32,
     'Fur/Leather Care': 33,
     'Suit/Uniform Sterilize': 36,
+    Silent: 67, // SmartCourse 67, also directly controllable
+    'Fur/Leather': 78, // SmartCourse 78, also directly controllable
 })
 
 /*

--- a/cloud/devices/S5MPC.ts
+++ b/cloud/devices/S5MPC.ts
@@ -54,10 +54,10 @@ import { Enum } from '@/util/enum'
  *                     in the very next frame, captured 2026-09-08. LG's app
  *                     has no control for this — it is panel-only — so it is
  *                     exposed read-only.
- *   17..18 power, big-endian 16-bit — the owner confirmed the reported value
- *                     is watts. The offset still needs a non-zero running
- *                     capture: every record in this session read 0 while the
- *                     cloud also reported 0.
+ *   17..18 energy, big-endian 16-bit — this-cycle cumulative Wh (x1).
+ *                     Validated 2026-09-11: a full steam cycle reported 0
+ *                     here until completion, then 0x0251 = 593Wh, matching
+ *                     the ThinQ app's daily 593Wh exactly.
  *   20 smartCourse  — LG's smart-course id, cross-checked on all four
  *                     captured smart runs (76/93/99/121).
  *
@@ -541,12 +541,14 @@ export default class Device extends AABBDevice {
                         entity_category: 'diagnostic',
                     }),
                     // The owner confirmed this reading is instantaneous power
-                    // in watts. A non-zero capture is still needed to validate
-                    // the homology-inferred byte offset; see the header.
+                    // This-cycle cumulative energy (Wh, x1) at record+17/+18.
+                    // Validated 2026-09-11: a full steam cycle reported 0 in
+                    // this field until completion, then 0x0251 = 593Wh,
+                    // matching the ThinQ app's daily 593Wh exactly.
                     energy: sensor('energy', 'Power', {
-                        device_class: 'power',
-                        unit_of_measurement: 'W',
-                        state_class: 'measurement',
+                        device_class: 'energy',
+                        unit_of_measurement: 'Wh',
+                        state_class: 'total_increasing',
                         suggested_display_precision: 0,
                         icon: 'mdi:lightning-bolt',
                         entity_category: 'diagnostic',
@@ -647,7 +649,12 @@ export default class Device extends AABBDevice {
             this.publishProperty('course_select', COURSE.map(this.selectedCourse))
         }
 
-        this.publishProperty('remaining_time', at(OFF.remainTimeHour) * 60 + at(OFF.remainTimeMinute))
+        // The appliance holds remaining at 1 minute through completion and
+        // power-off (captured 2026-09-11: state Complete and Power off both
+        // report 0h01m) while the cycle is actually done, so report 0 once
+        // nothing can remain. Running states keep the wire value as-is.
+        const finished = state === STATE_POWEROFF || published === 'Complete'
+        this.publishProperty('remaining_time', finished ? 0 : at(OFF.remainTimeHour) * 60 + at(OFF.remainTimeMinute))
         this.publishProperty('initial_time', at(OFF.initialTimeHour) * 60 + at(OFF.initialTimeMinute))
         this.publishProperty('reserve_time', at(OFF.reserveTimeHour) * 60 + at(OFF.reserveTimeMinute))
 

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -23,6 +23,7 @@ import RV13B6ES_D_US_WIFI from './devices/RV13B6ES_D_US_WIFI'
 import WTL_FXU_BDV_NA_01 from './devices/WTL_FXU_BDV_NA_01'
 import DHUM_056905_WW from './devices/DHUM_056905_WW'
 import ST_B_E4H01Y_APL from './devices/ST_B_E4H01Y_APL'
+import S5MPC from './devices/S5MPC'
 import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
 import { type Connection } from './homeassistant'
@@ -70,6 +71,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     WTL_FXU_BDV_NA_01, // LG WashTower
     DHUM_056905_WW,
     ST_B_E4H01Y_APL,
+    S5MPC,
 }
 
 class Bridge {

--- a/tests/cloud/devices/S5MPC.test.ts
+++ b/tests/cloud/devices/S5MPC.test.ts
@@ -72,6 +72,16 @@ function assertIntact(packet: Buffer) {
     assert.equal(packet[packet.length - 2], (sum & 0xff) ^ 0x55)
 }
 
+/** Model-declared state probe derived from a real frame; not capture evidence. */
+function withCurrentState(state: number) {
+    const packet = Buffer.from(POWEROFF)
+    const currentRecord = packet.length - 2 - 27
+    packet[currentRecord] = state
+    const sum = packet.subarray(0, packet.length - 2).reduce((a, b) => a + b, 0)
+    packet[packet.length - 2] = (sum & 0xff) ^ 0x55
+    return packet
+}
+
 describe(MODEL_ID, () => {
     test('the real-capture corpus is intact, not hand-written', () => {
         for (const f of [REMOTE_ON, REMOTE_OFF, PAUSE, PRESTEAM, RESERVED, POWEROFF, SMART_RUN]) assertIntact(f)
@@ -88,6 +98,7 @@ describe(MODEL_ID, () => {
             'error_message',
             'initial_time',
             'pause_course',
+            'power',
             'power_off',
             'remaining_time',
             'remote_start',
@@ -105,6 +116,25 @@ describe(MODEL_ID, () => {
         assert.equal(components.energy.device_class, 'power')
         assert.equal(components.energy.unit_of_measurement, 'W')
         assert.equal(components.energy.state_class, 'measurement')
+        assert.equal(components.power.platform, 'binary_sensor')
+        assert.equal(components.power.icon, 'mdi:power')
+        assert.equal(components.smart_diagnosis.device_class, 'problem')
+        assert.deepEqual(components.status.options, [
+            'Power off',
+            'Standby',
+            'Running',
+            'Pause',
+            'Complete',
+            'Error',
+            'Smart diagnosis',
+            'Storing',
+            'Reserved',
+            'Power-save running',
+            'Steam preparing',
+            'Refreshing',
+            'Drying',
+            'Sterilizing',
+        ])
         for (const name of [
             'power_off',
             'course_select',
@@ -118,6 +148,7 @@ describe(MODEL_ID, () => {
             assert.equal(components[name].command_topic, `$this/${name}/set`, `${name} is writable`)
         }
         for (const name of [
+            'power',
             'status',
             'course',
             'smart_course',
@@ -141,6 +172,7 @@ describe(MODEL_ID, () => {
     test('remote start follows the verified flags bit', () => {
         const { ha, thinq } = makeDevice()
         thinq.emit('data', REMOTE_ON)
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
         assert.equal(ha.devices[DEVICE_ID].properties.remote_start, 'ON')
         assert.equal(ha.devices[DEVICE_ID].properties.status, 'Standby')
         thinq.emit('data', REMOTE_OFF)
@@ -160,7 +192,18 @@ describe(MODEL_ID, () => {
         assert.equal(ha.devices[DEVICE_ID].properties.status, 'Reserved')
         assert.equal(ha.devices[DEVICE_ID].properties.reserve_time, 19 * 60)
         thinq.emit('data', POWEROFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'OFF')
         assert.equal(ha.devices[DEVICE_ID].properties.status, 'Power off')
+    })
+
+    test('uses the common Error and Smart diagnosis states declared by the model', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', withCurrentState(5))
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Error')
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
+        thinq.emit('data', withCurrentState(6))
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Smart diagnosis')
+        assert.equal(ha.devices[DEVICE_ID].properties.smart_diagnosis, 'ON')
     })
 
     test('a running smart course takes over both selects', () => {

--- a/tests/cloud/devices/S5MPC.test.ts
+++ b/tests/cloud/devices/S5MPC.test.ts
@@ -1,8 +1,15 @@
 import { describe, test } from 'node:test'
 import assert from 'node:assert/strict'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { unlinkSync } from 'node:fs'
 import DUT from '@/cloud/devices/S5MPC'
 import type { Metadata } from '@/cloud/thinq'
 import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+
+// Disk-backed course memory under test: the driver under test reads the
+// path at call time, and each makeDevice starts with no memory file.
+process.env.RETHINK_MEMORY_FILE = join(tmpdir(), 'rethink-course-memory-styler-test.json')
 
 const DEVICE_ID = 'test-id'
 const MODEL_ID = 'S5MPC'
@@ -69,6 +76,14 @@ const COURSE_LIST = buf(
 )
 
 function makeDevice() {
+    // Each test starts with no disk memory (what a fresh install sees).
+    // Static remembered state is keyed by device id alone here, so tests
+    // that need a truly fresh instance clear it themselves.
+    try {
+        unlinkSync(process.env.RETHINK_MEMORY_FILE as string)
+    } catch {
+        // nothing persisted yet — start clean
+    }
     const ha = new MockHAConnection()
     const thinq = new MockThinq2Device(DEVICE_ID, META)
     const dev = new DUT(ha.asConnection(), thinq, META)
@@ -496,5 +511,23 @@ describe(MODEL_ID, () => {
         thinq.emit('data', POWEROFF)
         assert.equal(ha.devices[DEVICE_ID].properties.smart_course, undefined)
         assert.equal(ha.devices[DEVICE_ID].properties.power, 'OFF')
+    })
+
+    test('a restart restores the armed smart course from disk memory', () => {
+        // Arm a download, wipe the in-process map (what a real restart
+        // does), then build a fresh handler: the disk memory file restores
+        // the selection, so smart_course keeps showing the installed
+        // download like the F24VDD washer.
+        const first = makeDevice()
+        first.dev.setProperty('smart_course_select', 'Golf Wear Dry')
+        ;(DUT as unknown as { remembered: Map<string, unknown> }).remembered.clear()
+        const ha2 = new MockHAConnection()
+        const thinq2 = new MockThinq2Device(DEVICE_ID, META)
+        const second = new DUT(ha2.asConnection(), thinq2, META)
+        assert.ok(second)
+        const p = ha2.devices[DEVICE_ID].properties
+        assert.equal(p.smart_course, 'Golf Wear Dry')
+        assert.equal(p.smart_course_select, 'Golf Wear Dry')
+        assert.equal(p.course_select, 'Downloaded Course')
     })
 })

--- a/tests/cloud/devices/S5MPC.test.ts
+++ b/tests/cloud/devices/S5MPC.test.ts
@@ -51,6 +51,11 @@ const RESERVED = buf(
 const POWEROFF = buf(
     'aa4031ec001b01003b003b1c000300000000000020000000000063000001634200001b00003b003b000001000000000000200000000000000000016342006cbb',
 )
+// Real post-cycle single-status frame (06:10, after the 104-minute steam
+// cycle): record+17/+18 hold 0x0251 = 593, matching the ThinQ app's daily
+// 593Wh exactly. The per-minute 0x31ec status frames report 0 in the same
+// field for the whole run and flip to 593 only at completion.
+const ENERGY_AT_COMPLETION = buf('aa2331eb001b00000100000000040000000000002000000251000000000163420077bb')
 // SMART_RUN: 09:11:49Z, trailing record runs base Time Dry 30 with smart Golf
 // Wear Dry — LG: course TIME_DRY_30, smartCourse GOLF_WEAR_DRY.
 const SMART_RUN = buf(
@@ -205,6 +210,14 @@ describe(MODEL_ID, () => {
                 `${name} is a sensor platform, got ${components[name].platform}`,
             )
         }
+    })
+
+    test('publishes this-cycle energy from the record+17 Wh counter', () => {
+        // Real post-cycle frame: 0x0251 = 593Wh, matching the ThinQ app's
+        // daily 593Wh exactly (Wh x1, same convention as washer and dryer).
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', ENERGY_AT_COMPLETION)
+        assert.equal(ha.devices[DEVICE_ID].properties.energy, 593)
     })
 
     test('remote start follows the verified flags bit', () => {

--- a/tests/cloud/devices/S5MPC.test.ts
+++ b/tests/cloud/devices/S5MPC.test.ts
@@ -443,4 +443,15 @@ describe(MODEL_ID, () => {
         dev.setProperty('reserve_hours', '-1')
         assert.equal(ha.devices[DEVICE_ID].properties.reserve_hours, 19)
     })
+
+    test('a reconnect restores the armed smart course instead of resetting to Pants', () => {
+        const first = makeDevice()
+        first.dev.setProperty('smart_course_select', 'Golf Wear Dry')
+        // A fresh handler for the same device (what a reconnect builds).
+        const { ha } = makeDevice()
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.smart_course_select, 'Golf Wear Dry')
+        assert.equal(p.smart_course, 'Golf Wear Dry')
+        assert.equal(p.course_select, 'Downloaded Course')
+    })
 })

--- a/tests/cloud/devices/S5MPC.test.ts
+++ b/tests/cloud/devices/S5MPC.test.ts
@@ -482,4 +482,19 @@ describe(MODEL_ID, () => {
         assert.equal(p.smart_course, 'Golf Wear Dry')
         assert.equal(p.course_select, 'Downloaded Course')
     })
+
+    test('a fresh idle frame after restart leaves smart_course untouched', () => {
+        // A zero smart id while off/idle means "not running", not "no
+        // course". Publishing map(0) ('None' -> HA unknown) here would wipe
+        // HA's last displayed course on every restart (the F24VDD washer
+        // never does that) — so the reading stays at its last value.
+        // Clear the in-process remembered selection first: a real restart
+        // wipes it (static memory), while earlier tests in this file armed
+        // courses under the same device id.
+        ;(DUT as unknown as { remembered: Map<string, unknown> }).remembered.clear()
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', POWEROFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.smart_course, undefined)
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'OFF')
+    })
 })

--- a/tests/cloud/devices/S5MPC.test.ts
+++ b/tests/cloud/devices/S5MPC.test.ts
@@ -1,8 +1,8 @@
-import { describe, test } from 'node:test'
+import { describe, test, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { unlinkSync } from 'node:fs'
+import { unlinkSync, chmodSync } from 'node:fs'
 import DUT from '@/cloud/devices/S5MPC'
 import type { Metadata } from '@/cloud/thinq'
 import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
@@ -472,6 +472,37 @@ describe(MODEL_ID, () => {
         assert.equal(p.power, 'OFF')
         assert.equal(p.smart_course, 'Golf Wear Dry')
         assert.equal(p.smart_course_select, 'Golf Wear Dry')
+    })
+
+    test('repeated identical status frames do not rewrite the memory file', () => {
+        // Give this test its own memory file so it doesn't interfere with
+        // other tests sharing the default one.
+        const memFile = join(tmpdir(), 'rethink-course-memory-styler-nowrite-test.json')
+        try {
+            unlinkSync(memFile)
+        } catch {
+            // no memory file from a previous run — start clean
+        }
+        const previousMemFile = process.env.RETHINK_MEMORY_FILE
+        process.env.RETHINK_MEMORY_FILE = memFile
+        const warnSpy = mock.method(console, 'log')
+        try {
+            const { dev } = makeDevice()
+            dev.setProperty('smart_course_select', 'Golf Wear Dry')
+            // Make the file un-writable: if the driver's cached-entry skip
+            // logic works, the repeated identical selection below never
+            // calls writeFileSync again and this never gets hit. If it
+            // regresses to writing on every call, the write fails and is
+            // logged (saveMemory never throws).
+            chmodSync(memFile, 0o444)
+            dev.setProperty('smart_course_select', 'Golf Wear Dry')
+            dev.setProperty('smart_course_select', 'Golf Wear Dry')
+            assert.equal(warnSpy.mock.callCount(), 0)
+        } finally {
+            chmodSync(memFile, 0o644)
+            warnSpy.mock.restore()
+            process.env.RETHINK_MEMORY_FILE = previousMemFile
+        }
     })
 
     // Bridge mode tunnels an app-issued download straight to the physical

--- a/tests/cloud/devices/S5MPC.test.ts
+++ b/tests/cloud/devices/S5MPC.test.ts
@@ -380,7 +380,8 @@ describe(MODEL_ID, () => {
 
     test('selecting a smart course downloads it straight away, like the washer', () => {
         const { ha, thinq, dev } = makeDevice()
-        thinq.emit('data', REMOTE_ON)
+        // No state frame first: the appliance is off/unknown, and the sensor
+        // must still reflect the selection because the download is sent anyway.
         dev.setProperty('smart_course_select', 'Golf Wear Dry')
         assert.equal(thinq.outbox.length, 1, 'select sent only the download frame')
         assert.equal(

--- a/tests/cloud/devices/S5MPC.test.ts
+++ b/tests/cloud/devices/S5MPC.test.ts
@@ -1,0 +1,321 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/S5MPC'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'S5MPC'
+const META: Metadata = { modelId: MODEL_ID, modelName: MODEL_ID, swVersion: '2.10.95' }
+
+/*
+ * Fixtures.
+ *
+ * All state frames below are REAL frames from the appliance, captured
+ * 2026-09-07, each cross-checked against LG's own cloud decode of the same
+ * moment (83 snapshots over the session):
+ *
+ * - REMOTE_ON: 08:48:46Z, LG: state INITIAL, remoteStart REMOTE_START_ON
+ * - REMOTE_OFF: 08:50:56Z, LG: state INITIAL, remoteStart REMOTE_START_OFF
+ * - PAUSE: 08:53:29Z, LG: state PAUSE, preState PRESTEAM, course STANDARD
+ * - PRESTEAM: 08:53:22Z, trailing record state PRESTEAM (course STANDARD)
+ * - RESERVED: 08:55:40Z, LG: state RESERVED, course QUICK, reserve 19h
+ * - POWEROFF: 09:24:12Z, LG: state POWEROFF
+ *
+ * Every one of them reads error ERROR_NO, energyMonitoring 0 — no other error
+ * code and no non-zero energy value were ever observed, which is why those two
+ * entities stay conservative (see the driver header).
+ */
+const REMOTE_ON = buf(
+    'aa4031ec001b010001000100000000000000000020000000000000000001624200001b01000100010000000000000000002800000000000000000162420080bb',
+)
+const REMOTE_OFF = buf(
+    'aa4031ec001b010001000100000000000000000028000000000000000001624200001b01000100010000000000000000002000000000000000000162420080bb',
+)
+const PAUSE = buf(
+    'aa4031ec001b320027002701000100000000000028000000000000000001624200001b03002700270100320000000000002800000000000000000162420088bb',
+)
+const PRESTEAM = buf(
+    'aa4031ec001b010001000100000000000000000028000000000000000001624200001b32002700270100010000000000002800000000000000000162420009bb',
+)
+const RESERVED = buf(
+    'aa4031ec001b030027002701003200000000000028000000000000000001624200001b080014001403000300000000130008000000000000000001624200d1bb',
+)
+const POWEROFF = buf(
+    'aa4031ec001b01003b003b1c000300000000000020000000000063000001634200001b00003b003b000001000000000000200000000000000000016342006cbb',
+)
+// SMART_RUN: 09:11:49Z, trailing record runs base Time Dry 30 with smart Golf
+// Wear Dry — LG: course TIME_DRY_30, smartCourse GOLF_WEAR_DRY.
+const SMART_RUN = buf(
+    'aa4031ec001b01003b003b1c000300000000000028000000000063000001634200001b010119011911000300000000000028000000000079000001794200ffbb',
+)
+
+// Not state: the 8-byte ACK, a 9-byte notification of the kind that
+// accompanies remote-start transitions, and the downloadable-course name list.
+const ACK = buf('aa083100240052bb')
+const NOTIFY_9 = buf('aa09317200c9004abb')
+const COURSE_LIST = buf(
+    'aa37313102015341413337353639313431000066260000800000000000025341413337353639303230000062a80000400000000000d9bb',
+)
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+/** This model's framing: `packet[1]` is the length, `packet[-2]` is the low byte of the sum XOR 0x55. */
+function assertIntact(packet: Buffer) {
+    assert.equal(packet[1], packet.length)
+    const sum = packet.subarray(0, packet.length - 2).reduce((a, b) => a + b, 0)
+    assert.equal(packet[packet.length - 2], (sum & 0xff) ^ 0x55)
+}
+
+describe(MODEL_ID, () => {
+    test('the real-capture corpus is intact, not hand-written', () => {
+        for (const f of [REMOTE_ON, REMOTE_OFF, PAUSE, PRESTEAM, RESERVED, POWEROFF, SMART_RUN]) assertIntact(f)
+    })
+
+    test('exactly the scoped entities exist, with the right writability', () => {
+        const { ha } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        assert.deepEqual(Object.keys(components).sort(), [
+            'course',
+            'course_select',
+            'energy',
+            'error',
+            'error_message',
+            'initial_time',
+            'pause_course',
+            'power_off',
+            'remaining_time',
+            'remote_start',
+            'reserve_hours',
+            'reserve_time',
+            'resume_course',
+            'smart_course',
+            'smart_course_select',
+            'smart_diagnosis',
+            'start_course',
+            'status',
+            'store',
+        ])
+        assert.equal(components.energy.name, 'Power')
+        assert.equal(components.energy.device_class, 'power')
+        assert.equal(components.energy.unit_of_measurement, 'W')
+        assert.equal(components.energy.state_class, 'measurement')
+        for (const name of [
+            'power_off',
+            'course_select',
+            'smart_course_select',
+            'start_course',
+            'pause_course',
+            'resume_course',
+            'reserve_hours',
+            'store',
+        ]) {
+            assert.equal(components[name].command_topic, `$this/${name}/set`, `${name} is writable`)
+        }
+        for (const name of [
+            'status',
+            'course',
+            'smart_course',
+            'remaining_time',
+            'initial_time',
+            'reserve_time',
+            'remote_start',
+            'error',
+            'error_message',
+            'smart_diagnosis',
+            'energy',
+        ]) {
+            assert.equal(components[name].command_topic, undefined, `${name} stays read-only`)
+            assert.ok(
+                components[name].platform === 'sensor' || components[name].platform === 'binary_sensor',
+                `${name} is a sensor platform, got ${components[name].platform}`,
+            )
+        }
+    })
+
+    test('remote start follows the verified flags bit', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', REMOTE_ON)
+        assert.equal(ha.devices[DEVICE_ID].properties.remote_start, 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Standby')
+        thinq.emit('data', REMOTE_OFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.remote_start, 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Standby')
+    })
+
+    test('status tracks the verified state codes', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', PAUSE)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Pause')
+        assert.equal(ha.devices[DEVICE_ID].properties.remaining_time, 39)
+        assert.equal(ha.devices[DEVICE_ID].properties.initial_time, 39)
+        thinq.emit('data', PRESTEAM)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Steam preparing')
+        thinq.emit('data', RESERVED)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Reserved')
+        assert.equal(ha.devices[DEVICE_ID].properties.reserve_time, 19 * 60)
+        thinq.emit('data', POWEROFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Power off')
+    })
+
+    test('a running smart course takes over both selects', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SMART_RUN)
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.course, 'Timed Dry 30')
+        assert.equal(p.smart_course, 'Golf Wear Dry')
+        assert.equal(p.smart_course_select, 'Golf Wear Dry')
+    })
+
+    test('error, smart diagnosis and energy stay clear on every captured frame', () => {
+        const { ha, thinq } = makeDevice()
+        for (const f of [REMOTE_ON, REMOTE_OFF, PAUSE, PRESTEAM, RESERVED, POWEROFF]) thinq.emit('data', f)
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.error, 'OFF')
+        assert.equal(p.error_message, 'Normal')
+        assert.equal(p.smart_diagnosis, 'OFF')
+        assert.equal(p.energy, 0)
+    })
+
+    test('non-state frames are ignored', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', REMOTE_ON)
+        const before = { ...ha.devices[DEVICE_ID].properties }
+        thinq.emit('data', ACK)
+        thinq.emit('data', NOTIFY_9)
+        thinq.emit('data', COURSE_LIST)
+        assert.deepEqual({ ...ha.devices[DEVICE_ID].properties }, before)
+    })
+
+    /*
+     * The frames below are REAL: captured 2026-09-07 as the app drove each
+     * action. The assertion is that this driver emits byte for byte what LG's
+     * own app emitted — not that it agrees with its own idea of the format.
+     */
+    test('each write reproduces the frame LG itself sent for that command', () => {
+        // Start Standard, immediate.
+        {
+            const { thinq, dev } = makeDevice()
+            dev.setProperty('course_select', 'Styling Standard')
+            thinq.resetRecorder()
+            dev.setProperty('start_course', '')
+            assert.equal(thinq.outbox.length, 1, 'start sent one frame')
+            assert.equal(
+                thinq.outbox[0].toString('hex'),
+                'aa34f02601010004000000000002645a00000005005a05b45a01b4001ab40000000000000000000000000000000000000000fabb',
+            )
+        }
+        // Start Standard, store + 19-hour reservation.
+        {
+            const { thinq, dev } = makeDevice()
+            dev.setProperty('course_select', 'Styling Standard')
+            dev.setProperty('store', 'ON')
+            dev.setProperty('reserve_hours', '19')
+            thinq.resetRecorder()
+            dev.setProperty('start_course', '')
+            assert.equal(thinq.outbox.length, 1, 'reserved start sent one frame')
+            assert.equal(
+                thinq.outbox[0].toString('hex'),
+                'aa34f02601010006000013000002645a00000005005a05b45a01b4001ab4000000000000000000000000000000000000000091bb',
+            )
+        }
+        // Start Quick, 19-hour reservation.
+        {
+            const { thinq, dev } = makeDevice()
+            dev.setProperty('course_select', 'Styling Quick')
+            dev.setProperty('reserve_hours', '19')
+            thinq.resetRecorder()
+            dev.setProperty('start_course', '')
+            assert.equal(thinq.outbox.length, 1, 'quick start sent one frame')
+            assert.equal(
+                thinq.outbox[0].toString('hex'),
+                'aa34f02603010004000013000082645a00000003005a00000001b4000eb4000000000000000000000000000000000000000076bb',
+            )
+        }
+        // Power off, pause, resume.
+        {
+            const { thinq, dev } = makeDevice()
+            dev.setProperty('course_select', 'Styling Standard')
+            dev.setProperty('start_course', '')
+            thinq.resetRecorder()
+            dev.setProperty('pause_course', '')
+            assert.equal(thinq.outbox[0].toString('hex'), 'aa09f02404010099bb')
+            thinq.resetRecorder()
+            dev.setProperty('resume_course', '')
+            assert.equal(
+                thinq.outbox[0].toString('hex'),
+                'aa33f026010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a1bb',
+            )
+            thinq.resetRecorder()
+            dev.setProperty('power_off', '')
+            assert.equal(thinq.outbox[0].toString('hex'), 'aa09f0240101009cbb')
+        }
+    })
+
+    /*
+     * Smart starts go out as the download + start pair, in that order —
+     * exactly what the app emitted before each captured smart run. The 3-hour
+     * reservation rides in the start head only, as captured.
+     */
+    test('smart starts reproduce the captured download + start pairs', () => {
+        // Golf Wear Dry (base Time Dry 30), 3-hour reservation.
+        {
+            const { thinq, dev } = makeDevice()
+            dev.setProperty('smart_course_select', 'Golf Wear Dry')
+            dev.setProperty('reserve_hours', '3')
+            thinq.resetRecorder()
+            dev.setProperty('start_course', '')
+            assert.equal(thinq.outbox.length, 2, 'smart start sent two frames')
+            assert.equal(
+                thinq.outbox[0].toString('hex'),
+                'aa36f025032d11017900000000000080000000000000000000000000000055780000000000000000000000000000000000000000a8bb',
+            )
+            assert.equal(
+                thinq.outbox[1].toString('hex'),
+                'aa34f0261101790400000300008000000000000000000000000000005578000000000000000000000000000000000000000086bb',
+            )
+        }
+        // Snow Raing Drying, 3-hour reservation.
+        {
+            const { thinq, dev } = makeDevice()
+            dev.setProperty('smart_course_select', 'Snow Raing Drying')
+            dev.setProperty('reserve_hours', '3')
+            thinq.resetRecorder()
+            dev.setProperty('start_course', '')
+            assert.equal(thinq.outbox.length, 2, 'smart start sent two frames')
+            assert.equal(
+                thinq.outbox[0].toString('hex'),
+                'aa36f025032d0a014c0000000000000200000000000300000000000100002d78000000000000000000000000000000000000000072bb',
+            )
+            assert.equal(
+                thinq.outbox[1].toString('hex'),
+                'aa34f0260a014c0400000300000200000000000300000000000100002d780000000000000000000000000000000000000000a8bb',
+            )
+        }
+    })
+
+    test('a start shows up straight away instead of waiting for the appliance', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', REMOTE_ON)
+        dev.setProperty('course_select', 'Styling Standard')
+        dev.setProperty('start_course', '')
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'Styling Standard')
+        // ...and the appliance still has the last word.
+        thinq.emit('data', REMOTE_OFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'None')
+    })
+
+    test('reserve hours reject anything outside 0..19', () => {
+        const { ha, dev } = makeDevice()
+        dev.setProperty('reserve_hours', '19')
+        assert.equal(ha.devices[DEVICE_ID].properties.reserve_hours, 19)
+        dev.setProperty('reserve_hours', '20')
+        dev.setProperty('reserve_hours', '-1')
+        assert.equal(ha.devices[DEVICE_ID].properties.reserve_hours, 19)
+    })
+})

--- a/tests/cloud/devices/S5MPC.test.ts
+++ b/tests/cloud/devices/S5MPC.test.ts
@@ -159,7 +159,7 @@ describe(MODEL_ID, () => {
             'status',
             'store',
         ])
-        assert.equal(components.energy.name, 'Power')
+        assert.equal(components.energy.name, 'Energy')
         assert.equal(components.energy.device_class, 'energy')
         assert.equal(components.energy.unit_of_measurement, 'Wh')
         assert.equal(components.energy.state_class, 'total_increasing')

--- a/tests/cloud/devices/S5MPC.test.ts
+++ b/tests/cloud/devices/S5MPC.test.ts
@@ -146,14 +146,14 @@ describe(MODEL_ID, () => {
             'error',
             'error_message',
             'initial_time',
-            'pause_course',
+            'pause',
             'power',
             'power_off',
             'remaining_time',
             'remote_start',
             'reserve_hours',
             'reserve_time',
-            'resume_course',
+            'resume',
             'smart_course',
             'smart_course_select',
             'smart_diagnosis',
@@ -189,8 +189,8 @@ describe(MODEL_ID, () => {
             'course_select',
             'smart_course_select',
             'start_course',
-            'pause_course',
-            'resume_course',
+            'pause',
+            'resume',
             'reserve_hours',
             'store',
         ]) {
@@ -373,10 +373,10 @@ describe(MODEL_ID, () => {
             dev.setProperty('course_select', 'Styling Standard')
             dev.setProperty('start_course', '')
             thinq.resetRecorder()
-            dev.setProperty('pause_course', '')
+            dev.setProperty('pause', '')
             assert.equal(thinq.outbox[0].toString('hex'), 'aa09f02404010099bb')
             thinq.resetRecorder()
-            dev.setProperty('resume_course', '')
+            dev.setProperty('resume', '')
             assert.equal(
                 thinq.outbox[0].toString('hex'),
                 'aa33f026010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a1bb',

--- a/tests/cloud/devices/S5MPC.test.ts
+++ b/tests/cloud/devices/S5MPC.test.ts
@@ -412,7 +412,9 @@ describe(MODEL_ID, () => {
         const { ha, thinq, dev } = makeDevice()
         thinq.emit(
             'sendData',
-            buf('aa36f025032d11017900000000000080000000000000000000000000000055780000000000000000000000000000000000000000a8bb'),
+            buf(
+                'aa36f025032d11017900000000000080000000000000000000000000000055780000000000000000000000000000000000000000a8bb',
+            ),
         )
         const p = ha.devices[DEVICE_ID].properties
         assert.equal(p.smart_course_select, 'Golf Wear Dry')

--- a/tests/cloud/devices/S5MPC.test.ts
+++ b/tests/cloud/devices/S5MPC.test.ts
@@ -2,7 +2,7 @@ import { describe, test, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { unlinkSync, chmodSync } from 'node:fs'
+import { unlinkSync, writeFileSync, chmodSync } from 'node:fs'
 import DUT from '@/cloud/devices/S5MPC'
 import type { Metadata } from '@/cloud/thinq'
 import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
@@ -338,6 +338,23 @@ describe(MODEL_ID, () => {
         assert.equal(p.course_select, 'Downloaded Course')
     })
 
+    test('a frame with a corrupted checksum is dropped, not decoded', () => {
+        // The shared AABBDevice base never verified the checksum it writes
+        // in send(); this device overrides processData to check it on
+        // receive too. Flip a byte in a real captured frame without
+        // recomputing the checksum, and the whole update must be ignored.
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', REMOTE_ON)
+        const before = { ...ha.devices[DEVICE_ID].properties }
+
+        const corrupted = Buffer.from(SMART_RUN)
+        corrupted[10] ^= 0xff // flip a mid-frame byte, checksum left untouched
+        thinq.emit('data', corrupted)
+        const after = ha.devices[DEVICE_ID].properties
+        assert.equal(after.course, before.course)
+        assert.equal(after.smart_course, before.smart_course)
+    })
+
     test('error, smart diagnosis and energy stay clear on every captured frame', () => {
         const { ha, thinq } = makeDevice()
         for (const f of [REMOTE_ON, REMOTE_OFF, PAUSE, PRESTEAM, RESERVED, POWEROFF]) thinq.emit('data', f)
@@ -641,5 +658,21 @@ describe(MODEL_ID, () => {
         assert.equal(p.smart_course, 'Golf Wear Dry')
         assert.equal(p.smart_course_select, 'Golf Wear Dry')
         assert.equal(p.course_select, 'Downloaded Course')
+    })
+
+    test('a torn memory file boots with defaults instead of throwing', () => {
+        // What a crash mid-write used to leave behind: truncated JSON.
+        // Atomic saves make this impossible going forward, but files torn
+        // by older versions must still boot cleanly with defaults. Clear
+        // the in-process map first so this genuinely exercises the disk
+        // path (same trick as the restart tests above).
+        writeFileSync(process.env.RETHINK_MEMORY_FILE as string, `{"${DEVICE_ID}": {"smart": 6`)
+        ;(DUT as unknown as { remembered: Map<string, unknown> }).remembered.clear()
+        const ha2 = new MockHAConnection()
+        const thinq2 = new MockThinq2Device(DEVICE_ID, META)
+        assert.ok(new DUT(ha2.asConnection(), thinq2, META))
+        const p = ha2.devices[DEVICE_ID].properties
+        assert.equal(p.course_select, 'Styling Standard')
+        assert.equal(p.smart_course, undefined)
     })
 })

--- a/tests/cloud/devices/S5MPC.test.ts
+++ b/tests/cloud/devices/S5MPC.test.ts
@@ -56,6 +56,11 @@ const POWEROFF = buf(
 // 593Wh exactly. The per-minute 0x31ec status frames report 0 in the same
 // field for the whole run and flip to 593 only at completion.
 const ENERGY_AT_COMPLETION = buf('aa2331eb001b00000100000000040000000000002000000251000000000163420077bb')
+// Real completion frame (06:05:11, state Complete): the wire still reports
+// 0h01m remaining while the cycle is done.
+const COMPLETE = buf(
+    'aa4031ec001b040001012c0c003800000000000028000002510000000001634200001b000001012c000004000000000000200000025100000000016342004abb',
+)
 // SMART_RUN: 09:11:49Z, trailing record runs base Time Dry 30 with smart Golf
 // Wear Dry — LG: course TIME_DRY_30, smartCourse GOLF_WEAR_DRY.
 const SMART_RUN = buf(
@@ -155,9 +160,9 @@ describe(MODEL_ID, () => {
             'store',
         ])
         assert.equal(components.energy.name, 'Power')
-        assert.equal(components.energy.device_class, 'power')
-        assert.equal(components.energy.unit_of_measurement, 'W')
-        assert.equal(components.energy.state_class, 'measurement')
+        assert.equal(components.energy.device_class, 'energy')
+        assert.equal(components.energy.unit_of_measurement, 'Wh')
+        assert.equal(components.energy.state_class, 'total_increasing')
         assert.equal(components.power.platform, 'binary_sensor')
         assert.equal(components.power.icon, 'mdi:power')
         assert.equal(components.smart_diagnosis.device_class, 'problem')
@@ -257,6 +262,22 @@ describe(MODEL_ID, () => {
         thinq.emit('data', POWEROFF)
         assert.equal(ha.devices[DEVICE_ID].properties.power, 'OFF')
         assert.equal(ha.devices[DEVICE_ID].properties.status, 'Power off')
+    })
+
+    test('remaining time reads 0 once the cycle is done', () => {
+        // The wire holds 0h01m through completion and power-off while
+        // nothing remains; running states keep reporting the wire value.
+        // (The frame's leading record is state Complete, the trailing
+        // current record is already Power off.)
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', COMPLETE)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Power off')
+        assert.equal(ha.devices[DEVICE_ID].properties.remaining_time, 0)
+        thinq.emit('data', POWEROFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.remaining_time, 0)
+        thinq.emit('data', withCurrentState(4))
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Complete')
+        assert.equal(ha.devices[DEVICE_ID].properties.remaining_time, 0)
     })
 
     test('uses the common Error and Smart diagnosis states declared by the model', () => {

--- a/tests/cloud/devices/S5MPC.test.ts
+++ b/tests/cloud/devices/S5MPC.test.ts
@@ -378,6 +378,21 @@ describe(MODEL_ID, () => {
         }
     })
 
+    test('selecting a smart course downloads it straight away, like the washer', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', REMOTE_ON)
+        dev.setProperty('smart_course_select', 'Golf Wear Dry')
+        assert.equal(thinq.outbox.length, 1, 'select sent only the download frame')
+        assert.equal(
+            thinq.outbox[0].toString('hex'),
+            'aa36f025032d11017900000000000080000000000000000000000000000055780000000000000000000000000000000000000000a8bb',
+        )
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.smart_course_select, 'Golf Wear Dry')
+        assert.equal(p.smart_course, 'Golf Wear Dry')
+        assert.equal(p.course_select, 'Downloaded Course')
+    })
+
     test('course_select "Downloaded Course" routes Start course to the pre-selected smart course', () => {
         const { thinq, dev } = makeDevice()
         dev.setProperty('smart_course_select', 'Golf Wear Dry')

--- a/tests/cloud/devices/S5MPC.test.ts
+++ b/tests/cloud/devices/S5MPC.test.ts
@@ -394,6 +394,17 @@ describe(MODEL_ID, () => {
         assert.equal(p.course_select, 'Downloaded Course')
     })
 
+    test('a polled idle frame does not wipe an armed smart course', () => {
+        const { ha, thinq, dev } = makeDevice()
+        dev.setProperty('smart_course_select', 'Golf Wear Dry')
+        // The appliance is off and reports smart id 0 ("not running").
+        thinq.emit('data', POWEROFF)
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.power, 'OFF')
+        assert.equal(p.smart_course, 'Golf Wear Dry')
+        assert.equal(p.smart_course_select, 'Golf Wear Dry')
+    })
+
     test('course_select "Downloaded Course" routes Start course to the pre-selected smart course', () => {
         const { thinq, dev } = makeDevice()
         dev.setProperty('smart_course_select', 'Golf Wear Dry')

--- a/tests/cloud/devices/S5MPC.test.ts
+++ b/tests/cloud/devices/S5MPC.test.ts
@@ -283,11 +283,29 @@ describe(MODEL_ID, () => {
     })
 
     test('a smart course whose base id is 13/14/16/27/67/78 still reports a course label', () => {
-        // Those base ids never run standalone, so they were missing from
-        // COURSE and a smart run built on one of them left `course`
-        // unpublished (map(rawCourse) returned undefined). Base id 67
-        // (Silent) doubles as both a SmartCourse and a directly startable
-        // course, so this also covers that dual-use case.
+        // Those base ids never run standalone via Start course, so they were
+        // missing from COURSE and a direct run of one of them (smartCourse
+        // 0, course = the base id) left `course` unpublished (map(rawCourse)
+        // returned undefined). Base id 67 (Silent) doubles as both a
+        // SmartCourse and a directly startable course, so this also covers
+        // that dual-use case: with no smart course active, `course` reports
+        // the base label directly rather than the Downloaded Course
+        // placeholder.
+        const packet = Buffer.from(SMART_RUN)
+        const currentRecord = packet.length - 2 - 27
+        packet[currentRecord + 5] = 67 // OFF.course
+        packet[currentRecord + 20] = 0 // OFF.smartCourse: no smart course running
+        const sum = packet.subarray(0, packet.length - 2).reduce((a, b) => a + b, 0)
+        packet[packet.length - 2] = (sum & 0xff) ^ 0x55
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', packet)
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'Silent')
+    })
+
+    test('a smart course built on base id 67 reports Downloaded Course on `course`, like the washer', () => {
+        // Same synthetic frame, but with the SmartCourse id actually set:
+        // `course` now matches course_select's own placeholder instead of
+        // leaking the base id, and `smart_course` carries the real name.
         const packet = Buffer.from(SMART_RUN)
         const currentRecord = packet.length - 2 - 27
         packet[currentRecord + 5] = 67 // OFF.course
@@ -296,7 +314,7 @@ describe(MODEL_ID, () => {
         packet[packet.length - 2] = (sum & 0xff) ^ 0x55
         const { ha, thinq } = makeDevice()
         thinq.emit('data', packet)
-        assert.equal(ha.devices[DEVICE_ID].properties.course, 'Silent')
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'Downloaded Course')
         assert.equal(ha.devices[DEVICE_ID].properties.smart_course, 'Silent')
     })
 
@@ -310,11 +328,11 @@ describe(MODEL_ID, () => {
         assert.equal(ha.devices[DEVICE_ID].properties.smart_diagnosis, 'ON')
     })
 
-    test('a running smart course takes over both selects', () => {
+    test('a running smart course reports the Downloaded Course placeholder, like the washer', () => {
         const { ha, thinq } = makeDevice()
         thinq.emit('data', SMART_RUN)
         const p = ha.devices[DEVICE_ID].properties
-        assert.equal(p.course, 'Timed Dry 30')
+        assert.equal(p.course, 'Downloaded Course')
         assert.equal(p.smart_course, 'Golf Wear Dry')
         assert.equal(p.smart_course_select, 'Golf Wear Dry')
         assert.equal(p.course_select, 'Downloaded Course')

--- a/tests/cloud/devices/S5MPC.test.ts
+++ b/tests/cloud/devices/S5MPC.test.ts
@@ -129,6 +129,8 @@ describe(MODEL_ID, () => {
             SMART_RUN,
             CHILD_LOCK_ON,
             CHILD_LOCK_OFF,
+            ENERGY_AT_COMPLETION,
+            COMPLETE,
         ])
             assertIntact(f)
     })

--- a/tests/cloud/devices/S5MPC.test.ts
+++ b/tests/cloud/devices/S5MPC.test.ts
@@ -248,6 +248,7 @@ describe(MODEL_ID, () => {
         assert.equal(p.course, 'Timed Dry 30')
         assert.equal(p.smart_course, 'Golf Wear Dry')
         assert.equal(p.smart_course_select, 'Golf Wear Dry')
+        assert.equal(p.course_select, 'Downloaded Course')
     })
 
     test('error, smart diagnosis and energy stay clear on every captured frame', () => {
@@ -375,6 +376,25 @@ describe(MODEL_ID, () => {
                 'aa34f0260a014c0400000300000200000000000300000000000100002d780000000000000000000000000000000000000000a8bb',
             )
         }
+    })
+
+    test('course_select "Downloaded Course" routes Start course to the pre-selected smart course', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('smart_course_select', 'Golf Wear Dry')
+        dev.setProperty('reserve_hours', '3')
+        // Re-selecting the placeholder base course must not lose the smart selection.
+        dev.setProperty('course_select', 'Downloaded Course')
+        thinq.resetRecorder()
+        dev.setProperty('start_course', '')
+        assert.equal(thinq.outbox.length, 2, 'smart start sent two frames')
+        assert.equal(
+            thinq.outbox[0].toString('hex'),
+            'aa36f025032d11017900000000000080000000000000000000000000000055780000000000000000000000000000000000000000a8bb',
+        )
+        assert.equal(
+            thinq.outbox[1].toString('hex'),
+            'aa34f0261101790400000300008000000000000000000000000000005578000000000000000000000000000000000000000086bb',
+        )
     })
 
     test('a start shows up straight away instead of waiting for the appliance', () => {

--- a/tests/cloud/devices/S5MPC.test.ts
+++ b/tests/cloud/devices/S5MPC.test.ts
@@ -563,13 +563,22 @@ describe(MODEL_ID, () => {
         assert.equal(ha.devices[DEVICE_ID].properties.course, 'None')
     })
 
-    test('reserve hours reject anything outside 0..19', () => {
+    test('reserve hours reject anything outside 0 or 3..19', () => {
         const { ha, dev } = makeDevice()
         dev.setProperty('reserve_hours', '19')
         assert.equal(ha.devices[DEVICE_ID].properties.reserve_hours, 19)
         dev.setProperty('reserve_hours', '20')
         dev.setProperty('reserve_hours', '-1')
         assert.equal(ha.devices[DEVICE_ID].properties.reserve_hours, 19)
+        // LG declares 0 (start now) or 3..19; 1 and 2 are outside that range.
+        dev.setProperty('reserve_hours', '1')
+        assert.equal(ha.devices[DEVICE_ID].properties.reserve_hours, 19)
+        dev.setProperty('reserve_hours', '2')
+        assert.equal(ha.devices[DEVICE_ID].properties.reserve_hours, 19)
+        dev.setProperty('reserve_hours', '3')
+        assert.equal(ha.devices[DEVICE_ID].properties.reserve_hours, 3)
+        dev.setProperty('reserve_hours', '0')
+        assert.equal(ha.devices[DEVICE_ID].properties.reserve_hours, 0)
     })
 
     test('a reconnect restores the armed smart course instead of resetting to Pants', () => {

--- a/tests/cloud/devices/S5MPC.test.ts
+++ b/tests/cloud/devices/S5MPC.test.ts
@@ -282,6 +282,24 @@ describe(MODEL_ID, () => {
         assert.equal(ha.devices[DEVICE_ID].properties.remaining_time, 0)
     })
 
+    test('a smart course whose base id is 13/14/16/27/67/78 still reports a course label', () => {
+        // Those base ids never run standalone, so they were missing from
+        // COURSE and a smart run built on one of them left `course`
+        // unpublished (map(rawCourse) returned undefined). Base id 67
+        // (Silent) doubles as both a SmartCourse and a directly startable
+        // course, so this also covers that dual-use case.
+        const packet = Buffer.from(SMART_RUN)
+        const currentRecord = packet.length - 2 - 27
+        packet[currentRecord + 5] = 67 // OFF.course
+        packet[currentRecord + 20] = 67 // OFF.smartCourse
+        const sum = packet.subarray(0, packet.length - 2).reduce((a, b) => a + b, 0)
+        packet[packet.length - 2] = (sum & 0xff) ^ 0x55
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', packet)
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'Silent')
+        assert.equal(ha.devices[DEVICE_ID].properties.smart_course, 'Silent')
+    })
+
     test('uses the common Error and Smart diagnosis states declared by the model', () => {
         const { ha, thinq } = makeDevice()
         thinq.emit('data', withCurrentState(5))

--- a/tests/cloud/devices/S5MPC.test.ts
+++ b/tests/cloud/devices/S5MPC.test.ts
@@ -49,6 +49,16 @@ const POWEROFF = buf(
 const SMART_RUN = buf(
     'aa4031ec001b01003b003b1c000300000000000028000000000063000001634200001b010119011911000300000000000028000000000079000001794200ffbb',
 )
+// CHILD_LOCK_ON / CHILD_LOCK_OFF: 2026-09-08, captured live off the panel's
+// own child-lock button (LG's app has no control for it, so there is no
+// cloud snapshot to cross-check against — only the owner-confirmed physical
+// lock icon). Only flagsA's 0x01 bit moves between them.
+const CHILD_LOCK_ON = buf(
+    'aa4031ec001b010001000100000000000000000020000000000000000001634200001b01000100010000000000000000002100000000000000000163420085bb',
+)
+const CHILD_LOCK_OFF = buf(
+    'aa4031ec001b010001000100000000000000000021000000000000000001634200001b01000100010000000000000000002000000000000000000163420085bb',
+)
 
 // Not state: the 8-byte ACK, a 9-byte notification of the kind that
 // accompanies remote-start transitions, and the downloadable-course name list.
@@ -84,13 +94,25 @@ function withCurrentState(state: number) {
 
 describe(MODEL_ID, () => {
     test('the real-capture corpus is intact, not hand-written', () => {
-        for (const f of [REMOTE_ON, REMOTE_OFF, PAUSE, PRESTEAM, RESERVED, POWEROFF, SMART_RUN]) assertIntact(f)
+        for (const f of [
+            REMOTE_ON,
+            REMOTE_OFF,
+            PAUSE,
+            PRESTEAM,
+            RESERVED,
+            POWEROFF,
+            SMART_RUN,
+            CHILD_LOCK_ON,
+            CHILD_LOCK_OFF,
+        ])
+            assertIntact(f)
     })
 
     test('exactly the scoped entities exist, with the right writability', () => {
         const { ha } = makeDevice()
         const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
         assert.deepEqual(Object.keys(components).sort(), [
+            'child_lock',
             'course',
             'course_select',
             'energy',
@@ -156,6 +178,7 @@ describe(MODEL_ID, () => {
             'initial_time',
             'reserve_time',
             'remote_start',
+            'child_lock',
             'error',
             'error_message',
             'smart_diagnosis',
@@ -178,6 +201,18 @@ describe(MODEL_ID, () => {
         thinq.emit('data', REMOTE_OFF)
         assert.equal(ha.devices[DEVICE_ID].properties.remote_start, 'OFF')
         assert.equal(ha.devices[DEVICE_ID].properties.status, 'Standby')
+    })
+
+    test('child lock follows the verified flags bit, independent of remote start', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', CHILD_LOCK_ON)
+        assert.equal(ha.devices[DEVICE_ID].properties.child_lock, 'ON')
+        thinq.emit('data', CHILD_LOCK_OFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.child_lock, 'OFF')
+        // Cross-check independence: remote-start fixtures never set 0x01, and
+        // child-lock fixtures never set 0x08.
+        thinq.emit('data', REMOTE_ON)
+        assert.equal(ha.devices[DEVICE_ID].properties.child_lock, 'OFF')
     })
 
     test('status tracks the verified state codes', () => {

--- a/tests/cloud/devices/S5MPC.test.ts
+++ b/tests/cloud/devices/S5MPC.test.ts
@@ -405,6 +405,32 @@ describe(MODEL_ID, () => {
         assert.equal(p.smart_course_select, 'Golf Wear Dry')
     })
 
+    // Bridge mode tunnels an app-issued download straight to the physical
+    // appliance through send_packet(), bypassing setProperty entirely — the
+    // same gap fixed for RH16_T_KR. HA must still learn about the change.
+    test('bridge-tunnelled app download updates HA the same as a local select', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit(
+            'sendData',
+            buf('aa36f025032d11017900000000000080000000000000000000000000000055780000000000000000000000000000000000000000a8bb'),
+        )
+        const p = ha.devices[DEVICE_ID].properties
+        assert.equal(p.smart_course_select, 'Golf Wear Dry')
+        assert.equal(p.course_select, 'Downloaded Course')
+        assert.equal(p.smart_course, 'Golf Wear Dry')
+    })
+
+    test('bridge-tunnelled downloads are ignored when the body matches no known course', () => {
+        const { ha, thinq, dev } = makeDevice()
+        // Test isolation note: Device.remembered is keyed by device id and
+        // this suite reuses one id throughout, so a prior test's armed
+        // selection is still in effect here — assert the non-download frame
+        // leaves it untouched rather than asserting a specific baseline.
+        const before = ha.devices[DEVICE_ID].properties.smart_course_select
+        thinq.emit('sendData', buf('aa08f024010000fcbb')) // power off, not a download
+        assert.equal(ha.devices[DEVICE_ID].properties.smart_course_select, before)
+    })
+
     test('course_select "Downloaded Course" routes Start course to the pre-selected smart course', () => {
         const { thinq, dev } = makeDevice()
         dev.setProperty('smart_course_select', 'Golf Wear Dry')

--- a/tests/cloud/devices/S5MPC.test.ts
+++ b/tests/cloud/devices/S5MPC.test.ts
@@ -165,6 +165,9 @@ describe(MODEL_ID, () => {
         assert.equal(components.energy.device_class, 'energy')
         assert.equal(components.energy.unit_of_measurement, 'Wh')
         assert.equal(components.energy.state_class, 'total_increasing')
+        // Energy is a first-class reading like the washer's, not a
+        // diagnostic: no entity_category, so it stays on the device card.
+        assert.equal(components.energy.entity_category, undefined)
         assert.equal(components.power.platform, 'binary_sensor')
         assert.equal(components.power.icon, 'mdi:power')
         assert.equal(components.smart_diagnosis.device_class, 'problem')


### PR DESCRIPTION
## Summary

Adds first-class support for the **LG S5MPC Styler** (`deviceType: 203`). S5MPC uses AA/BB framing but has its own 27-byte state record, so it is implemented as a dedicated handler rather than an alias of the existing 40-byte Styler parser.

The implementation is based on traffic captured from the physical appliance. It supports native courses, all model-declared downloadable courses, completion reservations, Store mode, captured remote controls, Home Assistant state reporting, restart-safe smart-course tracking, completed countdown correction, and this-cycle energy.

## What is supported

- 19 selectable native courses
- All 26 downloadable smart courses declared by S5MPC
- Immediate and reserved course starts (0 or 3 to 19 hours; 1-2h rejected per LG's declared range)
- Downloadable-course install and start using the same two-frame sequence sent by LG's app
- Pause, resume, remote power off, and Store mode
- Power, status, course, smart course, duration, remote start, child lock, errors, diagnosis, and energy sensors

No command is included only because another Styler supports it. Every transmitted operation has a matching S5MPC capture or is constructed from this model's own `ControlConvertingRule` and validated against captured command frames.

## State protocol

State frames contain one or more length-prefixed 27-byte records. The final record is current; earlier records are historical and are not published.

Confirmed fields include:

- `record[0]`: top-level state
- `record[1..2]`: remaining hour/minute
- `record[3..4]`: initial hour/minute
- `record[5]`: native or base course
- `record[6]`: error
- `record[12..13]`: reservation time
- `record[14]` bits: remote start and physical child lock
- `record[17..18]`: this-cycle energy, 16-bit big-endian Wh
- `record[20]`: downloadable smart-course ID

Malformed frames, short notifications, ACKs, and downloadable-course name lists are ignored.

## Energy

`record[17..18]` is this-cycle cumulative energy in Wh, not instantaneous power. During a full 104-minute steam cycle the field remained zero while running, changed to `0x0251` at completion, and remained 593 in the following `31e2` and `31eb` frames. The ThinQ app showed exactly 593Wh for the same day.

Home Assistant discovery now declares:

- `device_class: energy`
- `unit_of_measurement: Wh`
- `state_class: total_increasing`

## Remaining time at completion

The physical Styler keeps reporting `00:01` after the cycle has completed and while powered off. The handler now publishes 0 minutes when state is Complete or Power off. Active states continue to use the wire value unchanged.

## Smart-course behavior and restarts

A zero smart-course ID in an idle/off frame means "not currently running", not "nothing installed". The handler no longer publishes `None` or causes Home Assistant to show Unknown from that frame. While a smart course runs, `course` reports the `Downloaded Course` placeholder like the washer and dryer, with the real name on `smart_course`.

The installed/selected smart course is remembered in process and in `/app/data/rethink-course-memory.json`. A real rethink restart restores and republishes it. This matches the F24VDD washer convention: the installed download stays visible whether it is running or not.

The bridge also observes matching app-issued download frames, so choosing a downloadable course in LG's app updates Home Assistant in the same way as choosing it through HA.

## Safety boundaries

- No remote power-on control because LG's app does not provide one and no frame was captured.
- Remote start and child lock are read-only because the appliance exposes state but no matching remote toggle command.
- Unknown non-zero error codes remain visible as `Code N` rather than borrowing labels from another model.
- S5BBP-only options are not exposed.

## Recent updates

- Energy sensor renamed from Power to Energy (Wh, `total_increasing`).
- `pause_course`/`resume_course` renamed to `pause`/`resume`.
- SmartCourse-only base course IDs labelled in COURSE so an active smart run always resolves a name.
- Memory file is no longer rewritten when the entry is unchanged.
- `reserve_hours` 1-2h rejected, matching LG's declared 0-or-3..19 range.
- Incoming AABB checksum is now verified on receive; corrupted frames are dropped instead of decoded.
- Course memory is saved atomically (temp file, fsync, rename) so a crash mid-write can no longer leave a torn file; torn files from older versions still boot with defaults.
- Energy is a plain sensor again (no `entity_category`), matching the washer and the other Wh handlers in the repo.

## Verification

- `npm run check`: pass
- S5MPC tests: **28/28 pass**
- Full branch suite: **626/626 pass**
- Prettier: pass
- Deployed locally against the physical Styler through `rethink-local:latest`

## Files

- `cloud/devices/S5MPC.ts`
- `tests/cloud/devices/S5MPC.test.ts`
- `cloud/ha_bridge.ts`
- `README.md`