### PR TITLE
Fix WIN_056905_WW discovery config: nest device name under device.name

### DIFF
--- a/cloud/devices/WIN_056905_WW.ts
+++ b/cloud/devices/WIN_056905_WW.ts
@@ -24,8 +24,7 @@ export default class Device extends TLVDevice {
     constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
         super(HA, thinq)
         const config: DeviceDiscovery = allowExtendedType({
-            ...HADevice.config(meta),
-            name: 'LG Air Conditioner',
+            ...HADevice.config(meta, { name: 'LG Air Conditioner' }),
             components: {
                 climate: {
                     platform: 'climate',


### PR DESCRIPTION
The handler set 'name' at the top level of the MQTT discovery payload instead of inside the device object, which every other handler does via HADevice.config(meta, { name }). A stray top-level field appears to make Home Assistant silently reject the whole discovery message — the device worked fine at the protocol/MQTT-state level but never appeared as an entity in HA.