### PR TITLE
Fix WIN_056905_WW.ts protocol mapping and add filter/timer/power support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following appliances are currently supported in rethink:
 - Air Conditioners:
     - 👍 LG DualCool family (Standard 2, Deluxe with and without air purifier, etc.) wall-mounted Air Conditioner IDUs - high level of support. What's missing are mostly some features of higher-end models and more diagnostic coverage,
     - 👍 LW1822HRSM, Smart Window Air Conditioner - mostly working,
+    - 👍 LW1822IVSM, Smart Window Air Conditioner - mostly working, including filter tracking, off timer and power measurement,
     - 👍 LP1022FVSM Portable Air Conditioner - mostly working,
 - Fridges:
     - 🫤 LF28H8330S, Standard-Depth 4-Door French Door Refrigerator - preliminary support,

--- a/cloud/devices/WIN_056905_WW.ts
+++ b/cloud/devices/WIN_056905_WW.ts
@@ -52,9 +52,25 @@ export default class Device extends TLVDevice {
                     platform: 'climate',
                     unique_id: '$deviceid-climate',
                     name: null,
-                    temperature_unit: 'C',
-                    temp_step: 0.5,
-                    precision: 0.5,
+                    // Native unit is deliberately Fahrenheit, not the wire protocol's Celsius. This
+                    // unit only ever displays/accepts whole-degree Fahrenheit (61-86F, see the
+                    // temperature field's clamp below); if the entity's native unit were 'C' with a
+                    // 0.5 step, an HA instance running an imperial unit system would round-trip every
+                    // setpoint through an unaligned Celsius grid (e.g. typing 74F snaps to 23.5C,
+                    // which displays back as 74.5F, while the AC's own firmware converts that same
+                    // 23.5C to 75F on its panel) — confirmed live (2026-09-09). Declaring 'F' here
+                    // means HA never does that conversion; write_xform/read_xform below do the
+                    // C<->F math once, explicitly, against the wire's Celsius-based raw value.
+                    temperature_unit: 'F',
+                    temp_step: 1,
+                    precision: 1,
+                    // HA's MQTT climate min_temp/max_temp default to 7/35 -- correct for the old
+                    // Celsius-native config (bracketing 16-30C) but silently wrong now that the
+                    // entity's native unit is 'F': undeclared, they'd be read as 7-35 Fahrenheit,
+                    // far below the AC's real 61-86F range, clamping the setpoint slider. Must
+                    // match the clamp in the temperature field's write_xform below.
+                    min_temp: 61,
+                    max_temp: 86,
                     modes: ['off', 'cool', 'dry', 'fan_only', 'heat'],
                     fan_modes: FAN_MODES.options,
                     swing_modes: SWING_MODES.options,
@@ -93,22 +109,23 @@ export default class Device extends TLVDevice {
             comp: 'climate',
             state_topic: 'topic',
             writable: false,
-            read_xform: (raw) => raw / 2,
+            // raw is Celsius*2 on the wire; convert to whole Fahrenheit to match the entity's
+            // native unit (see the climate component's temperature_unit comment above).
+            read_xform: (raw) => Math.round((raw / 2) * (9 / 5) + 32),
         })
 
         this.addField(config, {
             id: 0x1fe,
             name: 'temperature',
             comp: 'climate',
-            read_xform: (raw) => raw / 2,
+            read_xform: (raw) => Math.round((raw / 2) * (9 / 5) + 32),
             write_xform: (valStr) => {
                 const val = Number(valStr)
-                // set val to min: 61F, max: 86F
-                const minCel = 16
-                const maxCel = 30.0
-                if (val < minCel) return minCel * 2
-                if (val > maxCel) return maxCel * 2
-                return Math.round(val * 2)
+                const minF = 61
+                const maxF = 86
+                const clampedF = Math.min(maxF, Math.max(minF, val))
+                const cel = ((clampedF - 32) * 5) / 9
+                return Math.round(cel * 2)
             },
             write_attach: [0x1f9, 0x1fa],
         })

--- a/cloud/devices/WIN_056905_WW.ts
+++ b/cloud/devices/WIN_056905_WW.ts
@@ -9,6 +9,7 @@ import { Enum } from '@/util/enum'
 
 const FAN_MODES = Enum.of({
     low: 2,
+    medium: 4,
     high: 6,
 })
 
@@ -18,14 +19,34 @@ const SWING_MODES = Enum.of({
 })
 
 /**
- * LG Air Conditioner Model LW1823HRSM
+ * LG Air Conditioner Models LW1822HRSM, LW1822IVSM
+ *
+ * The two share this handler (same reported modelId, WIN_056905_WW), but are not a trivial
+ * alias of each other — real differences were found and fixed against a real LW1822IVSM
+ * (2026-09-09): the 'dry' mode's raw value was wrong (was 8, actually Energy Saver; corrected to
+ * 1), 'medium' fan speed was missing, and Energy Saver/filter tracking/off timer/power
+ * measurement were entirely unimplemented. 'heat' (raw mode 4) remains unconfirmed on either
+ * model — kept from the original HRSM-only implementation, but IVSM has no heat option at all
+ * and its own supported modes (from the device's own capability advertisement) are only
+ * cool/dry/fan_only/Energy Saver.
+ *
+ * Not yet implemented, confirmed against a real LW1822IVSM (2026-09-09):
+ *   - 'Sleep' button: cycles a 1-24 display value on the panel, but produced no corresponding change
+ *     on the wire in testing — likely panel-local only, not reported over the cloud protocol.
  */
 export default class Device extends TLVDevice {
+    filterUsedTime: number = 0
+    filterLifeTime: number = 0
+    filterChangedDate: number = 0
+    filterInitialQueryTimeout: ReturnType<typeof setTimeout> | undefined
+    filterQueryTimer: ReturnType<typeof setInterval> | undefined
+    filterDoReset: boolean = false
+    energySensorAdded: boolean = false
+
     constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
         super(HA, thinq)
         const config: DeviceDiscovery = allowExtendedType({
-            ...HADevice.config(meta),
-            name: 'LG Air Conditioner',
+            ...HADevice.config(meta, { name: 'LG Air Conditioner' }),
             components: {
                 climate: {
                     platform: 'climate',
@@ -34,9 +55,34 @@ export default class Device extends TLVDevice {
                     temperature_unit: 'C',
                     temp_step: 0.5,
                     precision: 0.5,
-                    modes: ['off', 'cool', 'fan_only', 'heat'],
+                    modes: ['off', 'cool', 'dry', 'fan_only', 'heat'],
                     fan_modes: FAN_MODES.options,
                     swing_modes: SWING_MODES.options,
+                    // 'Energy Saver' (raw mode 8) is mutually exclusive with cool/dry/fan_only/heat
+                    // at the protocol level, but HA's hvac_mode vocabulary has no equivalent — expose
+                    // it as a preset instead. See the mode field's write_xform/read_callback below.
+                    // 'none' must NOT be listed here — HA's MQTT climate schema reserves it and
+                    // rejects the whole climate component if it's present in preset_modes, even
+                    // though 'none' is a valid state to report via preset_mode_state_topic.
+                    preset_modes: ['eco'],
+                },
+                // Off timer. Panel sets/reads this in whole-hour steps only (tag 0x21b is raw
+                // minutes, always a multiple of 60 when set from the panel); confirmed live
+                // (2026-09-09) that writing an arbitrary value here via the cloud is honored
+                // exactly like a panel button press (the unit dings and updates its display),
+                // including 0 to cancel. Exposed in hours to match the panel's own granularity —
+                // finer values were not tested and may not display sensibly on the panel.
+                offtimer: {
+                    platform: 'number',
+                    unique_id: '$deviceid-offtimer',
+                    name: 'Off timer',
+                    icon: 'mdi:timer-outline',
+                    min: 0,
+                    max: 24,
+                    step: 1,
+                    unit_of_measurement: 'h',
+                    state_topic: '$this/offtimer',
+                    command_topic: '$this/offtimer/set',
                 },
             },
         })
@@ -87,32 +133,39 @@ export default class Device extends TLVDevice {
             name: 'mode',
             comp: 'climate',
             read_xform: (raw) => {
-                // FIXME: this is inconsistent with modes2clip below.
-                const modes2ha = [
-                    'cool',
-                    undefined,
-                    'fan_only',
-                    undefined,
-                    'heat',
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined, // 'eco'
-                ]
+                // Confirmed against a real LW1822IVSM (2026-09-09): 0=cool, 1=dry, 2=fan_only,
+                // 8=Energy Saver (not a valid HA hvac_mode — reported via preset_mode instead, see
+                // below). 4=heat is unconfirmed on this unit (it has no heat option) but is kept for
+                // the sibling LW1823HRSM model this handler also serves.
+                const modes2ha = ['cool', 'dry', 'fan_only', undefined, 'heat']
                 if (this.raw_clip_state[0x1f7] === 0) return 'off'
                 return modes2ha[raw]
             },
             write_xform: (val) => {
-                const modes2clip: Record<string, number> = { cool: 0, fan_only: 2, heat: 4, dry: 8 }
+                const modes2clip: Record<string, number> = { cool: 0, dry: 1, fan_only: 2, heat: 4 }
                 if (val === 'off') {
                     // Call function power (0x1f7) with value OFF
-                    this.setProperty('power', 'OFF')
+                    this.setProperty('climate-power', 'OFF')
                 } else {
-                    this.setProperty('power', 'ON')
+                    this.setProperty('climate-power', 'ON')
                 }
                 return modes2clip[val]
             },
             write_attach: [0x1f7, 0x1fa, 0x1fe, 0x322],
+        })
+
+        this.addField(config, {
+            name: 'preset_mode',
+            comp: 'climate',
+            write_xform: (val) => (val === 'eco' ? 8 : undefined),
+            write_callback: (val) => {
+                this.setProperty('climate-power', 'ON')
+                this.raw_clip_state[0x1f9] = val
+                const attach = [0x1f9, 0x1f7, 0x1fa, 0x1fe, 0x322]
+                const tlvArray = attach.map((id) => ({ t: id, v: this.raw_clip_state[id] }))
+                this.send([1, 1, 2, 1, 1], tlvArray)
+                return false
+            },
         })
 
         this.addField(config, {
@@ -133,7 +186,231 @@ export default class Device extends TLVDevice {
             write_attach: [0x1f9, 0x1fa],
         })
 
+        // Off timer write path. `id` is safe to set here (unlike preset_mode's field) since no
+        // other field in this handler reads/writes tag 0x21b, so there's no fields_by_id clobber
+        // risk — this lets setProperty's generic single-field send path handle it, matching the
+        // exact minimal write ([1,1,2,1,1] header, no other tags attached) confirmed live.
+        this.fields_by_ha['offtimer'] = {
+            id: 0x21b,
+            name: '',
+            comp: '',
+            write_xform: (val) => Math.max(0, Math.min(24, Number(val))) * 60,
+        }
+
         this.setConfig(config)
+    }
+
+    drop() {
+        if (this.filterInitialQueryTimeout != undefined) {
+            clearTimeout(this.filterInitialQueryTimeout)
+            this.filterInitialQueryTimeout = undefined
+        }
+        if (this.filterQueryTimer != undefined) {
+            clearInterval(this.filterQueryTimer)
+            this.filterQueryTimer = undefined
+        }
+        super.drop()
+    }
+
+    valuesReceived() {
+        // Confirmed against a real LW1822IVSM (2026-09-09): private command 0x02/0x02 queries filter
+        // usage (used hours, life hours, last-reset date) — same sub-protocol as RAC_056905_WW.
+        this.initProbeForFilter()
+    }
+
+    initProbeForFilter() {
+        this.sendFilterQuery()
+        this.filterInitialQueryTimeout = setTimeout(() => {
+            this.filterInitialQueryTimeout = undefined
+            // no response within 5s: assume this unit doesn't support filter tracking
+        }, 5 * 1000)
+    }
+
+    sendFilterQuery() {
+        this.sendPrivCommand(0x02, 0x02)
+    }
+
+    sendFilterReset() {
+        if (!this.filterLifeTime) throw new Error('Filter lifetime not known')
+
+        const now = new Date()
+        const date = now.getUTCFullYear() * 10000 + (now.getUTCMonth() + 1) * 100 + now.getUTCDate()
+
+        const buf = Buffer.alloc(4 * 3)
+        // yes, it's opposite endianness vs read cmd
+        buf.writeUInt32BE(this.filterLifeTime, 1 * 4)
+        buf.writeUInt32BE(date, 2 * 4)
+
+        this.sendPrivCommand(0x02, 0x01, buf)
+    }
+
+    processPrivData(cmd: number, buf9: number, data: Buffer) {
+        if (cmd == 0x02) this.processFilterData(data)
+    }
+
+    processPrivDataCmdResp(success: boolean, buf1: number, cmd: number, data: Buffer) {
+        if (cmd == 0x02) this.processFilterCmdResp(success)
+    }
+
+    processFilterData(data: Buffer) {
+        if (data.length < 1 + 3 * 4) return
+
+        this.filterUsedTime = data.readUInt32LE(1 + 0 * 4)
+        this.filterLifeTime = data.readUInt32LE(1 + 1 * 4)
+        this.filterChangedDate = data.readUInt32LE(1 + 2 * 4)
+
+        if (this.filterInitialQueryTimeout != undefined) {
+            clearTimeout(this.filterInitialQueryTimeout)
+            this.filterInitialQueryTimeout = undefined
+
+            this.addFilterEntities()
+            this.publishFilterData()
+
+            // Refresh only once a day since a query might do an EEPROM write.
+            this.filterQueryTimer = setInterval(() => this.sendFilterQuery(), 24 * 60 * 60 * 1000)
+        } else {
+            this.publishFilterData()
+        }
+
+        if (this.filterDoReset) {
+            this.filterDoReset = false
+            this.sendFilterReset()
+        }
+    }
+
+    addFilterEntities() {
+        if (!this.config) return
+
+        const filterUsed = {
+            platform: 'sensor',
+            unique_id: '$deviceid-filterused',
+            state_topic: '$this/filterused',
+            name: 'Filter used time',
+            icon: 'mdi:air-filter',
+            device_class: 'duration',
+            unit_of_measurement: 'h',
+            state_class: 'total_increasing',
+            entity_category: 'diagnostic',
+        }
+        this.config.components['filterused'] = filterUsed
+
+        const filterLife = {
+            platform: 'sensor',
+            unique_id: '$deviceid-filterlife',
+            state_topic: '$this/filterlife',
+            name: 'Filter life time',
+            icon: 'mdi:air-filter',
+            device_class: 'duration',
+            unit_of_measurement: 'h',
+            entity_category: 'diagnostic',
+        }
+        this.config.components['filterlife'] = filterLife
+
+        const filterChanged = {
+            platform: 'sensor',
+            unique_id: '$deviceid-filterchangeddate',
+            state_topic: '$this/filterchangeddate',
+            name: 'Filter usage last reset',
+            icon: 'mdi:calendar-refresh-outline',
+            device_class: 'date',
+            entity_category: 'diagnostic',
+        }
+        this.config.components['changeddate'] = filterChanged
+
+        const filterReset = {
+            platform: 'button',
+            unique_id: '$deviceid-filterreset',
+            command_topic: '$this/filterreset/set',
+            name: 'Reset filter usage',
+            icon: 'mdi:calendar-refresh-outline',
+            entity_category: 'diagnostic',
+        }
+        this.config.components['filterreset'] = filterReset
+        this.fields_by_ha['filterreset'] = {
+            name: '',
+            comp: '',
+            write_xform: (val) => (val === 'PRESS' ? 1 : 0),
+            write_callback: (val) => {
+                if (val === 1) {
+                    this.filterDoReset = true
+                    // do a query first to get the most recent pre-reset values
+                    this.sendFilterQuery()
+                }
+                return false
+            },
+        }
+
+        this.setConfig(this.config)
+    }
+
+    publishFilterData() {
+        const changedDate =
+            Math.floor(this.filterChangedDate / 10000)
+                .toString()
+                .padStart(4, '0') +
+            '-' +
+            (Math.floor(this.filterChangedDate / 100) % 100).toString().padStart(2, '0') +
+            '-' +
+            (this.filterChangedDate % 100).toString().padStart(2, '0')
+
+        this.HA.publishProperty(this.id, 'filterused', this.filterUsedTime)
+        this.HA.publishProperty(this.id, 'filterlife', this.filterLifeTime)
+        this.HA.publishProperty(this.id, 'filterchangeddate', changedDate)
+    }
+
+    processFilterCmdResp(success: boolean) {
+        if (!success) return
+        this.sendFilterQuery()
+    }
+
+    processKeyValue(k: number, v: number) {
+        // Publish preset_mode from tag 0x1f9 unconditionally: the 'mode' field's own read_xform
+        // returns undefined for raw 8 (not a valid hvac_mode), which would otherwise short-circuit
+        // before any read_callback runs — see tlv_device.ts processKeyValue.
+        if (k === 0x1f9) this.HA.publishProperty(this.id, 'climate-preset_mode', v === 8 ? 'eco' : 'none')
+
+        // Off timer (tag 0x21b): raw minutes remaining, counts down once armed. See the
+        // 'offtimer' config component above for how writes work.
+        if (k === 0x21b) this.HA.publishProperty(this.id, 'offtimer', Math.round(v / 60))
+
+        // Live power draw (tag 0x2b3, same as RAC_056905_WW.ts's 'energy_current'). This is
+        // whole-unit power (compressor + fans + electronics), not compressor-only — confirmed
+        // against a real LW1822IVSM (2026-09-09) by listening to the compressor cycle on/off while
+        // watching this value: idle reads ~80W (fans/electronics, compressor off), not ~0W, and it
+        // tracks the inverter's ramp up/down smoothly and in real time — unlike the compressor
+        // Hz/IDU-thermo tags, which only ever appear once at connection time on this unit and never
+        // update (see the class docstring). Per RAC_056905_WW.ts's own notes, expect ~+/-10%
+        // accuracy: standby-only consumption (~4W) and the 4-way valve aren't included, and
+        // fan-only mode readings are the least accurate. RAC's handler guards this behind
+        // `if (this.raw_clip_state[0x2b3])` since some multi-split units always report zero; added
+        // dynamically here for the same reason, once a real value is seen.
+        if (k === 0x2b3 && v) {
+            if (!this.energySensorAdded) {
+                this.energySensorAdded = true
+                this.addEnergySensorEntity()
+            }
+            this.HA.publishProperty(this.id, 'energy_current', Math.max(5, v - 60))
+        }
+
+        super.processKeyValue(k, v)
+    }
+
+    addEnergySensorEntity() {
+        if (!this.config) return
+
+        const energyCurrent = {
+            platform: 'sensor',
+            unique_id: '$deviceid-energy_current',
+            state_topic: '$this/energy_current',
+            name: 'Power',
+            device_class: 'power',
+            unit_of_measurement: 'W',
+            state_class: 'measurement',
+            suggested_display_precision: 0,
+        }
+        this.config.components['energy_current'] = energyCurrent
+
+        this.setConfig(this.config)
     }
 
     isCapsResponse(tlvArray: TLV.TLV[]) {

--- a/tests/cloud/devices/WIN_056905_WW.test.ts
+++ b/tests/cloud/devices/WIN_056905_WW.test.ts
@@ -1,0 +1,305 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/WIN_056905_WW'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf, hex } from '@/tests/helpers/mocks'
+import { enableMockTimers, tickMockTimers } from '@/tests/helpers/timers'
+
+const DEVICE_ID = 'test-id'
+const MODEL_ID = 'WIN_056905_WW'
+const META: Metadata = { modelId: MODEL_ID, modelName: 'WIN_056905_WW', swVersion: '352200' }
+
+// Real packet captures from an LG LW1822IVSM window air conditioner (2026-09-09). This handler
+// also serves the sibling LW1823HRSM (see its docstring); heat (raw mode 4) is kept for that model
+// but is unconfirmed here, as this unit has no heat option.
+
+const CAPS_REQUEST_HEX = '01010400000065020201027D416A0D'
+const QUERY_REQUEST_HEX = '01010400000065020201027D425A6E'
+
+// Capability response from the device. Uses TLV marker 0xA7, like DHUM_056905_WW/POT_056905_WW.
+const CAPS_RESPONSE_HEX =
+    '000004000000A702015852B009B0600107B09054B0C1B103B300B340B4E05016B55060B6A00363B6F0352200B85020' +
+    'B8903CB8D020B9103CBC600201BD30080000BD47B5C0B6102AB646B5C1B600B646B5C2B600B646B5C8B61020B646FF48'
+
+// Initial values response while physically set to Cool / fan-high.
+//      t=0x1f7 v=1        power=ON
+//      t=0x1f9 v=0        mode=cool
+//      t=0x1fa v=6        fan=high
+//      t=0x1fd v=49       current_temp=24.5
+//      t=0x1fe v=42       set_temp=21
+const VALUES_COOL_HEX =
+    '000004000000A702045B477E407DC17E867F50317F902A8180C8C08340868086C08700884089408A10498A506A8A8F8CA0' +
+    '12C48CC7ACE00711D550F8D590FACAD05ACB10BCCB8CCBCFCC00CC909E1B01C0C01A7F'
+
+// Full values response captured while the unit's own panel displayed 'Energy Saver'.
+//      t=0x1f9 v=8        mode=Energy Saver (not a valid HA hvac_mode; exposed via preset_mode)
+//      t=0x1fa v=4        fan=medium
+const VALUES_ENERGY_SAVER_HEX =
+    '000004000000A70204A9477E487DC17E847F50317F902A8180C8C08340868086C08700884089408A103C8A50698A8F8C90' +
+    '898CD025ACE005D1D550F7D590FACAD05BCB10B8CB8CCBCFCC00CC90941B01C0C08B2B'
+
+// Small delta packet (mode field only) captured while the panel displayed 'Dry'.
+const VALUES_DRY_DELTA_HEX = '000004000000A70204AB027E4166F0'
+
+// Private-command filter query (sendPrivCommand(0x02, 0x02)) and its real captured response —
+// used=0, life=720 (hours), changed date=0 (never reset), on a brand-new unit.
+const FILTER_QUERY_REQUEST_HEX = '00FF0400000065FD02000102511B'
+const FILTER_QUERY_RESPONSE_HEX = '02FF0400000087FD03010D0200000000D0020000000000003920'
+
+// Off timer: real captured injection round-trip (2026-09-09) — set to 1h (60 raw minutes), the
+// unit echoed tag 0x21b=60 back and its panel/display updated (with an audible confirmation ding).
+const WRITE_TIMER_1H_HEX = '010104000000650201010386D03CB71E'
+const VALUES_TIMER_1H_HEX = '000004000000A70204E20386D03CA536'
+
+// Bytes produced by rethink for specific HA setProperty calls (from a Cool/fan-high baseline).
+// mode/preset writes emit two packets: the (currently ineffective, since power was already ON)
+// power=ON packet, then the real mode/preset packet.
+const WRITE_MODE_DRY_HEX = [
+    '01010400000065020101047DC17E407883',
+    '010104000000650201010E7E417DC17E867F902AC8B00000008492',
+]
+const WRITE_MODE_OFF_HEX = '01010400000065020101027DC00576'
+const WRITE_FAN_MEDIUM_HEX = '01010400000065020101077E847E407F902A6F7E'
+const WRITE_PRESET_ECO_HEX = [
+    '01010400000065020101047DC17E407883',
+    '010104000000650201010E7E487DC17E867F902AC8B0000000CAAB',
+]
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    ha.on('setProperty', (id: string, prop: string, value: string) => {
+        dev.setProperty(prop, value)
+    })
+    return { ha, thinq, dev }
+}
+
+function buildReadyDevice(t: import('node:test').TestContext) {
+    enableMockTimers(t)
+    const { ha, thinq, dev } = makeDevice()
+
+    thinq.resetRecorder()
+    thinq.emit('data', buf(CAPS_RESPONSE_HEX))
+    assert.equal(thinq.outbox.length, 1)
+    assert.equal(hex(thinq.outbox[0]), QUERY_REQUEST_HEX)
+
+    thinq.emit('data', buf(VALUES_COOL_HEX))
+    tickMockTimers(t, 1000)
+
+    thinq.resetRecorder()
+    return { ha, thinq, dev }
+}
+
+describe(MODEL_ID, () => {
+    test('config exposes expected climate component', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+
+        const device = ha.devices[DEVICE_ID]
+        assert.ok(device, 'HA configuration published')
+
+        const components = device.config!.components as Record<string, Record<string, unknown>>
+        assert.ok(components.climate, 'climate component')
+        assert.equal(components.climate.platform, 'climate')
+        assert.deepEqual(components.climate.modes, ['off', 'cool', 'dry', 'fan_only', 'heat'])
+        assert.deepEqual(components.climate.fan_modes, ['low', 'medium', 'high'])
+        assert.deepEqual(components.climate.swing_modes, ['on', 'off'])
+        assert.deepEqual(components.climate.preset_modes, ['eco'])
+
+        dev.drop()
+    })
+
+    test('Cool/fan-high values response publishes all expected HA properties', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'mode_state'), 'cool')
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'fan_mode_state'), 'high')
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'preset_mode_state'), 'none')
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'current_temperature'), 24.5)
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'temperature_state'), 21)
+
+        dev.drop()
+    })
+
+    test('Energy Saver values response reports preset_mode=eco, leaves hvac mode alone', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        thinq.emit('data', buf(VALUES_ENERGY_SAVER_HEX))
+
+        // raw mode 8 has no valid hvac_mode mapping, so the mode topic is left at its last known
+        // value (still 'cool' from the baseline capture) rather than publishing something wrong.
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'mode_state'), 'cool')
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'preset_mode_state'), 'eco')
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'fan_mode_state'), 'medium')
+
+        dev.drop()
+    })
+
+    test('Dry delta packet publishes mode=dry and preset_mode=none', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        thinq.emit('data', buf(VALUES_DRY_DELTA_HEX))
+
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'mode_state'), 'dry')
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'preset_mode_state'), 'none')
+
+        dev.drop()
+    })
+
+    test('valuesReceived sends a filter query, and filter data response adds diagnostic entities', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        // buildReadyDevice already triggered valuesReceived -> initProbeForFilter, which sends a
+        // filter query; confirm that happened (it's cleared by buildReadyDevice's own resetRecorder,
+        // so re-derive it here on a fresh device instead of relying on outbox state).
+        thinq.resetRecorder()
+        dev.sendFilterQuery()
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(hex(thinq.outbox[0]), FILTER_QUERY_REQUEST_HEX)
+
+        assert.equal(ha.devices[DEVICE_ID].config!.components['filterused'], undefined, 'not yet added')
+
+        thinq.emit('data', buf(FILTER_QUERY_RESPONSE_HEX))
+
+        assert.ok(ha.devices[DEVICE_ID].config!.components['filterused'], 'filterused component added')
+        assert.ok(ha.devices[DEVICE_ID].config!.components['filterlife'], 'filterlife component added')
+        assert.ok(ha.devices[DEVICE_ID].config!.components['changeddate'], 'changeddate component added')
+        assert.ok(ha.devices[DEVICE_ID].config!.components['filterreset'], 'filterreset component added')
+
+        assert.equal(ha.getProperty(DEVICE_ID, 'filterused', 'state'), 0)
+        assert.equal(ha.getProperty(DEVICE_ID, 'filterlife', 'state'), 720)
+        assert.equal(ha.getProperty(DEVICE_ID, 'changeddate', 'state'), '0000-00-00')
+
+        dev.drop()
+    })
+
+    test('power draw (tag 0x2b3) adds a Power sensor once a real value is seen and tracks it live', (t) => {
+        // Use a bare device (no VALUES_COOL_HEX, which already contains a real 0x2b3 reading) to
+        // exercise the dynamic-add path from a clean slate.
+        enableMockTimers(t)
+        const { ha, dev } = makeDevice()
+
+        assert.equal(ha.devices[DEVICE_ID]?.config?.components['energy_current'], undefined, 'not yet added')
+
+        // Real captured sequence from an inverter compressor ramp-down to idle (2026-09-09).
+        dev.processKeyValue(0x2b3, 1413)
+        assert.ok(ha.devices[DEVICE_ID].config!.components['energy_current'], 'energy_current component added')
+        assert.equal(ha.getProperty(DEVICE_ID, 'energy_current', 'state'), 1353)
+
+        dev.processKeyValue(0x2b3, 138)
+        assert.equal(ha.getProperty(DEVICE_ID, 'energy_current', 'state'), 78)
+
+        dev.drop()
+    })
+
+    test('off timer: values response with tag 0x21b publishes hours, HA write emits the confirmed bytes', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        thinq.emit('data', buf(VALUES_TIMER_1H_HEX))
+        assert.equal(ha.getProperty(DEVICE_ID, 'offtimer', 'state'), 1)
+
+        thinq.resetRecorder()
+        ha.setProperty(DEVICE_ID, 'offtimer', 'command', '1')
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(hex(thinq.outbox[0]), WRITE_TIMER_1H_HEX)
+
+        dev.drop()
+    })
+
+    test('pressing the filter reset button sends a filter query first', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        thinq.emit('data', buf(FILTER_QUERY_RESPONSE_HEX))
+        thinq.resetRecorder()
+
+        ha.setProperty(DEVICE_ID, 'filterreset', 'command', 'PRESS')
+
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(hex(thinq.outbox[0]), FILTER_QUERY_REQUEST_HEX)
+
+        dev.drop()
+    })
+
+    test('HA write climate-mode=dry emits expected bytes', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        ha.setProperty(DEVICE_ID, 'climate', 'mode_command', 'dry')
+
+        assert.deepEqual(
+            thinq.outbox.map((b) => hex(b)),
+            WRITE_MODE_DRY_HEX,
+        )
+
+        dev.drop()
+    })
+
+    test('HA write climate-mode=off triggers power=OFF instead of mode write', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        ha.setProperty(DEVICE_ID, 'climate', 'mode_command', 'off')
+
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(hex(thinq.outbox[0]), WRITE_MODE_OFF_HEX)
+
+        dev.drop()
+    })
+
+    test('HA write climate-fan_mode=medium emits expected bytes', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        ha.setProperty(DEVICE_ID, 'climate', 'fan_mode_command', 'medium')
+
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(hex(thinq.outbox[0]), WRITE_FAN_MEDIUM_HEX)
+
+        dev.drop()
+    })
+
+    test('HA write climate-preset_mode=eco emits expected bytes', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        ha.setProperty(DEVICE_ID, 'climate', 'preset_mode_command', 'eco')
+
+        assert.deepEqual(
+            thinq.outbox.map((b) => hex(b)),
+            WRITE_PRESET_ECO_HEX,
+        )
+
+        dev.drop()
+    })
+
+    test('HA write climate-preset_mode=none is a no-op (no defined way to cancel Energy Saver)', (t) => {
+        const { ha, thinq, dev } = buildReadyDevice(t)
+
+        ha.setProperty(DEVICE_ID, 'climate', 'preset_mode_command', 'none')
+
+        assert.equal(thinq.outbox.length, 0)
+
+        dev.drop()
+    })
+
+    test('0xA7 caps response triggers values query', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.resetRecorder()
+
+        thinq.emit('data', buf(CAPS_RESPONSE_HEX))
+
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(hex(thinq.outbox[0]), QUERY_REQUEST_HEX)
+
+        dev.drop()
+    })
+
+    test('constructor sends a queryCaps packet on the wire', () => {
+        const { thinq, dev } = makeDevice()
+        if (dev.query_caps_timeout) {
+            clearInterval(dev.query_caps_timeout)
+            dev.query_caps_timeout = undefined
+        }
+
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(hex(thinq.outbox[0]), CAPS_REQUEST_HEX)
+
+        dev.drop()
+    })
+})

--- a/tests/cloud/devices/WIN_056905_WW.test.ts
+++ b/tests/cloud/devices/WIN_056905_WW.test.ts
@@ -105,6 +105,8 @@ describe(MODEL_ID, () => {
         assert.deepEqual(components.climate.fan_modes, ['low', 'medium', 'high'])
         assert.deepEqual(components.climate.swing_modes, ['on', 'off'])
         assert.deepEqual(components.climate.preset_modes, ['eco'])
+        assert.equal(components.climate.min_temp, 61)
+        assert.equal(components.climate.max_temp, 86)
 
         dev.drop()
     })
@@ -115,8 +117,11 @@ describe(MODEL_ID, () => {
         assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'mode_state'), 'cool')
         assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'fan_mode_state'), 'high')
         assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'preset_mode_state'), 'none')
-        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'current_temperature'), 24.5)
-        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'temperature_state'), 21)
+        // Wire values are Celsius (24.5C / 21C, see VALUES_COOL_HEX above); the climate entity's
+        // native unit is Fahrenheit (see WIN_056905_WW.ts), so these are published converted:
+        // 24.5C -> 76.1F -> 76, 21C -> 69.8F -> 70.
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'current_temperature'), 76)
+        assert.equal(ha.getProperty(DEVICE_ID, 'climate', 'temperature_state'), 70)
 
         dev.drop()
     })
@@ -216,6 +221,25 @@ describe(MODEL_ID, () => {
 
         assert.equal(thinq.outbox.length, 1)
         assert.equal(hex(thinq.outbox[0]), FILTER_QUERY_REQUEST_HEX)
+
+        dev.drop()
+    })
+
+    test('HA write climate-temperature converts whole Fahrenheit to the wire Celsius*2 raw value, clamped to 61-86F', (t) => {
+        const { ha, dev } = buildReadyDevice(t)
+
+        ha.setProperty(DEVICE_ID, 'climate', 'temperature_command', '74')
+        // 74F -> 23.33C -> raw 47 (23.5C), not 46/48 -- exercises the fix for the reported bug
+        // where a Celsius-native 0.5-step entity would instead snap 74F to 74.5F/75F.
+        assert.equal(dev.raw_clip_state[0x1fe], 47)
+
+        // Below the 61F floor clamps to 61F (16.11C -> raw 32).
+        ha.setProperty(DEVICE_ID, 'climate', 'temperature_command', '50')
+        assert.equal(dev.raw_clip_state[0x1fe], 32)
+
+        // Above the 86F ceiling clamps to 86F (30C -> raw 60).
+        ha.setProperty(DEVICE_ID, 'climate', 'temperature_command', '95')
+        assert.equal(dev.raw_clip_state[0x1fe], 60)
 
         dev.drop()
     })

--- a/tests/util/packet-codec.test.ts
+++ b/tests/util/packet-codec.test.ts
@@ -6,6 +6,11 @@ import { encodePacket, decodePacket } from '@/util/packet-codec'
 
 // device_packet (device -> cloud), kind 0x87
 const FROM_DEVICE = '000004000000870204690b8ca036458cd059ace001de6ac9'
+// device_packet (device -> cloud), kind 0xa7 — used by DHUM_056905_WW/POT_056905_WW/WIN_056905_WW.
+// Real capture from an LG LW1822IVSM window AC (2026-09-09), values report with mode=cool, fan=high.
+const FROM_DEVICE_A7 =
+    '000004000000A702045B477E407DC17E867F50317F902A8180C8C08340868086C08700884089408A10498A506A8A8F8CA0' +
+    '12C48CC7ACE00711D550F8D590FACAD05ACB10BCCB8CCBCFCC00CC909E1B01C0C01A7F'
 // cloud -> device packet, kind 0x65
 const TO_DEVICE = '00010400000065020201027d416a0d'
 // AABB frame
@@ -20,6 +25,25 @@ test('decode: fromDevice TLV packet, CRC valid', () => {
     assert.equal(d.frame.kind, 0x87)
     assert.equal(d.frame.len, 0x0b)
     assert.ok(d.tlv.length > 0)
+})
+
+test('decode: fromDevice TLV packet with 0xa7 kind byte, CRC valid', () => {
+    // Regression: decodePacket used to only recognize kind 0x87 for fromDevice, so captures
+    // from 0xa7 devices (DHUM/POT/WIN protocol family) decoded as 'unknown'.
+    const d = decodePacket(FROM_DEVICE_A7)
+    assert.equal(d.protocol, 'tlv')
+    if (d.protocol !== 'tlv') return
+    assert.equal(d.direction, 'fromDevice')
+    assert.equal(d.crcOk, true)
+    assert.equal(d.frame.kind, 0xa7)
+    assert.ok(
+        d.tlv.some((e) => e.t === 0x1f9 && e.v === 0),
+        'mode=cool present',
+    )
+    assert.ok(
+        d.tlv.some((e) => e.t === 0x1fa && e.v === 6),
+        'fan=high present',
+    )
 })
 
 test('decode: toDevice TLV packet, CRC valid', () => {

--- a/util/packet-codec.ts
+++ b/util/packet-codec.ts
@@ -53,7 +53,7 @@ export type DecodedTlv = {
     crcOk: boolean
     tlv: TLV.TLV[]
     frame: {
-        kind: number // uart byte4: 0x87 fromDevice, 0x65 toDevice
+        kind: number // uart byte4: 0x87 or 0xa7 fromDevice, 0x65 toDevice
         byte5: number
         byte6: number
         byte7: number
@@ -158,9 +158,10 @@ export function decodePacket(hex: string): Decoded {
         }
     }
 
-    // TLV: identify by the uart "kind" byte at index 6
-    if (buf.length >= 13 && buf[2] === 0x04 && (buf[6] === 0x87 || buf[6] === 0x65)) {
-        const fromDevice = buf[6] === 0x87
+    // TLV: identify by the uart "kind" byte at index 6.
+    // 0x87 used by RAC/WIN; 0xA7 used by DHUM_056905_WW and similar (see tlv_device.ts processData).
+    if (buf.length >= 13 && buf[2] === 0x04 && (buf[6] === 0x87 || buf[6] === 0xa7 || buf[6] === 0x65)) {
+        const fromDevice = buf[6] === 0x87 || buf[6] === 0xa7
         const len = buf[10]
         if (11 + len + 2 > buf.length) {
             return { protocol: 'unknown', hex, reason: 'TLV length field overruns buffer' }


### PR DESCRIPTION
Confirmed against a real LW1822IVSM:
- dry mode's raw value was wrong (was 8, actually Energy Saver; corrected to 1)
- medium fan speed was missing from the fan table
- Energy Saver now exposed as a preset_mode
- filter usage tracking added (used/life/last-reset + reset button), ported from RAC_056905_WW.ts's private-command protocol
- live power draw sensor added (same tag/formula as RAC's 'energy_current')
- off timer exposed as a number entity, write path confirmed live
- fixed a setProperty('power', ...) typo that silently no-op'd
- fixed the same 0x87-only framing gap in util/packet-codec.ts that tlv_device.ts already had a fix for
- README/docstring updated to list LW1822IVSM as its own supported model