### PR TITLE
 Add support for WTWN3 (F4J7TN1W) washer and RC90U2_WW (RC9DN9029) dryer

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The following appliances are currently supported in rethink:
     - 🫤 DLE7300WE - preliminary support
     - 👍 DLEX3900B (RV13B6BSD_D_US_WIFI), Electric Dryer - mostly working
     - 👍 RV13B6ES_D_US_WIFI, Electric Dryer - mostly working
+    - 🫤 RC9DN9029 (RC90U2_WW), Heat Pump Dryer - preliminary support
 - WashTowers (combined washer+dryer):
     - 👍 WKEX200HBA (WTL_FXU_BDV_NA_01), WashTower - mostly working
 - Dehumidifiers

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The following appliances are currently supported in rethink:
 - Washing Machines:
     - 🫤 (model name unknown) Washing Machine - preliminary support
     - 👍 F2J7HG1W, Washing Machine - mostly working,
+    - 🫤 F4J7TN1W (WTWN3), Washing Machine - preliminary support
     - 🫤 F4WV508S2E, Front-Loading Washing Machine - preliminary support
     - 🫤 F4WV709P1E, Front-Loading Washing Machine - preliminary support
     - 👍 F4WV709P1 (F_C**Y\_**W.A\_\_QEUK), Front-Loading Washing Machine - mostly working

--- a/cloud/devices/RC90U2_WW.ts
+++ b/cloud/devices/RC90U2_WW.ts
@@ -1,0 +1,345 @@
+import HADevice from './base'
+import { Device as Thinq2Device } from '../thinq2/device'
+import { type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import AABBDevice from './aabb_device'
+import { Enum } from '@/util/enum'
+
+// LG RC9DN9029 (ThinQ Model ID RC90U2_WW, deviceType 202): 9 kg DUAL Inverter heat pump dryer with
+// Eco Hybrid, EU/Nordic market. ThinQ2 with the QCOM_QCA4010 module (clip_hna_v1.9.230, protocolVer
+// 4.9). Same AABB dialect as the US dryers (RV13B6ES_D_US_WIFI): frames start with 0x30 and are
+// discriminated by buf[1]:
+//   0xEC  status update, two stacked records (previous, current), each prefixed 0x00 0x19
+//   0xEB  single-record status, the reply to the family-wide 0xF0ED status request
+//   0x31  serial/part-number frame, 0x19 five-byte power events — not decoded
+// Records are 25 bytes and follow LG's own modelJson Monitoring.protocol for this model byte for byte,
+// so field meanings come from the spec. The offsets and the enum codes below were confirmed live by
+// driving the panel and diffing consecutive 0xEC records: power off/on, eleven courses (one of them
+// downloaded) with their default dry level / Eco Hybrid / time estimate, the Dry Level button, Delay
+// End, and a Cool Air cycle (Running, Cooling phase, remaining time counting down). The Option1 bits
+// for Anti crease and Child lock were each toggled by a panel button whose
+// label has not been matched to the bit yet; Damp dry beep and Hand iron follow the spec and have not
+// been observed set. Errors are per spec only.
+
+const STATUS_FRAME_TYPE = 0xec
+const STATUS_FRAME_LEN = 56 // 30 EC + 2 x (00 19 + 25-byte record)
+const CURRENT_RECORD_OFFSET = 31 // second record
+
+const SINGLE_STATUS_FRAME_TYPE = 0xeb
+const SINGLE_STATUS_FRAME_LEN = 29 // 30 EB + 00 19 + 25-byte record
+const SINGLE_RECORD_OFFSET = 4
+
+const RECORD_LEN = 25
+const RECORD_LEN_MARKER = 0x19
+
+// Family-wide read-only "report your state" request; the dryer answers with a 0xEB frame within a
+// second. Sent once per connect so the entities survive a rethink restart.
+const STATUS_REQUEST = 'F0ED1121010000001800'
+
+// Record offsets (modelJson Monitoring.protocol)
+const STATE_OFFSET = 0
+const REMAIN_HOUR_OFFSET = 1
+const REMAIN_MIN_OFFSET = 2
+const INITIAL_HOUR_OFFSET = 3
+const INITIAL_MIN_OFFSET = 4
+const COURSE_OFFSET = 5
+const ERROR_OFFSET = 6
+const DRY_LEVEL_OFFSET = 7
+const ECO_HYBRID_OFFSET = 8
+const PROCESS_OFFSET = 9
+const RESERVE_HOUR_OFFSET = 12
+const RESERVE_MIN_OFFSET = 13
+const OPTION1_OFFSET = 14
+const SMART_COURSE_OFFSET = 20
+
+// Option1 bits (modelJson Value.Option1). Bit 3 (0x08) is not in the spec: it is on by default, cleared
+// by a panel button (Buzzer suspected) and restored at power-off, so it is deliberately not exposed.
+const OPT1_RESERVATION = 0x01
+const OPT1_ANTI_CREASE = 0x02
+const OPT1_CHILD_LOCK = 0x10
+const OPT1_DAMP_DRY_BEEP = 0x40
+const OPT1_HAND_IRON = 0x80
+
+// Option2 (byte 15) is not decoded: the spec's RemoteStart bit 0 was set for the whole of a cycle started
+// from the panel and did not react to arming Remote Start, and bit 2 (0x04) is a constant. Neither is exposed.
+
+const STATE_OFF = 0x00
+
+export const STATES = Enum.of({
+    Off: 0,
+    Ready: 1,
+    Running: 2,
+    Paused: 3,
+    End: 4,
+    Error: 5,
+    Delayed: 100,
+})
+
+// ProcessState: the sub-phase while a cycle runs. The spec maps codes 2, 3 and 4 all to "Dry".
+export const PHASES = Enum.of({
+    Detecting: 0,
+    Steam: 1,
+    Drying: [2, 3, 4],
+    Cooling: 5,
+    'Anti-crease': 6,
+    End: 7,
+})
+
+// Course (byte 5) and SmartCourse (byte 20, downloaded courses) share one label space; a non-zero
+// SmartCourse overrides the base course.
+export const COURSES = Enum.of({
+    'Cotton Soft': 0x02,
+    Duvet: 0x04,
+    'Easy Care': 0x05,
+    'Mixed Fabric': 0x06,
+    Cotton: 0x07,
+    'Sports Wear': 0x08,
+    'Quick Dry': 0x09,
+    Delicate: 0x0a,
+    Wool: 0x0b,
+    'Rack Dry': 0x0c,
+    'Cool Air': 0x0d,
+    'Warm Air': 0x0e,
+    'Allergy Care': 0x10,
+    // downloaded ("smart") courses
+    'Baby Wear': 0x65,
+    'Gym Clothes': 0x66,
+    Blanket: 0x67,
+    'Blanket Refresh': 0x68,
+    'Rainy Season': 0x69,
+    'Single Garments': 0x6a,
+    Deodorization: 0x6b,
+    'Small Load': 0x6c,
+    Lingerie: 0x6d,
+    'Easy Iron': 0x6e,
+    'Super Dry': 0x6f,
+    'Economic Dry': 0x70,
+    'Big Size Item': 0x71,
+    'Minimize Wrinkles': 0x72,
+    'Shoes/Fabric Doll': 0x73,
+    'Full Size Load': 0x74,
+})
+
+// 0 = no dry level (timed courses such as Duvet, Cool Air, Warm Air), left undecoded.
+export const DRY_LEVELS = Enum.of({
+    Iron: 1,
+    Cupboard: 3,
+    Extra: 4,
+})
+
+export const ECO_HYBRID = Enum.of({
+    Eco: 1,
+    Normal: 2,
+    Time: 3,
+})
+
+export const ERRORS = Enum.of({
+    OK: 0,
+    'Temperature sensor error (tE1)': 1,
+    'Temperature sensor error (tE2)': 2,
+    'Condenser error (CE1)': 7,
+    'Drain motor error': 13,
+    'Empty water container': 14,
+    'Door open': 15,
+    'Filter missing': 17,
+    'Unknown error (F1)': 19,
+    'Motor error (LE2)': 20,
+    'Unknown error (AE)': 21,
+    'Motor error (LE1)': 30,
+    'Door sensor error (dE4)': 37,
+})
+
+export default class Device extends AABBDevice {
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: 'LG Dryer' }),
+                components: {
+                    power: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-power',
+                        state_topic: '$this/power',
+                        name: 'Power',
+                        icon: 'mdi:tumble-dryer',
+                        device_class: 'running',
+                    },
+                    status: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-status',
+                        state_topic: '$this/status',
+                        name: 'Status',
+                        icon: 'mdi:state-machine',
+                        device_class: 'enum',
+                        options: STATES.options,
+                    },
+                    phase: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-phase',
+                        state_topic: '$this/phase',
+                        name: 'Phase',
+                        icon: 'mdi:progress-clock',
+                        device_class: 'enum',
+                        options: PHASES.options,
+                    },
+                    error: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-error',
+                        state_topic: '$this/error',
+                        name: 'Error',
+                        icon: 'mdi:check-circle',
+                        device_class: 'problem',
+                        entity_category: 'diagnostic',
+                    },
+                    error_message: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-error-message',
+                        state_topic: '$this/error_message',
+                        name: 'Error message',
+                        icon: 'mdi:alert-circle-outline',
+                        device_class: 'enum',
+                        entity_category: 'diagnostic',
+                        options: ERRORS.options,
+                    },
+                    course: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-course',
+                        state_topic: '$this/course',
+                        name: 'Course',
+                        icon: 'mdi:pin-outline',
+                        device_class: 'enum',
+                        options: COURSES.options,
+                    },
+                    dry_level: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-dry_level',
+                        state_topic: '$this/dry_level',
+                        name: 'Dry level',
+                        icon: 'mdi:water-percent',
+                        device_class: 'enum',
+                        options: DRY_LEVELS.options,
+                    },
+                    eco_hybrid: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-eco_hybrid',
+                        state_topic: '$this/eco_hybrid',
+                        name: 'Eco Hybrid',
+                        icon: 'mdi:leaf',
+                        device_class: 'enum',
+                        options: ECO_HYBRID.options,
+                    },
+                    remaining_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-remaining_time',
+                        state_topic: '$this/remaining_time',
+                        name: 'Remaining time',
+                        icon: 'mdi:timer-outline',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                    },
+                    initial_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-initial_time',
+                        state_topic: '$this/initial_time',
+                        name: 'Initial time',
+                        icon: 'mdi:clock-outline',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        entity_category: 'diagnostic',
+                    },
+                    reserve_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-reserve_time',
+                        state_topic: '$this/reserve_time',
+                        name: 'Delay end',
+                        icon: 'mdi:timer-sand',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                    },
+                    delay: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-delay',
+                        state_topic: '$this/delay',
+                        name: 'Delay end set',
+                        icon: 'mdi:timer-sand',
+                    },
+                    anti_crease: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-anti_crease',
+                        state_topic: '$this/anti_crease',
+                        name: 'Anti crease',
+                        icon: 'mdi:iron-outline',
+                    },
+                    child_lock: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-child_lock',
+                        state_topic: '$this/child_lock',
+                        name: 'Child lock',
+                        icon: 'mdi:lock-outline',
+                        entity_category: 'diagnostic',
+                    },
+                    damp_dry_beep: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-damp_dry_beep',
+                        state_topic: '$this/damp_dry_beep',
+                        name: 'Damp dry beep',
+                        icon: 'mdi:water-alert-outline',
+                    },
+                    hand_iron: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-hand_iron',
+                        state_topic: '$this/hand_iron',
+                        name: 'Hand iron',
+                        icon: 'mdi:iron',
+                    },
+                },
+            }),
+        )
+    }
+
+    start() {
+        this.send(Buffer.from(STATUS_REQUEST, 'hex'))
+    }
+
+    processAABB(buf: Buffer) {
+        if (buf.length < 2 || buf[0] !== 0x30) return
+        if (buf[1] === STATUS_FRAME_TYPE) return this.processStatus(buf, CURRENT_RECORD_OFFSET, STATUS_FRAME_LEN)
+        if (buf[1] === SINGLE_STATUS_FRAME_TYPE)
+            return this.processStatus(buf, SINGLE_RECORD_OFFSET, SINGLE_STATUS_FRAME_LEN)
+        // 0x31 (serial numbers) and 0x19 (power events) are not decoded.
+    }
+
+    private processStatus(buf: Buffer, recordOffset: number, expectedLen: number) {
+        if (buf.length !== expectedLen) return // reject header/layout drift
+        if (buf[recordOffset - 1] !== RECORD_LEN_MARKER) return
+        const rec = buf.subarray(recordOffset, recordOffset + RECORD_LEN)
+
+        const state = rec[STATE_OFFSET]
+        const isOff = state === STATE_OFF
+        const isActive = state === STATES.unmap('Running') || state === STATES.unmap('Paused')
+        const error = rec[ERROR_OFFSET]
+        const option1 = rec[OPTION1_OFFSET]
+
+        this.publishProperty('power', isOff ? 'OFF' : 'ON')
+        this.publishProperty('error_message', ERRORS.map(error)) // publish message before set error state
+        this.publishProperty('error', error ? 'ON' : 'OFF')
+        this.publishProperty('status', STATES.map(state))
+        // the sub-phase byte keeps a stale value while idle, so it is only meaningful during a cycle
+        this.publishProperty('phase', isActive ? PHASES.map(rec[PROCESS_OFFSET]) : undefined)
+        this.publishProperty(
+            'course',
+            isOff ? undefined : (COURSES.map(rec[SMART_COURSE_OFFSET]) ?? COURSES.map(rec[COURSE_OFFSET])),
+        )
+        this.publishProperty('dry_level', isOff ? undefined : DRY_LEVELS.map(rec[DRY_LEVEL_OFFSET]))
+        this.publishProperty('eco_hybrid', isOff ? undefined : ECO_HYBRID.map(rec[ECO_HYBRID_OFFSET]))
+        this.publishProperty('remaining_time', isOff ? 0 : rec[REMAIN_HOUR_OFFSET] * 60 + rec[REMAIN_MIN_OFFSET])
+        this.publishProperty('initial_time', isOff ? 0 : rec[INITIAL_HOUR_OFFSET] * 60 + rec[INITIAL_MIN_OFFSET])
+        this.publishProperty('reserve_time', isOff ? 0 : rec[RESERVE_HOUR_OFFSET] * 60 + rec[RESERVE_MIN_OFFSET])
+        this.publishProperty('delay', option1 & OPT1_RESERVATION ? 'ON' : 'OFF')
+        this.publishProperty('anti_crease', option1 & OPT1_ANTI_CREASE ? 'ON' : 'OFF')
+        this.publishProperty('child_lock', option1 & OPT1_CHILD_LOCK ? 'ON' : 'OFF')
+        this.publishProperty('damp_dry_beep', option1 & OPT1_DAMP_DRY_BEEP ? 'ON' : 'OFF')
+        this.publishProperty('hand_iron', option1 & OPT1_HAND_IRON ? 'ON' : 'OFF')
+    }
+}

--- a/cloud/devices/WTWN3.ts
+++ b/cloud/devices/WTWN3.ts
@@ -1,0 +1,380 @@
+import HADevice from './base'
+import { Device as Thinq1Device } from '../thinq1/device'
+import { type Connection } from '../homeassistant'
+import { allowExtendedType } from '@/util/casting'
+import { Metadata } from '../thinq'
+import { Enum } from '@/util/enum'
+import { ERRORS, STATES } from './washer_common'
+
+// LG F4J7TN1W (ThinQ Model ID WTWN3, deviceType 201): 8 kg front-load washer, TITAN2 platform,
+// ThinQ1 with the QCA4002 module (FwVer QC_Modem_1.2.80). Same 28-byte status layout as WTDN3
+// (F2J7HG1W) minus the dryer: byte 11 is undefined for this model. Field offsets and enum codes
+// come from LG's own modelJson for WTWN3 (Monitoring.protocol / Value); labels are the English
+// language-pack text.
+//
+// Confirmed on a real F4J7TN1W: power/status, the Ready and Off frames, door lock and the tub clean
+// counter. The option bits, child lock, remote start and the Start/Pause/Power commands follow the
+// spec and the WTDN3 handler; they have not been exercised on this washer yet.
+
+// Course (byte 5) and SmartCourse (byte 20, downloaded courses) share one label space. A non-zero
+// SmartCourse overrides the base course, as on WTDN3.
+export const COURSES = Enum.of({
+    Cotton: 0x01,
+    'Easy Care': 0x02,
+    'Cotton+': 0x04,
+    Duvet: 0x05,
+    'Stain Care': 0x06,
+    Mix: 0x07,
+    'Sports Wear': 0x08,
+    'Silent Wash': 0x09,
+    'Gentle Care': 0x0b,
+    'Speed 14': 0x0c,
+    'Tub Clean': 0x12,
+    Delicate: 0x20,
+    'Baby Steam Care': 0x2c,
+    'Allergy SpaSteam': 0x2d,
+    // downloaded ("smart") courses
+    'Kids Wear': 0x34,
+    'School Uniform': 0x35,
+    'Swimming Wear': 0x36,
+    'Rainy Season': 0x37,
+    'Gym Clothes': 0x38,
+    Jeans: 0x39,
+    Blanket: 0x3a,
+    'Sweat Stain': 0x3b,
+    'Single Garment': 0x3e,
+    'Color Protection': 0x3f,
+    'Noise Minimize': 0x40,
+    'Small Load': 0x49,
+    Lingerie: 0x4a,
+    Wool: 0x4b,
+    'Cold Wash': 0x4d,
+    'Rinse + Spin': 0x64,
+    'Lightly Soiled Items': 0x65,
+    'Minimize Detergent Residue': 0x66,
+    '1hr. Wash': 0x67,
+    'Sleeve Hems and Collars': 0x6b,
+    'Juice and Food Stains': 0x6c,
+    'Minimize Wrinkles': 0x6f,
+})
+
+export const WASH = Enum.of({
+    'Turbo Wash': 1,
+    'Time Save': 2,
+    Normal: 3,
+    Intensive: 4,
+})
+
+export const TEMPERATURES = Enum.of({
+    Cold: 1,
+    '20': 2,
+    '30': 3,
+    '40': 4,
+    '50': 5,
+    '60': 6,
+    '95': 7,
+})
+
+export const RINSE = Enum.of({
+    Normal: 1,
+    'Rinse+': 2,
+    'Rinse++': 3,
+    'Normal + Hold': 4,
+    'Rinse+ + Hold': 5,
+})
+
+// RPM by code; 0 = not set, 0xff = course maximum (reported as unknown).
+export const SPINS = [undefined, 0, 400, 600, 700, 800, 900, 1000, 1100, 1200, 1400, 1600]
+
+// Option1 (byte 14) bit flags
+const OPT1_TURBO_WASH = 0x01
+const OPT1_CREASE_CARE = 0x02
+const OPT1_MEDIC_RINSE = 0x10
+const OPT1_PRE_WASH = 0x40
+const OPT1_STEAM = 0x80
+
+// Option2 (byte 15) bit flags
+const OPT2_REMOTE_START = 0x02
+const OPT2_DOOR_LOCK = 0x40
+const OPT2_CHILD_LOCK = 0x80
+
+export default class Device extends HADevice {
+    constructor(
+        HA: Connection,
+        readonly thinq: Thinq1Device,
+        meta: Metadata,
+    ) {
+        super(HA, thinq.id)
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: 'LG Washer' }),
+                components: {
+                    power: {
+                        platform: 'switch',
+                        unique_id: '$deviceid-power',
+                        state_topic: '$this/power',
+                        command_topic: '$this/power/set',
+                        name: '',
+                        icon: 'mdi:washing-machine',
+                    },
+                    start: {
+                        platform: 'button',
+                        unique_id: '$deviceid-start',
+                        command_topic: '$this/start/set',
+                        payload_press: '',
+                        name: 'Start',
+                        icon: 'mdi:play-circle-outline',
+                    },
+                    pause: {
+                        platform: 'button',
+                        unique_id: '$deviceid-pause',
+                        command_topic: '$this/pause/set',
+                        payload_press: '',
+                        name: 'Pause',
+                        icon: 'mdi:pause-circle-outline',
+                    },
+                    status: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-status',
+                        state_topic: '$this/status',
+                        name: 'Status',
+                        icon: 'mdi:state-machine',
+                        device_class: 'enum',
+                        options: STATES.options,
+                    },
+                    error: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-error',
+                        state_topic: '$this/error',
+                        name: 'Error',
+                        icon: 'mdi:check-circle',
+                        device_class: 'problem',
+                        entity_category: 'diagnostic',
+                    },
+                    error_message: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-error-message',
+                        state_topic: '$this/error_message',
+                        name: 'Error message',
+                        icon: 'mdi:alert-circle-outline',
+                        device_class: 'enum',
+                        entity_category: 'diagnostic',
+                        options: ERRORS.options,
+                    },
+                    course: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-course',
+                        state_topic: '$this/course',
+                        name: 'Course',
+                        icon: 'mdi:pin-outline',
+                        device_class: 'enum',
+                        options: COURSES.options,
+                    },
+                    wash: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-wash',
+                        state_topic: '$this/wash',
+                        name: 'Wash',
+                        icon: 'mdi:waves',
+                        device_class: 'enum',
+                        options: WASH.options,
+                    },
+                    temp: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-temp',
+                        state_topic: '$this/temp',
+                        name: 'Temperature',
+                        icon: 'mdi:thermometer',
+                        device_class: 'enum',
+                        options: TEMPERATURES.options,
+                    },
+                    spin: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-spin',
+                        state_topic: '$this/spin',
+                        name: 'Spin',
+                        icon: 'mdi:autorenew',
+                        unit_of_measurement: 'RPM',
+                    },
+                    rinse: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-rinse',
+                        state_topic: '$this/rinse',
+                        name: 'Rinse',
+                        icon: 'mdi:water',
+                        device_class: 'enum',
+                        options: RINSE.options,
+                    },
+                    turbo_wash: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-turbo_wash',
+                        state_topic: '$this/turbo_wash',
+                        name: 'TurboWash',
+                        icon: 'mdi:speedometer',
+                    },
+                    pre_wash: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-pre_wash',
+                        state_topic: '$this/pre_wash',
+                        name: 'Pre-wash',
+                        icon: 'mdi:water-plus-outline',
+                    },
+                    steam: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-steam',
+                        state_topic: '$this/steam',
+                        name: 'Steam',
+                        icon: 'mdi:weather-fog',
+                    },
+                    crease_care: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-crease_care',
+                        state_topic: '$this/crease_care',
+                        name: 'Crease care',
+                        icon: 'mdi:iron-outline',
+                    },
+                    medic_rinse: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-medic_rinse',
+                        state_topic: '$this/medic_rinse',
+                        name: 'Medic rinse',
+                        icon: 'mdi:medical-bag',
+                    },
+                    tub_clean_count: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-tub_clean_count',
+                        state_topic: '$this/tub_clean_count',
+                        name: 'Washes since tub clean',
+                        icon: 'mdi:counter',
+                        entity_category: 'diagnostic',
+                    },
+                    remote_start: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-remote_start',
+                        state_topic: '$this/remote_start',
+                        name: 'Remote start',
+                        icon: 'mdi:play-circle-outline',
+                    },
+                    door_lock: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-door_lock',
+                        state_topic: '$this/door_lock',
+                        name: 'Door lock',
+                        device_class: 'lock',
+                    },
+                    child_lock: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-child_lock',
+                        state_topic: '$this/child_lock',
+                        name: 'Child lock',
+                        icon: 'mdi:lock-outline',
+                    },
+                    standby: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-standby',
+                        state_topic: '$this/standby',
+                        name: 'Standby',
+                        icon: 'mdi:power-sleep',
+                        entity_category: 'diagnostic',
+                    },
+                    initial_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-initial_time',
+                        state_topic: '$this/initial_time',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        name: 'Initial time',
+                    },
+                    remaining_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-remaining_time',
+                        state_topic: '$this/remaining_time',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        name: 'Remaining time',
+                    },
+                    reserve_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-reserve_time',
+                        state_topic: '$this/reserve_time',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        name: 'Delay start',
+                        icon: 'mdi:timer-sand',
+                    },
+                },
+            }),
+        )
+
+        thinq.on('data', (buf) => {
+            if (buf.length == 28) {
+                const status = buf[0]
+                const time_remain = buf[1] * 60 + buf[2]
+                const time_initial = buf[3] * 60 + buf[4]
+                const native_course = buf[5]
+                const error = buf[6]
+                const wash = buf[7]
+                const spin = buf[8]
+                const temp = buf[9]
+                const rinse = buf[10]
+                const reserve = buf[12] * 60 + buf[13]
+                const option1 = buf[14]
+                const option2 = buf[15]
+                const smart_course = buf[20]
+                const tub_clean_count = buf[21]
+                const standby = buf[27]
+
+                this.publishProperty('power', status > 0 ? 'ON' : 'OFF')
+                this.publishProperty('error_message', ERRORS.map(error)) // publish message before set error state
+                this.publishProperty('error', error ? 'ON' : 'OFF')
+                this.publishProperty('status', STATES.map(status))
+                this.publishProperty('course', COURSES.map(smart_course) ?? COURSES.map(native_course))
+                this.publishProperty('wash', WASH.map(wash))
+                this.publishProperty('spin', SPINS[spin])
+                this.publishProperty('temp', TEMPERATURES.map(temp))
+                this.publishProperty('rinse', RINSE.map(rinse))
+                this.publishProperty('turbo_wash', option1 & OPT1_TURBO_WASH ? 'ON' : 'OFF')
+                this.publishProperty('crease_care', option1 & OPT1_CREASE_CARE ? 'ON' : 'OFF')
+                this.publishProperty('medic_rinse', option1 & OPT1_MEDIC_RINSE ? 'ON' : 'OFF')
+                this.publishProperty('pre_wash', option1 & OPT1_PRE_WASH ? 'ON' : 'OFF')
+                this.publishProperty('steam', option1 & OPT1_STEAM ? 'ON' : 'OFF')
+                this.publishProperty('tub_clean_count', tub_clean_count)
+                this.publishProperty('remote_start', option2 & OPT2_REMOTE_START ? 'ON' : 'OFF')
+                this.publishProperty('door_lock', !(option2 & OPT2_DOOR_LOCK) ? 'ON' : 'OFF') // lock class: ON = unlocked
+                this.publishProperty('child_lock', option2 & OPT2_CHILD_LOCK ? 'ON' : 'OFF')
+                this.publishProperty('standby', standby ? 'ON' : 'OFF')
+                this.publishProperty('initial_time', time_initial)
+                this.publishProperty('remaining_time', time_remain)
+                this.publishProperty('reserve_time', reserve)
+            }
+        })
+    }
+
+    start() {
+        this.thinq.send({ Cmd: 'Mon', CmdOpt: 'Start' })
+    }
+
+    publishCache = new Map<string, string | number | undefined>()
+
+    publishProperty(prop: string, value: string | number | undefined) {
+        // has() first: an undefined value on a never-published property must still go out
+        if (this.publishCache.has(prop) && this.publishCache.get(prop) === value) return
+
+        this.publishCache.set(prop, value)
+        this.HA.publishProperty(this.id, prop, value)
+    }
+
+    setProperty(prop: string, mqttValue: string) {
+        if (prop === 'power') {
+            if (mqttValue === 'ON') {
+                this.thinq.send({ Cmd: 'Control', CmdOpt: 'Power', Value: 'On', Format: 'B64', Data: '' })
+            } else if (mqttValue === 'OFF') {
+                this.thinq.send({ Cmd: 'Control', CmdOpt: 'Power', Value: 'Off', Format: 'B64', Data: '' })
+            }
+        }
+        if (prop === 'pause')
+            this.thinq.send({ Cmd: 'Control', CmdOpt: 'Operation', Value: 'Stop', Format: 'B64', Data: '' })
+        if (prop === 'start')
+            this.thinq.send({ Cmd: 'Control', CmdOpt: 'Operation', Value: 'Start', Format: 'B64', Data: mqttValue })
+    }
+}

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -22,6 +22,7 @@ import F3L2CYU__ from './devices/F3L2CYU__'
 import F3L7CYK5W_US_WIFI from './devices/F3L7CYK5W_US_WIFI'
 import RV13B6BSD_D_US_WIFI from './devices/RV13B6BSD_D_US_WIFI'
 import RV13B6ES_D_US_WIFI from './devices/RV13B6ES_D_US_WIFI'
+import RC90U2_WW from './devices/RC90U2_WW'
 import WTL_FXU_BDV_NA_01 from './devices/WTL_FXU_BDV_NA_01'
 import DHUM_056905_WW from './devices/DHUM_056905_WW'
 import ST_B_E4H01Y_APL from './devices/ST_B_E4H01Y_APL'
@@ -71,6 +72,8 @@ const t2deviceTypes: Record<string, T2Factory> = {
     ['RV13B6BSD_D_US_WIFI']: RV13B6BSD_D_US_WIFI, // LG electric dryer
     ['RV13B6ES_D_US_WIFI']: RV13B6ES_D_US_WIFI, // LG electric dryer, same frame layout as RV13B6BSD but
     // Wrinkle Care sits in a different bitfield, so it needs its own handler rather than an alias
+    // LG RC9DN9029 heat pump dryer (EU), same AABB dialect as the two dryers above but with the 25-byte EU record layout
+    RC90U2_WW,
     WTL_FXU_BDV_NA_01, // LG WashTower
     DHUM_056905_WW,
     ST_B_E4H01Y_APL,

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -1,5 +1,6 @@
 import POT_056905_WW from './devices/POT_056905_WW'
 import WTDN3 from './devices/WTDN3'
+import WTWN3 from './devices/WTWN3'
 import RAC_056905_WW from './devices/RAC_056905_WW'
 import WIN_056905_WW from './devices/WIN_056905_WW'
 import Dev_2REF11EIDA__4 from './devices/2REF11EIDA__4'
@@ -36,6 +37,7 @@ type T2Factory = new (HA: Connection, thinq: T2Device, metadata: Metadata) => HA
 
 const t1deviceTypes: Record<string, T1Factory> = {
     WTDN3,
+    WTWN3, // LG F4J7TN1W front-load washer (ThinQ1, QCA4002 module)
 }
 
 const t2deviceTypes: Record<string, T2Factory> = {

--- a/tests/cloud/devices/RC90U2_WW.test.ts
+++ b/tests/cloud/devices/RC90U2_WW.test.ts
@@ -1,0 +1,247 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/RC90U2_WW'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'RC90U2_WW'
+const META: Metadata = { modelId: MODEL_ID, modelName: MODEL_ID, swVersion: '2.9.61' }
+
+// All fixtures are REAL frames captured live from an RC9DN9029 via rethink on 2026-09-08 while
+// driving the panel; the comments say what the panel showed. Field meanings come from LG's modelJson
+// for RC90U2_WW, whose Monitoring.protocol the 25-byte record follows byte for byte.
+
+// Reply to the F0ED status request: on, Cotton selected, Cupboard, Eco, estimate 2:30.
+const EB_READY_COTTON = buf('aa2130eb001901021e00000700030102000000000804000000000000006b00f1bb')
+
+// Power button: Ready/Cotton -> Off. The off record keeps the option base bits and shows 01 at byte 19.
+const POWER_OFF = buf(
+    'AA3C30EC001901021E00000700030102000000000804000000000000006B00001900000000000000000000000000000804000000010000006B0004BB',
+)
+// Power button again: Off -> on with no course yet (all course fields zero).
+const POWER_ON_NO_COURSE = buf(
+    'AA3C30EC001900000000000000000000000000000804000000010000006B00001901000000000000000000000000000804000000000000006B0071BB',
+)
+// Knob: -> Mixed Fabric, Cupboard, Eco Hybrid "Time", estimate 1:10.
+const COURSE_MIXED = buf(
+    'AA3C30EC001901021E00000700030102000000000804000000000000006B00001901010A00000600030302000000000804000000000000006B003FBB',
+)
+// Knob: -> Duvet, no dry level (timed course), Eco Hybrid "Time", estimate 2:55.
+const COURSE_DUVET = buf(
+    'AA3C30EC001901010A00000600030302000000000804000000000000006B00001901023700000400000302000000000804000000000000006B002ABB',
+)
+// Delay End button: reserve hours 0 -> 3 in both reserve fields and Option1 bit 0 set (0x08 -> 0x09).
+const DELAY_END_ON = buf(
+    'AA3C30EC001901021E00000700030102000000000804000000000000006B00001901021E00000700030102030003000904000000000000006B00D0BB',
+)
+// Dry level button: Cotton Cupboard/Eco -> Cotton Iron/Time, estimate 1:30.
+const DRY_LEVEL_IRON = buf(
+    'AA3C30EC001901021E00000700030102000000000804000000000000006B00001901011E00000700010302000000000804000000000000006B0028BB',
+)
+// Knob: Allergy Care, timed course (no dry level), Eco Hybrid "Time", 3:00.
+const COURSE_ALLERGY_CARE = buf(
+    'AA3C30EC001901023700000400000302000000000004000000000000006B00001901030000001000000302000000000004000000000000006B003BBB',
+)
+// Knob: the Downloaded Course position, holding Deodorization (rec[20] = 0x6B on base course 0x01), 0:39.
+const COURSE_DOWNLOADED_DEODORIZATION = buf(
+    'AA3C30EC001901001E00000900000302000000000004000000000000006B00001901002700000100000304000000000004000000006B00006B008FBB',
+)
+// Knob: Cool Air, no Eco Hybrid, sub-phase byte 5 (cooling) while idle, 1:00.
+const COURSE_COOL_AIR = buf(
+    'AA3C30EC001901010F00000E00000102000000000004000000000000006B00001901010000000D00000005000000000004000000000000006B001DBB',
+)
+// Start button on Cool Air 0:30: State 01 -> 02, initial time filled in, ProcessState 5 (cooling).
+const START_COOL_AIR = buf(
+    'AA3C30EC001901001E00000D00000005000000000004000000000000006B00001902001E001E0D00000005000000000005000000010000006B00C0BB',
+)
+// Short 0x72 frame seen right after Start; must be ignored.
+const START_EVENT = buf('AA09307200C9004BBB')
+// Serial/part-number frame sent on connect; must be ignored.
+const SERIAL_FRAME = buf(
+    'AA3730310201534141333939333530303900007FD200008000000000000253414133393933343931320000A36700004000000000000FBB',
+)
+// Five-byte power events around power toggles; must be ignored.
+const POWER_EVENT = buf('AA07301900AFBB')
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('config exposes expected components', () => {
+        const { ha } = makeDevice()
+        const cfg = ha.devices[DEVICE_ID].config
+        assert.ok(cfg, 'config published on construction')
+        const components = cfg!.components as Record<string, Record<string, unknown>>
+        for (const c of [
+            'power',
+            'status',
+            'phase',
+            'error',
+            'error_message',
+            'course',
+            'dry_level',
+            'eco_hybrid',
+            'remaining_time',
+            'initial_time',
+            'reserve_time',
+            'delay',
+            'anti_crease',
+            'child_lock',
+            'damp_dry_beep',
+            'hand_iron',
+        ]) {
+            assert.ok(components[c], `component ${c} present`)
+        }
+        assert.ok((components.status.options as string[]).includes('Running'))
+        assert.ok((components.course.options as string[]).includes('Cotton'))
+        assert.ok((components.dry_level.options as string[]).includes('Cupboard'))
+    })
+
+    test('start() asks for a status snapshot with the family-wide F0ED request', () => {
+        const { thinq, dev } = makeDevice()
+        dev.start()
+        assert.deepEqual(
+            thinq.outbox.map((b) => b.toString('hex')),
+            ['aa0ef0ed1121010000001800b5bb'],
+        )
+    })
+
+    test('0xEB reply decodes Ready / Cotton / Cupboard / Eco / 2:30', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', EB_READY_COTTON)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.power, 'ON')
+        assert.equal(props.status, 'Ready')
+        assert.equal(props.phase, 'None') // sub-phase is stale while idle
+        assert.equal(props.course, 'Cotton')
+        assert.equal(props.dry_level, 'Cupboard')
+        assert.equal(props.eco_hybrid, 'Eco')
+        assert.equal(props.remaining_time, 150)
+        assert.equal(props.initial_time, 0)
+        assert.equal(props.reserve_time, 0)
+        assert.equal(props.error, 'OFF')
+        assert.equal(props.error_message, 'OK')
+        assert.equal(props.delay, 'OFF')
+        assert.equal(props.anti_crease, 'OFF')
+        assert.equal(props.child_lock, 'OFF')
+        assert.equal(props.damp_dry_beep, 'OFF')
+        assert.equal(props.hand_iron, 'OFF')
+    })
+
+    test('0xEC frames use the second (current) record: power off clears the course fields', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', POWER_OFF)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.power, 'OFF')
+        assert.equal(props.status, 'Off')
+        assert.equal(props.course, 'None')
+        assert.equal(props.dry_level, 'None')
+        assert.equal(props.eco_hybrid, 'None')
+        assert.equal(props.remaining_time, 0)
+    })
+
+    test('power on without a course reads Ready with unknown course', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', POWER_ON_NO_COURSE)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.power, 'ON')
+        assert.equal(props.status, 'Ready')
+        assert.equal(props.course, 'None')
+        assert.equal(props.remaining_time, 0)
+    })
+
+    test('course knob: Mixed Fabric and Duvet with their defaults', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', COURSE_MIXED)
+        let props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.course, 'Mixed Fabric')
+        assert.equal(props.dry_level, 'Cupboard')
+        assert.equal(props.eco_hybrid, 'Time')
+        assert.equal(props.remaining_time, 70)
+
+        thinq.emit('data', COURSE_DUVET)
+        props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.course, 'Duvet')
+        assert.equal(props.dry_level, 'None') // timed course, no dry level
+        assert.equal(props.eco_hybrid, 'Time')
+        assert.equal(props.remaining_time, 175)
+    })
+
+    test('timed courses, a downloaded course and Cool Air decode from the knob sweep', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', COURSE_ALLERGY_CARE)
+        let props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.course, 'Allergy Care')
+        assert.equal(props.dry_level, 'None')
+        assert.equal(props.eco_hybrid, 'Time')
+        assert.equal(props.remaining_time, 180)
+
+        thinq.emit('data', COURSE_DOWNLOADED_DEODORIZATION)
+        props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.course, 'Deodorization') // downloaded course overrides base course 0x01
+        assert.equal(props.remaining_time, 39)
+
+        thinq.emit('data', COURSE_COOL_AIR)
+        props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.course, 'Cool Air')
+        assert.equal(props.eco_hybrid, 'None')
+        assert.equal(props.phase, 'None') // sub-phase is not published while idle
+        assert.equal(props.remaining_time, 60)
+    })
+
+    test('Delay End sets the reserve time and the Reservation option bit', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', DELAY_END_ON)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.delay, 'ON')
+        assert.equal(props.reserve_time, 180)
+        assert.equal(props.course, 'Cotton')
+        // the always-on base bit 0x08 must not leak into any option entity
+        assert.equal(props.anti_crease, 'OFF')
+        assert.equal(props.child_lock, 'OFF')
+    })
+
+    test('dry level button: Cupboard -> Iron changes the estimate', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', DRY_LEVEL_IRON)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.dry_level, 'Iron')
+        assert.equal(props.eco_hybrid, 'Time')
+        assert.equal(props.remaining_time, 90)
+    })
+
+    test('Start on Cool Air: Running with the cooling phase and the full time left', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', START_COOL_AIR)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.power, 'ON')
+        assert.equal(props.status, 'Running')
+        assert.equal(props.phase, 'Cooling')
+        assert.equal(props.course, 'Cool Air')
+        assert.equal(props.dry_level, 'None')
+        assert.equal(props.eco_hybrid, 'None')
+        assert.equal(props.remaining_time, 30)
+        assert.equal(props.initial_time, 30)
+        assert.equal(props.delay, 'OFF')
+        assert.equal(props.error, 'OFF')
+    })
+
+    test('serial, power-event and start-event frames are ignored', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SERIAL_FRAME)
+        thinq.emit('data', POWER_EVENT)
+        thinq.emit('data', START_EVENT)
+        assert.deepEqual(ha.devices[DEVICE_ID].properties, {})
+    })
+
+    test('a 0xEC frame with a wrong length is rejected', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', buf('aa0830ec0019010000bb'))
+        assert.deepEqual(ha.devices[DEVICE_ID].properties, {})
+    })
+})

--- a/tests/cloud/devices/WTWN3.test.ts
+++ b/tests/cloud/devices/WTWN3.test.ts
@@ -1,0 +1,204 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/WTWN3'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq1Device, buf } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'WTWN3'
+const META: Metadata = { modelId: MODEL_ID, modelName: 'WTWN3', swVersion: '1.0' }
+
+// Samples: a real Mix cycle captured from a WTWN3 by the local_smarthinq1 project
+// (flows/washer-cycle-20260719.log), decoded there against LG's modelJson:
+// Course Mix, Wash Normal, Spin 1000, Temp 40, Rinse+, TCLCount 57.
+const SAMPLE_STATE_WASHING_MIX_1H33 = buf('06012101210700030704020000000040000001030039006400000400')
+const SAMPLE_STATE_RINSING_MIX_0H47 = buf('07002f01210700030700020000000040000001060039006400000400')
+const SAMPLE_STATE_SPINNING_MIX_0H11 = buf('08000b01210700000700000000000040000001070039006400000400')
+const SAMPLE_STATE_END_MIX = buf('0a000001210700000000000000000000000001080039006400000400')
+const SAMPLE_STATE_OFF_IDLE = buf('000000012107000000000000000000000000020a0039006400000400')
+// Real frame from the author's F4J7TN1W (2026-09-08): Tub Clean just started, Measuring, 1:14, door locked,
+// 41 washes since the last tub clean.
+const SAMPLE_STATE_MEASURING_TUB_CLEAN_LOCKED = buf(
+    '04 01 0e 01 0e 12 00 03 01 06 01 00 00 00 00 40 00 00 01 01 00 29 00 4b 00 00 02 00',
+)
+// Synthetic (bit layout from modelJson Option1/Option2): Ready, Cotton 1200/40, remaining 2:10,
+// delay start 3:00, TurboWash|PreWash|Steam set, remote start + child lock set, door unlocked.
+const SAMPLE_STATE_READY_COTTON_OPTIONS = buf(
+    '01 02 0a 02 0a 01 00 03 09 04 01 00 03 00 c1 82 00 00 00 00 00 39 00 64 00 00 04 00',
+)
+// Synthetic: error DE1 with downloaded course Jeans (0x39 at byte 20) overriding base course 3
+const SAMPLE_STATE_ERROR_DE1_SMART_JEANS = buf(
+    '12 01 0e 01 0e 03 02 03 07 02 01 00 00 00 00 00 00 00 00 00 39 39 00 64 00 00 04 00',
+)
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq1Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('config exposes expected components', () => {
+        const { ha } = makeDevice()
+        const cfg = ha.devices[DEVICE_ID].config
+        assert.ok(cfg, 'config published on construction')
+        const components = cfg!.components as Record<string, Record<string, unknown>>
+        for (const c of [
+            'power',
+            'start',
+            'pause',
+            'status',
+            'error',
+            'error_message',
+            'course',
+            'wash',
+            'temp',
+            'spin',
+            'rinse',
+            'turbo_wash',
+            'pre_wash',
+            'steam',
+            'crease_care',
+            'medic_rinse',
+            'tub_clean_count',
+            'remote_start',
+            'door_lock',
+            'child_lock',
+            'standby',
+            'initial_time',
+            'remaining_time',
+            'reserve_time',
+        ]) {
+            assert.ok(components[c], `component ${c} present`)
+        }
+        assert.ok((components.status.options as string[]).includes('Washing'))
+        assert.ok((components.course.options as string[]).includes('Mix'))
+        assert.ok((components.temp.options as string[]).includes('Cold'))
+    })
+
+    test('washing state decodes course, options and times from a real capture', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_STATE_WASHING_MIX_1H33)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.power, 'ON')
+        assert.equal(props.status, 'Washing')
+        assert.equal(props.course, 'Mix')
+        assert.equal(props.wash, 'Normal')
+        assert.equal(props.spin, 1000)
+        assert.equal(props.temp, '40')
+        assert.equal(props.rinse, 'Rinse+')
+        assert.equal(props.remaining_time, 93)
+        assert.equal(props.initial_time, 93)
+        assert.equal(props.reserve_time, 0)
+        assert.equal(props.error, 'OFF')
+        assert.equal(props.error_message, 'OK')
+        assert.equal(props.door_lock, 'OFF') // OFF means locked
+        assert.equal(props.child_lock, 'OFF')
+        assert.equal(props.remote_start, 'OFF')
+        assert.equal(props.tub_clean_count, 57)
+        assert.equal(props.standby, 'OFF')
+    })
+
+    test('tub clean start: Measuring with the door locked, from a live frame', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_STATE_MEASURING_TUB_CLEAN_LOCKED)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.power, 'ON')
+        assert.equal(props.status, 'Measuring')
+        assert.equal(props.course, 'Tub Clean')
+        assert.equal(props.wash, 'Normal')
+        assert.equal(props.spin, 0)
+        assert.equal(props.temp, '60')
+        assert.equal(props.rinse, 'Normal')
+        assert.equal(props.remaining_time, 74)
+        assert.equal(props.initial_time, 74)
+        assert.equal(props.door_lock, 'OFF') // locked
+        assert.equal(props.child_lock, 'OFF')
+        assert.equal(props.tub_clean_count, 41)
+    })
+
+    test('rinse and spin phases follow the state byte', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_STATE_RINSING_MIX_0H47)
+        let props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.status, 'Rinsing')
+        assert.equal(props.remaining_time, 47)
+        assert.equal(props.temp, 'None') // temperature cleared once washing is over
+
+        thinq.emit('data', SAMPLE_STATE_SPINNING_MIX_0H11)
+        props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.status, 'Spinning')
+        assert.equal(props.remaining_time, 11)
+        assert.equal(props.spin, 1000)
+    })
+
+    test('end state keeps power on, door unlocked', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_STATE_END_MIX)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.power, 'ON')
+        assert.equal(props.status, 'End')
+        assert.equal(props.remaining_time, 0)
+        assert.equal(props.door_lock, 'ON')
+    })
+
+    test('idle state publishes power=OFF and "Off" status', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_STATE_OFF_IDLE)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.power, 'OFF')
+        assert.equal(props.status, 'Off')
+        assert.equal(props.course, 'Mix') // last course stays visible on the panel
+        assert.equal(props.tub_clean_count, 57)
+    })
+
+    test('option bits, delay start and locks decode', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_STATE_READY_COTTON_OPTIONS)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.status, 'Ready')
+        assert.equal(props.course, 'Cotton')
+        assert.equal(props.spin, 1200)
+        assert.equal(props.temp, '40')
+        assert.equal(props.remaining_time, 130)
+        assert.equal(props.reserve_time, 180)
+        assert.equal(props.turbo_wash, 'ON')
+        assert.equal(props.pre_wash, 'ON')
+        assert.equal(props.steam, 'ON')
+        assert.equal(props.crease_care, 'OFF')
+        assert.equal(props.medic_rinse, 'OFF')
+        assert.equal(props.remote_start, 'ON')
+        assert.equal(props.child_lock, 'ON')
+        assert.equal(props.door_lock, 'ON') // unlocked
+    })
+
+    test('downloaded course overrides the base course; error publishes message', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', SAMPLE_STATE_ERROR_DE1_SMART_JEANS)
+        const props = ha.devices[DEVICE_ID].properties
+        assert.equal(props.status, 'Error')
+        assert.equal(props.error, 'ON')
+        assert.equal(props.error_message, 'Door open error (DE1)')
+        assert.equal(props.course, 'Jeans')
+    })
+
+    test('ignores frames that are not 28 bytes', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', buf('0102'))
+        assert.deepEqual(ha.devices[DEVICE_ID].properties, {})
+    })
+
+    test('power switch and buttons send ThinQ1 Control commands', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.setProperty('power', 'OFF')
+        dev.setProperty('pause', '')
+        dev.setProperty('start', '')
+        assert.deepEqual(thinq.sent, [
+            { Cmd: 'Control', CmdOpt: 'Power', Value: 'Off', Format: 'B64', Data: '' },
+            { Cmd: 'Control', CmdOpt: 'Operation', Value: 'Stop', Format: 'B64', Data: '' },
+            { Cmd: 'Control', CmdOpt: 'Operation', Value: 'Start', Format: 'B64', Data: '' },
+        ])
+    })
+})


### PR DESCRIPTION
Two new handlers, one commit each, with tests against captured frames.

- WTWN3 (LG F4J7TN1W), ThinQ1 washer. Same frame as WTDN3 minus the dryer byte; tables from LG's modelJson. Confirmed live: power, states up to Washing, course/wash/spin/temp/rinse, times, door lock, tub clean count. Option bits, child lock, remote start and the commands are spec-only so far (synthetic fixtures, labelled).

- RC90U2_WW (LG RC9DN9029), ThinQ2 heat pump dryer. US-dryer AABB dialect with the 25-byte EU record from LG's modelJson. Read-only. Confirmed live: power, Ready/Running, phase, 11 courses, dry level, Eco Hybrid, times, Delay End. Damp dry beep, hand iron, errors and Paused/End are spec-only. Unexplained bits are not exposed.