### PR TITLE
Add RH16VT (RH16_T_KR) heat-pump dryer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The following appliances are currently supported in rethink:
     - 🫤 DLE7300WE - preliminary support
     - 👍 DLEX3900B (RV13B6BSD_D_US_WIFI), Electric Dryer - mostly working
     - 👍 RV13B6ES_D_US_WIFI, Electric Dryer - mostly working
+    - 👍 RH16VT (RH16_T_KR), Heat Pump Dryer - mostly working
 - WashTowers (combined washer+dryer):
     - 👍 WKEX200HBA (WTL_FXU_BDV_NA_01), WashTower - mostly working
 - Dehumidifiers

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -1,0 +1,90 @@
+import { Device as Thinq2Device } from '../thinq2/device'
+import { type Connection } from '../homeassistant'
+import { type Metadata } from '../thinq'
+import { allowExtendedType } from '@/util/casting'
+import HADevice from './base'
+import AABBDevice from './aabb_device'
+import { Enum } from '@/util/enum'
+
+/*
+ * LG RH16_T_KR heat-pump dryer, deviceType 202.
+ *
+ * This intentionally exposes only the state fields grounded by this exact
+ * appliance. Its real AABB traffic uses a 0x30 device byte, a 0x19 record
+ * marker, a 29-byte EB body and a 56-byte EC body. The current record begins
+ * at body offset 30 in EC frames. Owner traffic captured both state 0 while
+ * powered off and state 1 while the appliance was in Initial; those values
+ * match this model JSON's MonitoringValue.state table. Other model fields are
+ * not exposed until a labelled non-zero transition isolates their offsets.
+ */
+const DEVICE_TYPE = 0x30
+const SINGLE_STATUS = 0xeb
+const DOUBLE_STATUS = 0xec
+const SINGLE_BODY_LEN = 29
+const DOUBLE_BODY_LEN = 56
+const SINGLE_RECORD_OFFSET = 3
+const DOUBLE_CURRENT_RECORD_OFFSET = 30
+const RECORD_MARKER = 0x19
+const STATE_OFFSET = 1
+const STATUS_REQUEST = 'F0ED1121010000001800'
+
+const STATE = Enum.of({
+    'Power off': 0,
+    Initial: 1,
+    Drying: 2,
+    Pause: 3,
+    Complete: 4,
+    Error: 5,
+    'Smart diagnosis': 8,
+    Reserved: 100,
+})
+
+export default class Device extends AABBDevice {
+    constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
+        super(HA, thinq)
+        this.setConfig(
+            allowExtendedType({
+                ...HADevice.config(meta, { name: 'LG Dryer' }),
+                components: {
+                    power: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-power',
+                        state_topic: '$this/power',
+                        name: 'Power',
+                        payload_on: 'ON',
+                        payload_off: 'OFF',
+                        device_class: 'running',
+                        icon: 'mdi:tumble-dryer',
+                    },
+                    status: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-status',
+                        state_topic: '$this/status',
+                        name: 'Status',
+                        device_class: 'enum',
+                        options: STATE.options,
+                        icon: 'mdi:tumble-dryer',
+                    },
+                },
+            }),
+        )
+    }
+
+    start() {
+        this.send(Buffer.from(STATUS_REQUEST, 'hex'))
+    }
+
+    processAABB(buf: Buffer) {
+        if (buf[0] !== DEVICE_TYPE) return
+
+        let recordOffset: number
+        if (buf[1] === SINGLE_STATUS && buf.length === SINGLE_BODY_LEN) recordOffset = SINGLE_RECORD_OFFSET
+        else if (buf[1] === DOUBLE_STATUS && buf.length === DOUBLE_BODY_LEN) recordOffset = DOUBLE_CURRENT_RECORD_OFFSET
+        else return
+
+        if (buf[recordOffset] !== RECORD_MARKER) return
+        const state = buf[recordOffset + STATE_OFFSET]
+        this.publishProperty('power', state === 0 ? 'OFF' : 'ON')
+        this.publishProperty('status', STATE.map(state) ?? 'None')
+    }
+}

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -154,6 +154,19 @@ const COURSE_DEFAULTS: Record<number, { dry: number; eco: number; ac: number }> 
 const DOWNLOAD_COURSE_TEMPLATE: Record<string, string> = {
     'Powerful Dry': 'f0250315000264000000000000001177000000000000000000',
     'Wrinkle Care Dry': 'f025031500025a000000000200000772000000030000000000',
+    'Full Size Load': 'f0250315000364000000000000000774000000050000000000',
+    // The app shows this download course as 리프레쉬 (Refresh). It is
+    // probably the model's DEODORIZATION entry, but that link is unconfirmed,
+    // so the select uses the on-screen name only.
+    Refresh: 'f0250315000314000000000000000f6b000000000000000000',
+    'Small Load': 'f025031500031e000000000000000e6c000000000000000000',
+    'Gym Clothes': 'f025031500013d000000000000000866000000000000000000',
+    'Rainy Season': 'f0250315000328000000000000000e69000000000000000000',
+    'Economic Dry': 'f025031500017d000000000000000770000000030000000000',
+    // The app shows this download course as 촉촉 건조, and the owner
+    // confirmed it is the dress-shirts course (model EASYIRON, Easy Iron).
+    'Easy Iron': 'f025031500034100000000000000076e000000010000000000',
+    'Big Size Item': 'f02503150003af000000000000000471000000000000000000',
 }
 const DOWNLOAD_COURSE_OPTIONS = Object.keys(DOWNLOAD_COURSE_TEMPLATE)
 

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -207,12 +207,13 @@ const DRY_LEVEL = Enum.of({
     Strong: 5,
 })
 // Rec[9] follows the model's own ecoHybrid index table (1 ECO, 2 NORMAL
-// labelled Auto in the app, 3 TURBO labelled Speed). Every captured run
-// reads back either the selected value or the course default from the
-// model's own Course function table.
+// labelled Auto in the app, 3 TURBO labelled Speed). Code 0 is what the
+// appliance reports on courses that do not expose the setting, so it reads
+// back as Off exactly like dry level does.
 const ECO_HYBRID_OFFSET = 9
 const ECO_HYBRID = Enum.of({
     Unsupported: [],
+    Off: 0,
     Energy: 1,
     Auto: 2,
     Speed: 3,
@@ -235,7 +236,6 @@ const STEAM_OFFSET = 17
 const STEAM_FLAG = 0x08
 
 const STATE = Enum.of({
-    Unsupported: [],
     'Power off': 0,
     Standby: 1,
     Drying: 2,
@@ -628,9 +628,12 @@ export default class Device extends AABBDevice {
     /*
      * The one place a record turns into a Status string. The washer reports
      * every phase as a plain state code, so the dryer folds its separate
-     * processState into the same entity to read the same way.
+     * processState into the same entity to read the same way. An unmapped
+     * state code publishes undefined, the styler convention, rather than a
+     * placeholder label: the model's state table covers every code seen so
+     * far, and a fake value would sit in Status as if it were real.
      */
-    private statusOf(buf: Buffer, offset: number): string {
+    private statusOf(buf: Buffer, offset: number): string | undefined {
         const state = buf[offset + STATE_OFFSET]
         const reservePending =
             buf[offset + RESERVE_REMAIN_HOUR_OFFSET] !== 0 ||
@@ -642,7 +645,7 @@ export default class Device extends AABBDevice {
         // is not the user pausing a cycle, so the reserve bytes win over both.
         if (reservePending && (state === STATE_RUNNING || state === STATE_PAUSE)) return 'Reserved'
         if (state === STATE_RUNNING) return PROCESS_STATE.map(buf[offset + PROCESS_STATE_OFFSET]) ?? 'Drying'
-        return STATE.map(state) ?? 'Unsupported'
+        return STATE.map(state)
     }
 
     processAABB(buf: Buffer) {

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -169,6 +169,24 @@ const DOWNLOAD_COURSE_TEMPLATE: Record<string, string> = {
     'Big Size Item': 'f02503150003af000000000000000471000000000000000000',
 }
 const DOWNLOAD_COURSE_OPTIONS = Object.keys(DOWNLOAD_COURSE_TEMPLATE)
+const SMART_COURSE_SENSOR_OPTIONS = ['Unknown', ...DOWNLOAD_COURSE_OPTIONS]
+// The downloaded program's execution id is byte 14 in each captured F025
+// install body, and its stable signature is byte 15. Live 3h reservations
+// for all ten courses reproduced those bytes at status rec[6] and rec[21].
+// The pair is required because several downloads reuse the same execution id.
+const DOWNLOAD_SIGNATURE_OFFSET = 21
+const DOWNLOAD_COURSE_BY_SIGNATURE = new Map(
+    Object.entries(DOWNLOAD_COURSE_TEMPLATE).map(([name, hex]) => {
+        const install = Buffer.from(hex, 'hex')
+        return [`${install[14]}:${install[15]}`, name]
+    }),
+)
+
+function smartCourseOf(buf: Buffer, recordOffset: number): string | undefined {
+    return DOWNLOAD_COURSE_BY_SIGNATURE.get(
+        `${buf[recordOffset + COURSE_OFFSET]}:${buf[recordOffset + DOWNLOAD_SIGNATURE_OFFSET]}`,
+    )
+}
 
 function buildCourseFrame(
     courseId: number,
@@ -201,6 +219,7 @@ function buildCourseFrame(
 const COURSE_OFFSET = 6
 const COURSE = Enum.of({
     Unsupported: [],
+    'Downloaded Course': [],
     Off: 0,
     'Steam Refresh': 1,
     Towel: 2,
@@ -369,6 +388,15 @@ export default class Device extends AABBDevice {
                         device_class: 'enum',
                         options: COURSE.options,
                         icon: 'mdi:playlist-check',
+                    },
+                    smart_course: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-smart_course',
+                        state_topic: '$this/smart_course',
+                        name: 'Smart course',
+                        device_class: 'enum',
+                        options: SMART_COURSE_SENSOR_OPTIONS,
+                        icon: 'mdi:playlist-star',
                     },
                     dry_level: {
                         platform: 'sensor',
@@ -727,7 +755,14 @@ export default class Device extends AABBDevice {
         this.publishProperty('error', errorCode === 0 ? 'OFF' : 'ON')
         this.publishProperty('error_message', ERROR_MESSAGE.map(errorCode) ?? 'Unsupported')
         this.publishProperty('smart_diagnosis', state === STATE_DIAGNOSIS ? 'ON' : 'OFF')
-        this.publishProperty('course', COURSE.map(buf[recordOffset + COURSE_OFFSET]) ?? 'Unsupported')
+        const smartCourse = smartCourseOf(buf, recordOffset)
+        this.publishProperty('smart_course', smartCourse ?? 'Unknown')
+        this.publishProperty(
+            'course',
+            smartCourse === undefined
+                ? (COURSE.map(buf[recordOffset + COURSE_OFFSET]) ?? 'Unsupported')
+                : 'Downloaded Course',
+        )
         this.publishProperty('dry_level', DRY_LEVEL.map(buf[recordOffset + DRY_LEVEL_OFFSET]) ?? 'Unsupported')
         this.publishProperty('eco_hybrid', ECO_HYBRID.map(buf[recordOffset + ECO_HYBRID_OFFSET]) ?? 'Unsupported')
         this.publishProperty('steam', (buf[recordOffset + STEAM_OFFSET] & STEAM_FLAG) !== 0 ? 'ON' : 'OFF')

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -801,7 +801,6 @@ export default class Device extends AABBDevice {
                         unit_of_measurement: 'Wh',
                         state_class: 'total_increasing',
                         icon: 'mdi:lightning-bolt',
-                        entity_category: 'diagnostic',
                     },
                 },
             }),

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -368,6 +368,20 @@ const ERROR_MESSAGE = Enum.of({
 })
 
 export default class Device extends AABBDevice {
+    // Preserve an armed downloaded course across handler rebuilds. The outer
+    // WeakMap keeps independent HA connections isolated, including tests.
+    private static remembered = new WeakMap<Connection, Map<string, { course: string; downloaded: boolean }>>()
+
+    private remember() {
+        let devices = Device.remembered.get(this.HA)
+        if (devices === undefined) {
+            devices = new Map()
+            Device.remembered.set(this.HA, devices)
+        }
+        if (this.downloadedCourse !== undefined)
+            devices.set(this.id, { course: this.downloadedCourse, downloaded: this.useDownloadedCourse })
+    }
+
     // Tracks what the HA selects were last set to, so Start course and
     // Resume can build a full frame. Defaults match the captured
     // no-reserve Standard base frame (dry Standard, eco Auto, no reserve,
@@ -653,7 +667,16 @@ export default class Device extends AABBDevice {
                 },
             }),
         )
-        this.publishProperty('course_select', COURSE.map(this.selectedCourse))
+        const remembered = Device.remembered.get(HA)?.get(this.id)
+        if (remembered !== undefined) {
+            this.downloadedCourse = remembered.course
+            this.useDownloadedCourse = remembered.downloaded
+        }
+        if (this.useDownloadedCourse && this.downloadedCourse !== undefined) {
+            this.publishProperty('course_select', 'Downloaded Course')
+            this.publishProperty('smart_course_select', this.downloadedCourse)
+            this.publishProperty('smart_course', this.downloadedCourse)
+        } else this.publishProperty('course_select', COURSE.map(this.selectedCourse))
         this.publishProperty('reserve_hours', this.reserveHours)
         this.publishProperty('dry_level_select', DRY_LEVEL.map(this.dryCode))
         this.publishProperty('eco_hybrid_select', ECO_HYBRID.map(this.ecoCode))
@@ -676,12 +699,14 @@ export default class Device extends AABBDevice {
         if (prop === 'course_select') {
             if (mqttValue === 'Downloaded Course') {
                 this.useDownloadedCourse = true
+                this.remember()
                 this.publishProperty('course_select', mqttValue)
                 return
             }
             const id = COURSE.unmap(mqttValue)
             if (id === undefined || COURSE_TEMPLATE[id] === undefined) return
             this.useDownloadedCourse = false
+            this.remember()
             this.selectedCourse = id
             const def = COURSE_DEFAULTS[id] ?? { dry: 0, eco: 2, ac: 0 }
             this.dryCode = def.dry
@@ -697,8 +722,12 @@ export default class Device extends AABBDevice {
             const blob = DOWNLOAD_COURSE_TEMPLATE[mqttValue]
             if (blob === undefined) return
             this.downloadedCourse = mqttValue
+            this.useDownloadedCourse = true
+            this.remember()
             this.send(Buffer.from(blob, 'hex'))
             this.publishProperty('smart_course_select', mqttValue)
+            this.publishProperty('course_select', 'Downloaded Course')
+            this.publishProperty('smart_course', mqttValue)
             return
         }
         if (prop === 'reserve_hours') {
@@ -808,11 +837,13 @@ export default class Device extends AABBDevice {
         if (smartCourse !== undefined) {
             this.downloadedCourse = smartCourse
             this.useDownloadedCourse = true
+            this.remember()
             this.publishProperty('smart_course_select', smartCourse)
             this.publishProperty('course_select', 'Downloaded Course')
         } else if (COURSE_TEMPLATE[rawCourse] !== undefined) {
             this.selectedCourse = rawCourse
             this.useDownloadedCourse = false
+            this.remember()
             this.publishProperty('course_select', COURSE.map(rawCourse))
         }
         this.publishProperty(

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -64,6 +64,7 @@ const INITIAL_MINUTE_OFFSET = 5
 // the child-lock flag; the 0x01 bit tracks a pending reservation.
 const ANTI_CREASE_OFFSET = 15
 const ANTI_CREASE_FLAG = 0x02
+const RESERVATION_FLAG = 0x01
 // Owner-labelled remote-control ON→OFF transition isolated rec[16] bit
 // 0x01: 0x19→0x18 while the unrelated 0x18 bits remained set.
 const REMOTE_START_OFFSET = 16
@@ -674,6 +675,19 @@ export default class Device extends AABBDevice {
                         payload_off: 'OFF',
                         icon: 'mdi:tshirt-crew-outline',
                     },
+                    // Same byte as anti_crease, a separate bit (0x01): ON
+                    // while a reservation is pending, independent of the
+                    // computed 'Reserved' Status label.
+                    reservation: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-reservation',
+                        state_topic: '$this/reservation',
+                        name: 'Reservation',
+                        payload_on: 'ON',
+                        payload_off: 'OFF',
+                        icon: 'mdi:calendar-clock',
+                        entity_category: 'diagnostic',
+                    },
                     remote_start: {
                         platform: 'binary_sensor',
                         unique_id: '$deviceid-remote_start',
@@ -924,6 +938,10 @@ export default class Device extends AABBDevice {
         this.publishProperty(
             'anti_crease',
             (buf[recordOffset + ANTI_CREASE_OFFSET] & ANTI_CREASE_FLAG) !== 0 ? 'ON' : 'OFF',
+        )
+        this.publishProperty(
+            'reservation',
+            (buf[recordOffset + ANTI_CREASE_OFFSET] & RESERVATION_FLAG) !== 0 ? 'ON' : 'OFF',
         )
         this.publishProperty(
             'remote_start',

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -39,6 +39,14 @@ const PROCESS_STATE_OFFSET = 10
 // rec[16] bit remained set across the lock transition and power cycle.
 const CHILD_LOCK_OFFSET = 15
 const CHILD_LOCK_FLAG = 0x08
+// remainTime/initialTime (rec[2:4]/rec[4:6]) read equal HH:MM while a run is
+// only reserved or just started, and the Time Dry capture's minutes matched
+// the user-selected 30 exactly, confirming these are the model's own
+// remainTimeHour/Minute and initialTimeHour/Minute fields, in that order.
+const REMAIN_HOUR_OFFSET = 2
+const REMAIN_MINUTE_OFFSET = 3
+const INITIAL_HOUR_OFFSET = 4
+const INITIAL_MINUTE_OFFSET = 5
 // Single-toggle ON→OFF with course/eco/dry-level/reserve held constant
 // isolated rec[15] bit 0x02: ON ...03 99..., OFF ...01 99.... Same byte as
 // the child-lock flag; the 0x01 bit tracks a pending reservation.
@@ -276,7 +284,7 @@ export default class Device extends AABBDevice {
                         command_topic: '$this/power_off/set',
                         payload_press: '',
                         name: 'Power off',
-                        icon: 'mdi:power-off',
+                        icon: 'mdi:power',
                     },
                     course: {
                         platform: 'sensor',
@@ -401,8 +409,8 @@ export default class Device extends AABBDevice {
                         name: 'Child lock',
                         payload_on: 'ON',
                         payload_off: 'OFF',
-                        device_class: 'lock',
-                        icon: 'mdi:lock-outline',
+                        icon: 'mdi:lock',
+                        entity_category: 'diagnostic',
                     },
                     anti_crease: {
                         platform: 'binary_sensor',
@@ -453,6 +461,47 @@ export default class Device extends AABBDevice {
                         icon: 'mdi:stethoscope',
                         entity_category: 'diagnostic',
                     },
+                    remaining_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-remaining_time',
+                        state_topic: '$this/remaining_time',
+                        name: 'Remaining time',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        state_class: 'measurement',
+                        icon: 'mdi:timer-sand',
+                    },
+                    initial_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-initial_time',
+                        state_topic: '$this/initial_time',
+                        name: 'Initial time',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        state_class: 'measurement',
+                        icon: 'mdi:timer-outline',
+                    },
+                    reserve_time: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-reserve_time',
+                        state_topic: '$this/reserve_time',
+                        name: 'Reserve time',
+                        device_class: 'duration',
+                        unit_of_measurement: 'min',
+                        state_class: 'measurement',
+                        icon: 'mdi:calendar-clock',
+                    },
+                    energy: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-energy',
+                        state_topic: '$this/energy',
+                        name: 'Power',
+                        device_class: 'energy',
+                        unit_of_measurement: 'Wh',
+                        state_class: 'total_increasing',
+                        icon: 'mdi:lightning-bolt',
+                        entity_category: 'diagnostic',
+                    },
                 },
             }),
         )
@@ -461,6 +510,12 @@ export default class Device extends AABBDevice {
         this.publishProperty('dry_level_select', DRY_LEVEL.map(this.dryCode))
         this.publishProperty('eco_hybrid_select', ECO_HYBRID.map(this.ecoCode))
         this.publishProperty('anti_crease_select', 'Off')
+        // Energy offset not yet isolated for RH16 (tail bytes vary without a
+        // labelled transition) — expose as 0 until a running vs idle capture
+        // grounds it, same convention as F24VDD. The model's own
+        // EnergyMonitoring.powertable gives reference wattage per dry level
+        // (1400-2600W) but no cumulative Wh field has been captured on the wire.
+        this.publishProperty('energy', 0)
     }
 
     start() {
@@ -569,5 +624,14 @@ export default class Device extends AABBDevice {
         this.publishProperty('dry_level', DRY_LEVEL.map(buf[recordOffset + DRY_LEVEL_OFFSET]) ?? 'None')
         this.publishProperty('eco_hybrid', ECO_HYBRID.map(buf[recordOffset + ECO_HYBRID_OFFSET]) ?? 'None')
         this.publishProperty('steam', (buf[recordOffset + STEAM_OFFSET] & STEAM_FLAG) !== 0 ? 'ON' : 'OFF')
+        this.publishProperty(
+            'remaining_time',
+            buf[recordOffset + REMAIN_HOUR_OFFSET] * 60 + buf[recordOffset + REMAIN_MINUTE_OFFSET],
+        )
+        this.publishProperty(
+            'initial_time',
+            buf[recordOffset + INITIAL_HOUR_OFFSET] * 60 + buf[recordOffset + INITIAL_MINUTE_OFFSET],
+        )
+        this.publishProperty('reserve_time', buf[recordOffset + RESERVE_REMAIN_HOUR_OFFSET] * 60)
     }
 }

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -60,6 +60,85 @@ const STATUS_REQUEST = 'F0ED1121010000001800'
 const PAUSE_COMMAND = 'F024040100'
 // Owner-labelled ThinQ app power-off, MCP toDevice seq 222.
 const POWER_OFF_COMMAND = 'F024010100'
+// F026 course-start templates: the exact ThinQ app bytes captured per
+// course (MCP toDevice seq in comments). Only the reserve byte (index 8)
+// is ever overwritten: it reads back the selected hours on all 20
+// reservation captures and 0 on both immediate starts. Every other byte,
+// including the dry level (3), eco (4) and anti-crease (11) positions,
+// stays exactly as captured unless the course's own model table declares
+// the field selectable (see *_WRITABLE below). The Standard template is
+// the captured no-reserve base frame, which is also what the app replays
+// for Resume.
+const COURSE_TEMPLATE: Record<number, string> = {
+    1: 'f0260100020000000300000003080000', // seq190 Steam Refresh, reserve 3
+    2: 'f0260200020000000300000003000000', // seq150 Towel, reserve 3
+    4: 'f0260400030000000400000203000000', // seq156 Bulky Item, reserve 4, anti-crease on
+    5: 'f0260503020000000300000003000000', // seq163 Easy Care, dry Standard, reserve 3
+    7: 'f0260703020000000000000001000000', // captured no-reserve base = Resume frame
+    8: 'f0260800010000000400000003000000', // seq94 Sports Wear, reserve 4
+    9: 'f0260900030000000300000203000000', // seq101 Quick Dry, reserve 3, anti-crease on
+    11: 'f0260b00020000000300000003000000', // seq107 Wool, reserve 3
+    15: 'f0260f00030000000400000003000000', // seq120 Bedding Brush, reserve 4
+    16: 'f0261000030000000300000003080000', // seq126 Allergy Care, reserve 3
+    18: 'f0261200030000000000000003080000', // seq212 Condenser Care, immediate
+    19: 'f0261300030000000300000003080000', // seq218 Tub Clean, reserve 3
+    20: 'f0261400030000000300000003000000', // seq196 Padding Refresh, reserve 3
+    21: 'f0261500021e00000300000003000000', // seq114 Time Dry 30min, reserve 3
+    22: 'f0261600033c00000300000003000000', // seq206 Outdoor Refresh, reserve 3
+    23: 'f0261700020000000400000003000000', // seq144 Baby Wear, reserve 4
+}
+const TEMPLATE_DRY_OFFSET = 3
+const TEMPLATE_ECO_OFFSET = 4
+const TEMPLATE_RESERVE_OFFSET = 8
+const TEMPLATE_AC_OFFSET = 11
+const AC_BYTE_ON = 0x02
+// Per-course, per-field write whitelists from the model's own Course
+// function tables: dry level is selectable only on Standard (all five)
+// and Easy Care (Light/Standard); eco only on Standard; anti-crease on
+// every course whose model entry declares it (all but Condenser Care and
+// Tub Clean). A value outside the whitelist leaves the template byte
+// untouched instead of sending a combo the app can never produce.
+const DRY_WRITABLE: Record<number, number[]> = { 7: [1, 2, 3, 4, 5], 5: [2, 3] }
+const ECO_WRITABLE: Record<number, number[]> = { 7: [1, 2, 3] }
+const AC_WRITABLE = [1, 2, 4, 5, 7, 8, 9, 11, 15, 16, 20, 21, 22, 23]
+// Model Course function defaults per course: selecting a course resets the
+// remembered options to what the app itself shows, so a Start without
+// touching the selects replays exactly that.
+const COURSE_DEFAULTS: Record<number, { dry: number; eco: number; ac: number }> = {
+    1: { dry: 0, eco: 2, ac: 0 },
+    2: { dry: 0, eco: 2, ac: 0 },
+    4: { dry: 0, eco: 3, ac: 1 },
+    5: { dry: 3, eco: 2, ac: 0 },
+    7: { dry: 3, eco: 2, ac: 0 },
+    8: { dry: 0, eco: 1, ac: 0 },
+    9: { dry: 0, eco: 3, ac: 1 },
+    11: { dry: 0, eco: 2, ac: 0 },
+    15: { dry: 0, eco: 3, ac: 0 },
+    16: { dry: 0, eco: 3, ac: 0 },
+    18: { dry: 0, eco: 3, ac: 0 },
+    19: { dry: 0, eco: 3, ac: 0 },
+    20: { dry: 0, eco: 3, ac: 0 },
+    21: { dry: 0, eco: 2, ac: 0 },
+    22: { dry: 0, eco: 3, ac: 0 },
+    23: { dry: 0, eco: 2, ac: 0 },
+}
+
+function buildCourseFrame(
+    courseId: number,
+    reserveHours: number,
+    dry: number,
+    eco: number,
+    antiCrease: number,
+): Buffer | undefined {
+    const template = COURSE_TEMPLATE[courseId]
+    if (template === undefined) return undefined
+    const bytes = Buffer.from(template, 'hex')
+    bytes[TEMPLATE_RESERVE_OFFSET] = reserveHours
+    if (DRY_WRITABLE[courseId]?.includes(dry)) bytes[TEMPLATE_DRY_OFFSET] = dry
+    if (ECO_WRITABLE[courseId]?.includes(eco)) bytes[TEMPLATE_ECO_OFFSET] = eco
+    if (AC_WRITABLE.includes(courseId)) bytes[TEMPLATE_AC_OFFSET] = antiCrease === 1 ? AC_BYTE_ON : 0x00
+    return bytes
+}
 // Sixteen course codes isolated from owner-labelled ThinQ app starts with
 // matching state records: Standard 07, Sports Wear 08, Quick Dry 09,
 // Wool 0B, Bedding Brush 0F, Allergy Care 10, Condenser Care
@@ -158,6 +237,16 @@ const ERROR_MESSAGE = Enum.of({
 })
 
 export default class Device extends AABBDevice {
+    // Tracks what the HA selects were last set to, so Start course and
+    // Resume can build a full frame. Defaults match the captured
+    // no-reserve Standard base frame (dry Standard, eco Auto, no reserve,
+    // anti-crease off).
+    private selectedCourse = 7
+    private reserveHours = 0
+    private dryCode = 3
+    private ecoCode = 2
+    private antiCreaseCode = 0
+
     constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
         super(HA, thinq)
         this.setConfig(
@@ -224,6 +313,77 @@ export default class Device extends AABBDevice {
                         payload_on: 'ON',
                         payload_off: 'OFF',
                         icon: 'mdi:cloud-outline',
+                    },
+                    // Only courses with a captured start template are offered.
+                    // Start course replays the exact captured app bytes for the
+                    // selected course with the chosen reserve/options folded in
+                    // wherever the model declares them selectable.
+                    course_select: {
+                        platform: 'select',
+                        unique_id: '$deviceid-course_select',
+                        state_topic: '$this/course_select',
+                        command_topic: '$this/course_select/set',
+                        name: 'Course select',
+                        options: COURSE.options,
+                        icon: 'mdi:playlist-edit',
+                    },
+                    reserve_hours: {
+                        platform: 'number',
+                        unique_id: '$deviceid-reserve_hours',
+                        state_topic: '$this/reserve_hours',
+                        command_topic: '$this/reserve_hours/set',
+                        name: 'Reserve hours',
+                        min: 0,
+                        max: 19,
+                        step: 1,
+                        icon: 'mdi:calendar-clock',
+                        entity_category: 'config',
+                    },
+                    dry_level_select: {
+                        platform: 'select',
+                        unique_id: '$deviceid-dry_level_select',
+                        state_topic: '$this/dry_level_select',
+                        command_topic: '$this/dry_level_select/set',
+                        name: 'Dry level select',
+                        options: DRY_LEVEL.options,
+                        icon: 'mdi:thermometer',
+                        entity_category: 'config',
+                    },
+                    eco_hybrid_select: {
+                        platform: 'select',
+                        unique_id: '$deviceid-eco_hybrid_select',
+                        state_topic: '$this/eco_hybrid_select',
+                        command_topic: '$this/eco_hybrid_select/set',
+                        name: 'Eco hybrid select',
+                        options: ECO_HYBRID.options,
+                        icon: 'mdi:leaf',
+                        entity_category: 'config',
+                    },
+                    anti_crease_select: {
+                        platform: 'select',
+                        unique_id: '$deviceid-anti_crease_select',
+                        state_topic: '$this/anti_crease_select',
+                        command_topic: '$this/anti_crease_select/set',
+                        name: 'Anti crease select',
+                        options: ['Off', 'On'],
+                        icon: 'mdi:shirt-crew-outline',
+                        entity_category: 'config',
+                    },
+                    start_course: {
+                        platform: 'button',
+                        unique_id: '$deviceid-start_course',
+                        command_topic: '$this/start_course/set',
+                        payload_press: '',
+                        name: 'Start course',
+                        icon: 'mdi:play-circle-outline',
+                    },
+                    resume: {
+                        platform: 'button',
+                        unique_id: '$deviceid-resume',
+                        command_topic: '$this/resume/set',
+                        payload_press: '',
+                        name: 'Resume',
+                        icon: 'mdi:play-pause',
                     },
                     status: {
                         platform: 'sensor',
@@ -296,15 +456,75 @@ export default class Device extends AABBDevice {
                 },
             }),
         )
+        this.publishProperty('course_select', COURSE.map(this.selectedCourse))
+        this.publishProperty('reserve_hours', this.reserveHours)
+        this.publishProperty('dry_level_select', DRY_LEVEL.map(this.dryCode))
+        this.publishProperty('eco_hybrid_select', ECO_HYBRID.map(this.ecoCode))
+        this.publishProperty('anti_crease_select', 'Off')
     }
 
     start() {
         this.send(Buffer.from(STATUS_REQUEST, 'hex'))
     }
 
-    setProperty(prop: string, _mqttValue: string) {
+    setProperty(prop: string, mqttValue: string) {
         if (prop === 'pause') this.send(Buffer.from(PAUSE_COMMAND, 'hex'))
         if (prop === 'power_off') this.send(Buffer.from(POWER_OFF_COMMAND, 'hex'))
+        if (prop === 'course_select') {
+            const id = COURSE.unmap(mqttValue)
+            if (id === undefined || COURSE_TEMPLATE[id] === undefined) return
+            this.selectedCourse = id
+            const def = COURSE_DEFAULTS[id] ?? { dry: 0, eco: 2, ac: 0 }
+            this.dryCode = def.dry
+            this.ecoCode = def.eco
+            this.antiCreaseCode = def.ac
+            this.publishProperty('course_select', mqttValue)
+            this.publishProperty('dry_level_select', DRY_LEVEL.map(def.dry) ?? 'None')
+            this.publishProperty('eco_hybrid_select', ECO_HYBRID.map(def.eco) ?? 'None')
+            this.publishProperty('anti_crease_select', def.ac === 1 ? 'On' : 'Off')
+            return
+        }
+        if (prop === 'reserve_hours') {
+            const hours = Number(mqttValue)
+            if (!Number.isInteger(hours) || hours < 0 || hours > 19) return
+            this.reserveHours = hours
+            this.publishProperty('reserve_hours', hours)
+            return
+        }
+        if (prop === 'dry_level_select') {
+            const code = DRY_LEVEL.unmap(mqttValue)
+            if (code === undefined) return
+            this.dryCode = code
+            this.publishProperty('dry_level_select', mqttValue)
+            return
+        }
+        if (prop === 'eco_hybrid_select') {
+            const code = ECO_HYBRID.unmap(mqttValue)
+            if (code === undefined) return
+            this.ecoCode = code
+            this.publishProperty('eco_hybrid_select', mqttValue)
+            return
+        }
+        if (prop === 'anti_crease_select') {
+            if (mqttValue !== 'Off' && mqttValue !== 'On') return
+            this.antiCreaseCode = mqttValue === 'On' ? 1 : 0
+            this.publishProperty('anti_crease_select', mqttValue)
+            return
+        }
+        // Resume replays the remembered full start frame: the captured
+        // ThinQ app resume is byte-identical in structure to a start with
+        // the same options, so both buttons build from the same templates.
+        if (prop === 'start_course' || prop === 'resume') {
+            const frame = buildCourseFrame(
+                this.selectedCourse,
+                this.reserveHours,
+                this.dryCode,
+                this.ecoCode,
+                this.antiCreaseCode,
+            )
+            if (frame !== undefined) this.send(frame)
+            return
+        }
     }
 
     processAABB(buf: Buffer) {

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -1,6 +1,7 @@
 import { Device as Thinq2Device } from '../thinq2/device'
 import { type Connection } from '../homeassistant'
 import { type Metadata } from '../thinq'
+import { readFileSync, writeFileSync } from 'node:fs'
 import { allowExtendedType } from '@/util/casting'
 import HADevice from './base'
 import AABBDevice from './aabb_device'
@@ -22,6 +23,13 @@ const SINGLE_STATUS = 0xeb
 const DOUBLE_STATUS = 0xec
 const SINGLE_BODY_LEN = 29
 const DOUBLE_BODY_LEN = 56
+// Persistent course memory shared by the three laundry drivers: the F24VDD
+// washer re-reports its installed download on every status frame, but the
+// dryer and styler only report it while running, so their installed course
+// is kept here to survive rethink restarts. Overridable for tests.
+function courseMemoryFile(): string {
+    return process.env.RETHINK_MEMORY_FILE ?? '/app/data/rethink-course-memory.json'
+}
 const SINGLE_RECORD_OFFSET = 3
 const DOUBLE_CURRENT_RECORD_OFFSET = 30
 const RECORD_MARKER = 0x19
@@ -390,6 +398,53 @@ export default class Device extends AABBDevice {
         }
         if (this.downloadedCourse !== undefined)
             devices.set(this.id, { course: this.downloadedCourse, downloaded: this.useDownloadedCourse })
+        this.saveMemory()
+    }
+
+    // Disk-backed course memory. The static remembered map dies with the
+    // process, but the appliance keeps its installed download — and no
+    // monitor byte reads it back (see downloadedCourse below), so without
+    // disk the F24VDD washer convention ("smart_course always shows the
+    // installed download, never Unknown") would break on every restart.
+    // A single JSON map on the persistent volume; failures never throw.
+    private loadMemory(): {
+        downloadedCourse?: string
+        useDownloadedCourse?: boolean
+        selectedCourse?: number
+        reserveHours?: number
+        dryCode?: number
+        ecoCode?: number
+    } {
+        try {
+            const all = JSON.parse(readFileSync(courseMemoryFile(), 'utf8')) as Record<string, unknown>
+            const entry = all[this.id]
+            if (typeof entry !== 'object' || entry === null) return {}
+            return entry as ReturnType<Device['loadMemory']>
+        } catch {
+            return {}
+        }
+    }
+
+    private saveMemory(): void {
+        try {
+            let all: Record<string, unknown> = {}
+            try {
+                all = JSON.parse(readFileSync(courseMemoryFile(), 'utf8')) as Record<string, unknown>
+            } catch {
+                // no memory file yet — create it below
+            }
+            all[this.id] = {
+                downloadedCourse: this.downloadedCourse,
+                useDownloadedCourse: this.useDownloadedCourse,
+                selectedCourse: this.selectedCourse,
+                reserveHours: this.reserveHours,
+                dryCode: this.dryCode,
+                ecoCode: this.ecoCode,
+            }
+            writeFileSync(courseMemoryFile(), JSON.stringify(all))
+        } catch (err) {
+            console.warn(`course memory save failed for ${this.id}: ${err}`)
+        }
     }
 
     // Tracks what the HA selects were last set to, so Start course and
@@ -703,6 +758,18 @@ export default class Device extends AABBDevice {
         if (remembered !== undefined) {
             this.downloadedCourse = remembered.course
             this.useDownloadedCourse = remembered.downloaded
+        } else {
+            // Same-process reconnects restore from the static map above; a
+            // real restart restores from disk so smart_course keeps showing
+            // the installed download exactly like the F24VDD washer, which
+            // re-reports it on every status frame.
+            const disk = this.loadMemory()
+            if (disk.downloadedCourse !== undefined) this.downloadedCourse = disk.downloadedCourse
+            if (disk.useDownloadedCourse !== undefined) this.useDownloadedCourse = disk.useDownloadedCourse
+            if (disk.selectedCourse !== undefined) this.selectedCourse = disk.selectedCourse
+            if (disk.reserveHours !== undefined) this.reserveHours = disk.reserveHours
+            if (disk.dryCode !== undefined) this.dryCode = disk.dryCode
+            if (disk.ecoCode !== undefined) this.ecoCode = disk.ecoCode
         }
         if (this.useDownloadedCourse && this.downloadedCourse !== undefined) {
             this.publishProperty('course_select', 'Downloaded Course')
@@ -877,7 +944,10 @@ export default class Device extends AABBDevice {
             this.useDownloadedCourse = false
             this.remember()
             this.publishProperty('course_select', COURSE.map(rawCourse))
-            this.publishProperty('smart_course', 'Unknown')
+            // smart_course is deliberately left alone: the installed download
+            // is still on the appliance (running a native course does not
+            // uninstall it), and the F24VDD washer keeps reporting it whether
+            // it runs or not. Never assert 'Unknown' here.
         }
         // else: no positive evidence either way. An idle frame with nothing
         // we remember armed may still mean a download is installed on the

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -31,6 +31,10 @@ const STATE_OFFSET = 1
 // rec[16] bit remained set across the lock transition and power cycle.
 const CHILD_LOCK_OFFSET = 15
 const CHILD_LOCK_FLAG = 0x08
+// Owner-labelled remote-control ON→OFF transition isolated rec[16] bit
+// 0x01: 0x19→0x18 while the unrelated 0x18 bits remained set.
+const REMOTE_START_OFFSET = 16
+const REMOTE_START_FLAG = 0x01
 const STATE_POWEROFF = 0
 const STATE_ERROR = 5
 const STATE_DIAGNOSIS = 8
@@ -82,6 +86,15 @@ export default class Device extends AABBDevice {
                         device_class: 'lock',
                         icon: 'mdi:lock-outline',
                     },
+                    remote_start: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-remote_start',
+                        state_topic: '$this/remote_start',
+                        name: 'Remote start',
+                        payload_on: 'ON',
+                        payload_off: 'OFF',
+                        icon: 'mdi:cellphone-check',
+                    },
                     error: {
                         platform: 'binary_sensor',
                         unique_id: '$deviceid-error',
@@ -128,6 +141,10 @@ export default class Device extends AABBDevice {
         this.publishProperty(
             'child_lock',
             (buf[recordOffset + CHILD_LOCK_OFFSET] & CHILD_LOCK_FLAG) !== 0 ? 'ON' : 'OFF',
+        )
+        this.publishProperty(
+            'remote_start',
+            (buf[recordOffset + REMOTE_START_OFFSET] & REMOTE_START_FLAG) !== 0 ? 'ON' : 'OFF',
         )
         this.publishProperty('error', state === STATE_ERROR ? 'ON' : 'OFF')
         this.publishProperty('smart_diagnosis', state === STATE_DIAGNOSIS ? 'ON' : 'OFF')

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -748,7 +748,7 @@ export default class Device extends AABBDevice {
                         platform: 'sensor',
                         unique_id: '$deviceid-energy',
                         state_topic: '$this/energy',
-                        name: 'Power',
+                        name: 'Energy',
                         device_class: 'energy',
                         unit_of_measurement: 'Wh',
                         state_class: 'total_increasing',

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -153,10 +153,16 @@ function buildCourseFrame(
 // 12, Tub Clean 13, Padding Refresh 14, Time Dry 15, Outdoor
 // Refresh 16, Baby Wear 17, Steam Refresh 01, Towel 02, Bulky Item 04,
 // Easy Care 05. The model's RACKDRY and COOLAIR entries have no captured code
-// yet and read back as 'None' through the safe fallback below.
+// yet and read back as 'Unsupported' through the safe fallback below.
+//
+// HA's MQTT sensor treats the literal payload 'None' as PAYLOAD_NONE and
+// forces the state to unknown, so a real reading must never publish that
+// string. 'Off' carries code 0, which is what the appliance reports for a
+// course that does not offer the setting at all.
 const COURSE_OFFSET = 6
 const COURSE = Enum.of({
-    None: 0,
+    Unsupported: [],
+    Off: 0,
     'Steam Refresh': 1,
     Towel: 2,
     'Bulky Item': 4,
@@ -178,10 +184,11 @@ const COURSE = Enum.of({
 // 3 IRON, 4 CUPBOARD, 5 VERY); the owner-facing names are the ThinQ app
 // labels reported for those levels. 0 is the model default NO_DRYLEVEL,
 // captured live on Steam Refresh, Towel, Bulky Item, Sports Wear, Quick
-// Dry, Wool and every other course that does not offer a dry level.
+// Dry, Wool and every other course that does not offer a dry level, and
+// shows as Off exactly like the app greys the setting out.
 const DRY_LEVEL_OFFSET = 8
 const DRY_LEVEL = Enum.of({
-    None: 0,
+    Off: 0,
     Delicate: 1,
     Light: 2,
     Standard: 3,
@@ -194,10 +201,22 @@ const DRY_LEVEL = Enum.of({
 // model's own Course function table.
 const ECO_HYBRID_OFFSET = 9
 const ECO_HYBRID = Enum.of({
+    Unsupported: [],
     Energy: 1,
     Auto: 2,
     Speed: 3,
 })
+// Selects offer only what can actually be sent. 'Unsupported' is the
+// read-only fallback for a code with no captured meaning, so it never
+// belongs in a writable option list. 'Off' stays: the appliance really does
+// report a dry level or eco setting of Off on courses that do not expose it,
+// and an HA select's state has to be one of its own options.
+const selectable = (options: string[]) => options.filter((option) => option !== 'Unsupported')
+const COURSE_SELECT_OPTIONS = selectable(COURSE.options).filter(
+    (option) => COURSE_TEMPLATE[COURSE.unmap(option) ?? -1] !== undefined,
+)
+const DRY_LEVEL_SELECT_OPTIONS = selectable(DRY_LEVEL.options)
+const ECO_HYBRID_SELECT_OPTIONS = selectable(ECO_HYBRID.options)
 // Steam courses (Steam refresh, Steam sterilize, Condenser care, Steam tub
 // sterilize) read rec[17] 0x08 while all 17 non-steam captures read 0x00,
 // and the same courses carry the 0x08 byte in the start payload tail.
@@ -205,6 +224,7 @@ const STEAM_OFFSET = 17
 const STEAM_FLAG = 0x08
 
 const STATE = Enum.of({
+    Unsupported: [],
     'Power off': 0,
     Standby: 1,
     Drying: 2,
@@ -226,7 +246,7 @@ const PROCESS_STATE = Enum.of({
 const STATUS_OPTIONS = [...new Set([...STATE.options, ...PROCESS_STATE.options])]
 
 const ERROR_MESSAGE = Enum.of({
-    None: -1,
+    Unsupported: [],
     Normal: 0,
     tE1: 1,
     tE2: 2,
@@ -336,7 +356,7 @@ export default class Device extends AABBDevice {
                         state_topic: '$this/course_select',
                         command_topic: '$this/course_select/set',
                         name: 'Course select',
-                        options: COURSE.options,
+                        options: COURSE_SELECT_OPTIONS,
                         icon: 'mdi:playlist-edit',
                     },
                     reserve_hours: {
@@ -357,7 +377,7 @@ export default class Device extends AABBDevice {
                         state_topic: '$this/dry_level_select',
                         command_topic: '$this/dry_level_select/set',
                         name: 'Dry level select',
-                        options: DRY_LEVEL.options,
+                        options: DRY_LEVEL_SELECT_OPTIONS,
                         icon: 'mdi:thermometer',
                         entity_category: 'config',
                     },
@@ -367,7 +387,7 @@ export default class Device extends AABBDevice {
                         state_topic: '$this/eco_hybrid_select',
                         command_topic: '$this/eco_hybrid_select/set',
                         name: 'Eco hybrid select',
-                        options: ECO_HYBRID.options,
+                        options: ECO_HYBRID_SELECT_OPTIONS,
                         icon: 'mdi:leaf',
                         entity_category: 'config',
                     },
@@ -538,8 +558,8 @@ export default class Device extends AABBDevice {
             this.ecoCode = def.eco
             this.antiCreaseCode = def.ac
             this.publishProperty('course_select', mqttValue)
-            this.publishProperty('dry_level_select', DRY_LEVEL.map(def.dry) ?? 'None')
-            this.publishProperty('eco_hybrid_select', ECO_HYBRID.map(def.eco) ?? 'None')
+            this.publishProperty('dry_level_select', DRY_LEVEL.map(def.dry) ?? 'Off')
+            this.publishProperty('eco_hybrid_select', ECO_HYBRID.map(def.eco) ?? 'Auto')
             this.publishProperty('anti_crease_select', def.ac === 1 ? 'On' : 'Off')
             return
         }
@@ -607,7 +627,7 @@ export default class Device extends AABBDevice {
                 ? reservePending
                     ? 'Reserved'
                     : (PROCESS_STATE.map(processState) ?? 'Drying')
-                : (STATE.map(state) ?? 'None'),
+                : (STATE.map(state) ?? 'Unsupported'),
         )
         this.publishProperty(
             'child_lock',
@@ -622,11 +642,11 @@ export default class Device extends AABBDevice {
             (buf[recordOffset + REMOTE_START_OFFSET] & REMOTE_START_FLAG) !== 0 ? 'ON' : 'OFF',
         )
         this.publishProperty('error', errorCode === 0 ? 'OFF' : 'ON')
-        this.publishProperty('error_message', ERROR_MESSAGE.map(errorCode) ?? 'None')
+        this.publishProperty('error_message', ERROR_MESSAGE.map(errorCode) ?? 'Unsupported')
         this.publishProperty('smart_diagnosis', state === STATE_DIAGNOSIS ? 'ON' : 'OFF')
-        this.publishProperty('course', COURSE.map(buf[recordOffset + COURSE_OFFSET]) ?? 'None')
-        this.publishProperty('dry_level', DRY_LEVEL.map(buf[recordOffset + DRY_LEVEL_OFFSET]) ?? 'None')
-        this.publishProperty('eco_hybrid', ECO_HYBRID.map(buf[recordOffset + ECO_HYBRID_OFFSET]) ?? 'None')
+        this.publishProperty('course', COURSE.map(buf[recordOffset + COURSE_OFFSET]) ?? 'Unsupported')
+        this.publishProperty('dry_level', DRY_LEVEL.map(buf[recordOffset + DRY_LEVEL_OFFSET]) ?? 'Unsupported')
+        this.publishProperty('eco_hybrid', ECO_HYBRID.map(buf[recordOffset + ECO_HYBRID_OFFSET]) ?? 'Unsupported')
         this.publishProperty('steam', (buf[recordOffset + STEAM_OFFSET] & STEAM_FLAG) !== 0 ? 'ON' : 'OFF')
         this.publishProperty(
             'remaining_time',

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -419,6 +419,7 @@ export default class Device extends AABBDevice {
         reserveHours?: number
         dryCode?: number
         ecoCode?: number
+        antiCreaseCode?: number
     } {
         try {
             const all = JSON.parse(readFileSync(courseMemoryFile(), 'utf8')) as Record<string, unknown>
@@ -431,6 +432,22 @@ export default class Device extends AABBDevice {
     }
 
     private saveMemory(): void {
+        const entry = {
+            downloadedCourse: this.downloadedCourse,
+            useDownloadedCourse: this.useDownloadedCourse,
+            selectedCourse: this.selectedCourse,
+            reserveHours: this.reserveHours,
+            dryCode: this.dryCode,
+            ecoCode: this.ecoCode,
+            antiCreaseCode: this.antiCreaseCode,
+        }
+        const serialized = JSON.stringify(entry)
+        // Every recognised status frame calls remember(), which used to mean
+        // every poll rewrote the whole shared file even when nothing in this
+        // device's entry actually changed — needless flash wear and a wider
+        // window for a torn write. Skip the write when the serialized entry
+        // is identical to what was last written.
+        if (serialized === this.lastSavedMemory) return
         try {
             let all: Record<string, unknown> = {}
             try {
@@ -438,19 +455,14 @@ export default class Device extends AABBDevice {
             } catch {
                 // no memory file yet — create it below
             }
-            all[this.id] = {
-                downloadedCourse: this.downloadedCourse,
-                useDownloadedCourse: this.useDownloadedCourse,
-                selectedCourse: this.selectedCourse,
-                reserveHours: this.reserveHours,
-                dryCode: this.dryCode,
-                ecoCode: this.ecoCode,
-            }
+            all[this.id] = entry
             writeFileSync(courseMemoryFile(), JSON.stringify(all))
+            this.lastSavedMemory = serialized
         } catch (err) {
             console.warn(`course memory save failed for ${this.id}: ${err}`)
         }
     }
+    private lastSavedMemory: string | undefined
 
     // Tracks what the HA selects were last set to, so Start course and
     // Resume can build a full frame. Defaults match the captured
@@ -788,6 +800,7 @@ export default class Device extends AABBDevice {
             if (disk.reserveHours !== undefined) this.reserveHours = disk.reserveHours
             if (disk.dryCode !== undefined) this.dryCode = disk.dryCode
             if (disk.ecoCode !== undefined) this.ecoCode = disk.ecoCode
+            if (disk.antiCreaseCode !== undefined) this.antiCreaseCode = disk.antiCreaseCode
         }
         if (this.downloadedCourse !== undefined) {
             // The installed download is shown whether it runs or not —
@@ -801,7 +814,7 @@ export default class Device extends AABBDevice {
         this.publishProperty('reserve_hours', this.reserveHours)
         this.publishProperty('dry_level_select', DRY_LEVEL.map(this.dryCode))
         this.publishProperty('eco_hybrid_select', ECO_HYBRID.map(this.ecoCode))
-        this.publishProperty('anti_crease_select', 'Off')
+        this.publishProperty('anti_crease_select', this.antiCreaseCode === 1 ? 'On' : 'Off')
     }
 
     start() {
@@ -821,12 +834,12 @@ export default class Device extends AABBDevice {
             const id = COURSE.unmap(mqttValue)
             if (id === undefined || COURSE_TEMPLATE[id] === undefined) return
             this.useDownloadedCourse = false
-            this.remember()
             this.selectedCourse = id
             const def = COURSE_DEFAULTS[id] ?? { dry: 0, eco: 2, ac: 0 }
             this.dryCode = def.dry
             this.ecoCode = def.eco
             this.antiCreaseCode = def.ac
+            this.remember()
             this.publishProperty('course_select', mqttValue)
             this.publishProperty('dry_level_select', DRY_LEVEL.map(def.dry) ?? 'Off')
             this.publishProperty('eco_hybrid_select', ECO_HYBRID.map(def.eco) ?? 'Auto')
@@ -847,8 +860,11 @@ export default class Device extends AABBDevice {
         }
         if (prop === 'reserve_hours') {
             const hours = Number(mqttValue)
-            if (!Number.isInteger(hours) || hours < 0 || hours > 19) return
+            // LG declares reservation as 0 (start now) or 3..19 hours; 1 and 2
+            // are outside the model's own range and have never been captured.
+            if (!Number.isInteger(hours) || (hours !== 0 && (hours < 3 || hours > 19))) return
             this.reserveHours = hours
+            this.remember()
             this.publishProperty('reserve_hours', hours)
             return
         }
@@ -856,6 +872,7 @@ export default class Device extends AABBDevice {
             const code = DRY_LEVEL.unmap(mqttValue)
             if (code === undefined) return
             this.dryCode = code
+            this.remember()
             this.publishProperty('dry_level_select', mqttValue)
             return
         }
@@ -863,12 +880,14 @@ export default class Device extends AABBDevice {
             const code = ECO_HYBRID.unmap(mqttValue)
             if (code === undefined) return
             this.ecoCode = code
+            this.remember()
             this.publishProperty('eco_hybrid_select', mqttValue)
             return
         }
         if (prop === 'anti_crease_select') {
             if (mqttValue !== 'Off' && mqttValue !== 'On') return
             this.antiCreaseCode = mqttValue === 'On' ? 1 : 0
+            this.remember()
             this.publishProperty('anti_crease_select', mqttValue)
             return
         }

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -34,11 +34,15 @@ const ERROR_OFFSET = 7
 // This run isolated rec[10] as MonitoringValue.processState: it changed
 // 0 (Detecting) -> 2 (Drying) while the top-level state stayed Running.
 const PROCESS_STATE_OFFSET = 10
-// Owner-labelled ON→OFF transition isolated rec[15] bit 0x08:
-// ON current record ...00 08 08..., OFF ...00 00 08.... The adjacent
-// rec[16] bit remained set across the lock transition and power cycle.
+// Owner-labelled ON→OFF→ON toggles isolated rec[15] bit 0x10: the record
+// went 0x01 → 0x11 → 0x01 with that byte the only one to change in either
+// direction, while the appliance sat in a reserved run. Bit 0x02 is
+// anti-crease and stayed clear throughout, so the two do not collide.
+// Bit 0x08 was the earlier mapping and is wrong: it is also set in the
+// plain INITIAL and PAUSED captures where the lock was never engaged, so
+// it tracks something else and reported the lock as ON while it was off.
 const CHILD_LOCK_OFFSET = 15
-const CHILD_LOCK_FLAG = 0x08
+const CHILD_LOCK_FLAG = 0x10
 // remainTime/initialTime (rec[2:4]/rec[4:6]) read equal HH:MM while a run is
 // only reserved or just started, and the Time Dry capture's minutes matched
 // the user-selected 30 exactly, confirming these are the model's own

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -218,14 +218,6 @@ const COURSE = Enum.of({
     'Time Dry': 21,
     'Outdoor Refresh': 22,
     'Baby Wear': 23,
-    // Observed live once: while the downloaded Powerful Dry ran on a
-    // reservation, the course byte read 0x11, where native courses report
-    // their own id (Standard read 0x07 while running). The washer works the
-    // same way with one shared downloaded id, so this is the generic
-    // downloaded-course marker until a second download course proves
-    // otherwise. It is display only: course select and Start stay native
-    // until per-course smart start frames are captured.
-    'Downloaded Course': 17,
 })
 // Rec[8] follows the model's own dryLevel index table (1 DAMP, 2 LESS,
 // 3 IRON, 4 CUPBOARD, 5 VERY); the owner-facing names are the ThinQ app

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -47,6 +47,7 @@ const STATE_POWEROFF = 0
 const STATE_RUNNING = 2
 const STATE_DIAGNOSIS = 8
 const STATUS_REQUEST = 'F0ED1121010000001800'
+const PAUSE_COMMAND = 'F024040100'
 
 const STATE = Enum.of({
     'Power off': 0,
@@ -99,6 +100,14 @@ export default class Device extends AABBDevice {
             allowExtendedType({
                 ...HADevice.config(meta, { name: 'LG Dryer' }),
                 components: {
+                    pause: {
+                        platform: 'button',
+                        unique_id: '$deviceid-pause',
+                        command_topic: '$this/pause/set',
+                        payload_press: '',
+                        name: 'Pause',
+                        icon: 'mdi:pause-circle-outline',
+                    },
                     power: {
                         platform: 'binary_sensor',
                         unique_id: '$deviceid-power',
@@ -174,6 +183,10 @@ export default class Device extends AABBDevice {
 
     start() {
         this.send(Buffer.from(STATUS_REQUEST, 'hex'))
+    }
+
+    setProperty(prop: string, _mqttValue: string) {
+        if (prop === 'pause') this.send(Buffer.from(PAUSE_COMMAND, 'hex'))
     }
 
     processAABB(buf: Buffer) {

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -374,7 +374,7 @@ export default class Device extends AABBDevice {
                         command_topic: '$this/anti_crease_select/set',
                         name: 'Anti crease select',
                         options: ['Off', 'On'],
-                        icon: 'mdi:shirt-crew-outline',
+                        icon: 'mdi:tshirt-crew-outline',
                         entity_category: 'config',
                     },
                     start_course: {
@@ -419,7 +419,7 @@ export default class Device extends AABBDevice {
                         name: 'Anti crease',
                         payload_on: 'ON',
                         payload_off: 'OFF',
-                        icon: 'mdi:shirt-crew-outline',
+                        icon: 'mdi:tshirt-crew-outline',
                     },
                     remote_start: {
                         platform: 'binary_sensor',

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -31,6 +31,9 @@ const STATE_OFFSET = 1
 // snapshots all report 0 here; non-zero labels come from this model's own
 // MonitoringValue.error table.
 const ERROR_OFFSET = 7
+// This run isolated rec[10] as MonitoringValue.processState: it changed
+// 0 (Detecting) -> 2 (Drying) while the top-level state stayed Running.
+const PROCESS_STATE_OFFSET = 10
 // Owner-labelled ON→OFF transition isolated rec[15] bit 0x08:
 // ON current record ...00 08 08..., OFF ...00 00 08.... The adjacent
 // rec[16] bit remained set across the lock transition and power cycle.
@@ -41,6 +44,7 @@ const CHILD_LOCK_FLAG = 0x08
 const REMOTE_START_OFFSET = 16
 const REMOTE_START_FLAG = 0x01
 const STATE_POWEROFF = 0
+const STATE_RUNNING = 2
 const STATE_DIAGNOSIS = 8
 const STATUS_REQUEST = 'F0ED1121010000001800'
 
@@ -54,6 +58,16 @@ const STATE = Enum.of({
     'Smart diagnosis': 8,
     Reserved: 100,
 })
+
+const PROCESS_STATE = Enum.of({
+    Detecting: 0,
+    Steam: 1,
+    Drying: [2, 3, 4],
+    Cooling: 5,
+    'Anti crease': 6,
+    Complete: 7,
+})
+const STATUS_OPTIONS = [...new Set([...STATE.options, ...PROCESS_STATE.options])]
 
 const ERROR_MESSAGE = Enum.of({
     None: -1,
@@ -100,7 +114,7 @@ export default class Device extends AABBDevice {
                         state_topic: '$this/status',
                         name: 'Status',
                         device_class: 'enum',
-                        options: STATE.options,
+                        options: STATUS_OPTIONS,
                         icon: 'mdi:tumble-dryer',
                     },
                     child_lock: {
@@ -172,9 +186,13 @@ export default class Device extends AABBDevice {
 
         if (buf[recordOffset] !== RECORD_MARKER) return
         const state = buf[recordOffset + STATE_OFFSET]
+        const processState = buf[recordOffset + PROCESS_STATE_OFFSET]
         const errorCode = buf[recordOffset + ERROR_OFFSET]
         this.publishProperty('power', state === STATE_POWEROFF ? 'OFF' : 'ON')
-        this.publishProperty('status', STATE.map(state) ?? 'None')
+        this.publishProperty(
+            'status',
+            state === STATE_RUNNING ? (PROCESS_STATE.map(processState) ?? 'Drying') : (STATE.map(state) ?? 'None'),
+        )
         this.publishProperty(
             'child_lock',
             (buf[recordOffset + CHILD_LOCK_OFFSET] & CHILD_LOCK_FLAG) !== 0 ? 'ON' : 'OFF',

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -39,6 +39,11 @@ const PROCESS_STATE_OFFSET = 10
 // rec[16] bit remained set across the lock transition and power cycle.
 const CHILD_LOCK_OFFSET = 15
 const CHILD_LOCK_FLAG = 0x08
+// Single-toggle ON→OFF with course/eco/dry-level/reserve held constant
+// isolated rec[15] bit 0x02: ON ...03 99..., OFF ...01 99.... Same byte as
+// the child-lock flag; the 0x01 bit tracks a pending reservation.
+const ANTI_CREASE_OFFSET = 15
+const ANTI_CREASE_FLAG = 0x02
 // Owner-labelled remote-control ON→OFF transition isolated rec[16] bit
 // 0x01: 0x19→0x18 while the unrelated 0x18 bits remained set.
 const REMOTE_START_OFFSET = 16
@@ -141,6 +146,15 @@ export default class Device extends AABBDevice {
                         device_class: 'lock',
                         icon: 'mdi:lock-outline',
                     },
+                    anti_crease: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-anti_crease',
+                        state_topic: '$this/anti_crease',
+                        name: 'Anti crease',
+                        payload_on: 'ON',
+                        payload_off: 'OFF',
+                        icon: 'mdi:shirt-crew-outline',
+                    },
                     remote_start: {
                         platform: 'binary_sensor',
                         unique_id: '$deviceid-remote_start',
@@ -220,6 +234,10 @@ export default class Device extends AABBDevice {
         this.publishProperty(
             'child_lock',
             (buf[recordOffset + CHILD_LOCK_OFFSET] & CHILD_LOCK_FLAG) !== 0 ? 'ON' : 'OFF',
+        )
+        this.publishProperty(
+            'anti_crease',
+            (buf[recordOffset + ANTI_CREASE_OFFSET] & ANTI_CREASE_FLAG) !== 0 ? 'ON' : 'OFF',
         )
         this.publishProperty(
             'remote_start',

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -43,6 +43,11 @@ const CHILD_LOCK_FLAG = 0x08
 // 0x01: 0x19→0x18 while the unrelated 0x18 bits remained set.
 const REMOTE_START_OFFSET = 16
 const REMOTE_START_FLAG = 0x01
+// Owner-labelled 19h and 3h reservations isolated rec[11] (remaining hour)
+// and rec[13] (set hour): both read 19 on the Energy/Delicate/19h run and 3
+// on the Speed/Low/3h run, while the no-reserve baseline reads 0 on both.
+const RESERVE_REMAIN_HOUR_OFFSET = 11
+const RESERVE_SET_HOUR_OFFSET = 13
 const STATE_POWEROFF = 0
 const STATE_RUNNING = 2
 const STATE_DIAGNOSIS = 8
@@ -201,10 +206,16 @@ export default class Device extends AABBDevice {
         const state = buf[recordOffset + STATE_OFFSET]
         const processState = buf[recordOffset + PROCESS_STATE_OFFSET]
         const errorCode = buf[recordOffset + ERROR_OFFSET]
+        const reservePending =
+            buf[recordOffset + RESERVE_REMAIN_HOUR_OFFSET] !== 0 || buf[recordOffset + RESERVE_SET_HOUR_OFFSET] !== 0
         this.publishProperty('power', state === STATE_POWEROFF ? 'OFF' : 'ON')
         this.publishProperty(
             'status',
-            state === STATE_RUNNING ? (PROCESS_STATE.map(processState) ?? 'Drying') : (STATE.map(state) ?? 'None'),
+            state === STATE_RUNNING
+                ? reservePending
+                    ? 'Reserved'
+                    : (PROCESS_STATE.map(processState) ?? 'Drying')
+                : (STATE.map(state) ?? 'None'),
         )
         this.publishProperty(
             'child_lock',

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -601,6 +601,9 @@ export default class Device extends AABBDevice {
                         options: DOWNLOAD_COURSE_OPTIONS,
                         icon: 'mdi:playlist-edit',
                     },
+                    // HA's number entity has no way to declare a hole, so the
+                    // slider still shows 0..19; setProperty is what actually
+                    // enforces LG's real 0-or-3..19 range (see below).
                     reserve_hours: {
                         platform: 'number',
                         unique_id: '$deviceid-reserve_hours',

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -59,10 +59,17 @@ const REMOTE_START_FLAG = 0x01
 // Owner-labelled 19h and 3h reservations isolated rec[11] (remaining hour)
 // and rec[13] (set hour): both read 19 on the Energy/Delicate/19h run and 3
 // on the Speed/Low/3h run, while the no-reserve baseline reads 0 on both.
+// Each hour byte is followed by its own minute byte, matching the model's
+// reserveTimeHour/reserveTimeMinute pair and the washer and styler mapping.
+// A 14h reservation part way through read 13h56m as rec[11]=13, rec[12]=56,
+// so the minutes have to be added or the countdown reads a whole hour short.
 const RESERVE_REMAIN_HOUR_OFFSET = 11
+const RESERVE_REMAIN_MINUTE_OFFSET = 12
 const RESERVE_SET_HOUR_OFFSET = 13
+const RESERVE_SET_MINUTE_OFFSET = 14
 const STATE_POWEROFF = 0
 const STATE_RUNNING = 2
+const STATE_PAUSE = 3
 const STATE_DIAGNOSIS = 8
 const STATUS_REQUEST = 'F0ED1121010000001800'
 const PAUSE_COMMAND = 'F024040100'
@@ -619,15 +626,21 @@ export default class Device extends AABBDevice {
         const processState = buf[recordOffset + PROCESS_STATE_OFFSET]
         const errorCode = buf[recordOffset + ERROR_OFFSET]
         const reservePending =
-            buf[recordOffset + RESERVE_REMAIN_HOUR_OFFSET] !== 0 || buf[recordOffset + RESERVE_SET_HOUR_OFFSET] !== 0
+            buf[recordOffset + RESERVE_REMAIN_HOUR_OFFSET] !== 0 ||
+            buf[recordOffset + RESERVE_REMAIN_MINUTE_OFFSET] !== 0 ||
+            buf[recordOffset + RESERVE_SET_HOUR_OFFSET] !== 0 ||
+            buf[recordOffset + RESERVE_SET_MINUTE_OFFSET] !== 0
         this.publishProperty('power', state === STATE_POWEROFF ? 'OFF' : 'ON')
+        // A reservation waits out its countdown in either RUNNING or PAUSE:
+        // the 14h capture sat in PAUSE with 13h56m still on the clock, which
+        // is not the user pausing a cycle, so the reserve bytes win over both.
         this.publishProperty(
             'status',
-            state === STATE_RUNNING
-                ? reservePending
-                    ? 'Reserved'
-                    : (PROCESS_STATE.map(processState) ?? 'Drying')
-                : (STATE.map(state) ?? 'Unsupported'),
+            reservePending && (state === STATE_RUNNING || state === STATE_PAUSE)
+                ? 'Reserved'
+                : state === STATE_RUNNING
+                  ? (PROCESS_STATE.map(processState) ?? 'Drying')
+                  : (STATE.map(state) ?? 'Unsupported'),
         )
         this.publishProperty(
             'child_lock',
@@ -656,6 +669,9 @@ export default class Device extends AABBDevice {
             'initial_time',
             buf[recordOffset + INITIAL_HOUR_OFFSET] * 60 + buf[recordOffset + INITIAL_MINUTE_OFFSET],
         )
-        this.publishProperty('reserve_time', buf[recordOffset + RESERVE_REMAIN_HOUR_OFFSET] * 60)
+        this.publishProperty(
+            'reserve_time',
+            buf[recordOffset + RESERVE_REMAIN_HOUR_OFFSET] * 60 + buf[recordOffset + RESERVE_REMAIN_MINUTE_OFFSET],
+        )
     }
 }

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -26,6 +26,11 @@ const SINGLE_RECORD_OFFSET = 3
 const DOUBLE_CURRENT_RECORD_OFFSET = 30
 const RECORD_MARKER = 0x19
 const STATE_OFFSET = 1
+// Owner-labelled ON→OFF transition isolated rec[15] bit 0x08:
+// ON current record ...00 08 08..., OFF ...00 00 08.... The adjacent
+// rec[16] bit remained set across the lock transition and power cycle.
+const CHILD_LOCK_OFFSET = 15
+const CHILD_LOCK_FLAG = 0x08
 const STATE_POWEROFF = 0
 const STATE_ERROR = 5
 const STATE_DIAGNOSIS = 8
@@ -66,6 +71,16 @@ export default class Device extends AABBDevice {
                         device_class: 'enum',
                         options: STATE.options,
                         icon: 'mdi:tumble-dryer',
+                    },
+                    child_lock: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-child_lock',
+                        state_topic: '$this/child_lock',
+                        name: 'Child lock',
+                        payload_on: 'ON',
+                        payload_off: 'OFF',
+                        device_class: 'lock',
+                        icon: 'mdi:lock-outline',
                     },
                     error: {
                         platform: 'binary_sensor',
@@ -110,6 +125,10 @@ export default class Device extends AABBDevice {
         const state = buf[recordOffset + STATE_OFFSET]
         this.publishProperty('power', state === STATE_POWEROFF ? 'OFF' : 'ON')
         this.publishProperty('status', STATE.map(state) ?? 'None')
+        this.publishProperty(
+            'child_lock',
+            (buf[recordOffset + CHILD_LOCK_OFFSET] & CHILD_LOCK_FLAG) !== 0 ? 'ON' : 'OFF',
+        )
         this.publishProperty('error', state === STATE_ERROR ? 'ON' : 'OFF')
         this.publishProperty('smart_diagnosis', state === STATE_DIAGNOSIS ? 'ON' : 'OFF')
     }

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -156,6 +156,7 @@ function buildCourseFrame(
 // yet and read back as 'None' through the safe fallback below.
 const COURSE_OFFSET = 6
 const COURSE = Enum.of({
+    None: 0,
     'Steam Refresh': 1,
     Towel: 2,
     'Bulky Item': 4,
@@ -175,9 +176,12 @@ const COURSE = Enum.of({
 })
 // Rec[8] follows the model's own dryLevel index table (1 DAMP, 2 LESS,
 // 3 IRON, 4 CUPBOARD, 5 VERY); the owner-facing names are the ThinQ app
-// labels reported for those levels. 0 is the model default NO_DRYLEVEL.
+// labels reported for those levels. 0 is the model default NO_DRYLEVEL,
+// captured live on Steam Refresh, Towel, Bulky Item, Sports Wear, Quick
+// Dry, Wool and every other course that does not offer a dry level.
 const DRY_LEVEL_OFFSET = 8
 const DRY_LEVEL = Enum.of({
+    None: 0,
     Delicate: 1,
     Light: 2,
     Standard: 3,

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -24,6 +24,12 @@ const SINGLE_BODY_LEN = 29
 const DOUBLE_BODY_LEN = 56
 const SINGLE_RECORD_OFFSET = 3
 const DOUBLE_CURRENT_RECORD_OFFSET = 30
+// An EC frame stacks two records: the previous state at offset 3 and the
+// current one at 30. Only the current one was being read. Across this
+// session's captures the leading record always held the state the appliance
+// was in before the change that produced the frame, exactly like the styler's
+// preState, so it feeds a diagnostic Previous state entity.
+const DOUBLE_PREVIOUS_RECORD_OFFSET = 3
 const RECORD_MARKER = 0x19
 const STATE_OFFSET = 1
 // RH16 uses the same dryer record layout as the captured RV13 family and the
@@ -246,6 +252,14 @@ const STATE = Enum.of({
     Reserved: 100,
 })
 
+/*
+ * MonitoringValue.processState, the sub-phase reported while the top-level
+ * state is Running. The washer folds its equivalent phases straight into one
+ * Status enum (Detecting, Rinsing, Spinning and so on are plain state codes
+ * there), so the dryer publishes the phase into the same Status entity to
+ * match. DRY_LV1/2/3 all label as @WM_STATE_DRY_W in the model, so they
+ * collapse to one Drying entry.
+ */
 const PROCESS_STATE = Enum.of({
     Detecting: 0,
     Steam: 1,
@@ -437,6 +451,16 @@ export default class Device extends AABBDevice {
                         options: STATUS_OPTIONS,
                         icon: 'mdi:tumble-dryer',
                     },
+                    previous_status: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-previous_status',
+                        state_topic: '$this/previous_status',
+                        name: 'Previous state',
+                        device_class: 'enum',
+                        options: STATUS_OPTIONS,
+                        icon: 'mdi:history',
+                        entity_category: 'diagnostic',
+                    },
                     child_lock: {
                         platform: 'binary_sensor',
                         unique_id: '$deviceid-child_lock',
@@ -617,6 +641,26 @@ export default class Device extends AABBDevice {
         }
     }
 
+    /*
+     * The one place a record turns into a Status string. The washer reports
+     * every phase as a plain state code, so the dryer folds its separate
+     * processState into the same entity to read the same way.
+     */
+    private statusOf(buf: Buffer, offset: number): string {
+        const state = buf[offset + STATE_OFFSET]
+        const reservePending =
+            buf[offset + RESERVE_REMAIN_HOUR_OFFSET] !== 0 ||
+            buf[offset + RESERVE_REMAIN_MINUTE_OFFSET] !== 0 ||
+            buf[offset + RESERVE_SET_HOUR_OFFSET] !== 0 ||
+            buf[offset + RESERVE_SET_MINUTE_OFFSET] !== 0
+        // A reservation waits out its countdown in either RUNNING or PAUSE:
+        // the 14h capture sat in PAUSE with 13h56m still on the clock, which
+        // is not the user pausing a cycle, so the reserve bytes win over both.
+        if (reservePending && (state === STATE_RUNNING || state === STATE_PAUSE)) return 'Reserved'
+        if (state === STATE_RUNNING) return PROCESS_STATE.map(buf[offset + PROCESS_STATE_OFFSET]) ?? 'Drying'
+        return STATE.map(state) ?? 'Unsupported'
+    }
+
     processAABB(buf: Buffer) {
         if (buf[0] !== DEVICE_TYPE) return
 
@@ -627,25 +671,15 @@ export default class Device extends AABBDevice {
 
         if (buf[recordOffset] !== RECORD_MARKER) return
         const state = buf[recordOffset + STATE_OFFSET]
-        const processState = buf[recordOffset + PROCESS_STATE_OFFSET]
         const errorCode = buf[recordOffset + ERROR_OFFSET]
-        const reservePending =
-            buf[recordOffset + RESERVE_REMAIN_HOUR_OFFSET] !== 0 ||
-            buf[recordOffset + RESERVE_REMAIN_MINUTE_OFFSET] !== 0 ||
-            buf[recordOffset + RESERVE_SET_HOUR_OFFSET] !== 0 ||
-            buf[recordOffset + RESERVE_SET_MINUTE_OFFSET] !== 0
         this.publishProperty('power', state === STATE_POWEROFF ? 'OFF' : 'ON')
-        // A reservation waits out its countdown in either RUNNING or PAUSE:
-        // the 14h capture sat in PAUSE with 13h56m still on the clock, which
-        // is not the user pausing a cycle, so the reserve bytes win over both.
-        this.publishProperty(
-            'status',
-            reservePending && (state === STATE_RUNNING || state === STATE_PAUSE)
-                ? 'Reserved'
-                : state === STATE_RUNNING
-                  ? (PROCESS_STATE.map(processState) ?? 'Drying')
-                  : (STATE.map(state) ?? 'Unsupported'),
-        )
+        this.publishProperty('status', this.statusOf(buf, recordOffset))
+        // Only an EC frame carries the preceding state, and only when its
+        // record marker is present. An EB frame leaves the last value alone
+        // rather than publishing a wrong one.
+        if (recordOffset === DOUBLE_CURRENT_RECORD_OFFSET && buf[DOUBLE_PREVIOUS_RECORD_OFFSET] === RECORD_MARKER) {
+            this.publishProperty('previous_status', this.statusOf(buf, DOUBLE_PREVIOUS_RECORD_OFFSET))
+        }
         this.publishProperty(
             'child_lock',
             (buf[recordOffset + CHILD_LOCK_OFFSET] & CHILD_LOCK_FLAG) !== 0 ? 'ON' : 'OFF',

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -878,16 +878,17 @@ export default class Device extends AABBDevice {
             this.remember()
             this.publishProperty('course_select', COURSE.map(rawCourse))
             this.publishProperty('smart_course', 'Unknown')
-        } else if (!this.useDownloadedCourse) {
-            // Idle/native frame with nothing armed: no download is running.
-            this.publishProperty('smart_course', 'Unknown')
         }
-        // else: a download is armed (installed via HA or the bridge-tunnelled
-        // app path) but this particular frame carries no signature match —
-        // the signature only appears once the run is reserved or actually
-        // executing, not while merely installed and idle/powered off. Leave
-        // 'smart_course' at its last known value instead of flapping back to
-        // Unknown between the install and the run actually starting.
+        // else: no positive evidence either way. An idle frame with nothing
+        // we remember armed may still mean a download is installed on the
+        // appliance — e.g. right after a rethink restart our own arming
+        // memory is gone, while the appliance kept its state — and an armed
+        // download's signature only appears once the run is reserved or
+        // executing, not while merely installed and idle/powered off.
+        // Asserting 'Unknown' here would wipe HA's last displayed course on
+        // every restart, which is exactly what the F24VDD washer never does:
+        // it only publishes smart_course on positive evidence, so follow
+        // that convention and leave the last value untouched instead.
         this.publishProperty(
             'course',
             smartCourse !== undefined || this.useDownloadedCourse

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -24,12 +24,6 @@ const SINGLE_BODY_LEN = 29
 const DOUBLE_BODY_LEN = 56
 const SINGLE_RECORD_OFFSET = 3
 const DOUBLE_CURRENT_RECORD_OFFSET = 30
-// An EC frame stacks two records: the previous state at offset 3 and the
-// current one at 30. Only the current one was being read. Across this
-// session's captures the leading record always held the state the appliance
-// was in before the change that produced the frame, exactly like the styler's
-// preState, so it feeds a diagnostic Previous state entity.
-const DOUBLE_PREVIOUS_RECORD_OFFSET = 3
 const RECORD_MARKER = 0x19
 const STATE_OFFSET = 1
 // RH16 uses the same dryer record layout as the captured RV13 family and the
@@ -451,16 +445,6 @@ export default class Device extends AABBDevice {
                         options: STATUS_OPTIONS,
                         icon: 'mdi:tumble-dryer',
                     },
-                    previous_status: {
-                        platform: 'sensor',
-                        unique_id: '$deviceid-previous_status',
-                        state_topic: '$this/previous_status',
-                        name: 'Previous state',
-                        device_class: 'enum',
-                        options: STATUS_OPTIONS,
-                        icon: 'mdi:history',
-                        entity_category: 'diagnostic',
-                    },
                     child_lock: {
                         platform: 'binary_sensor',
                         unique_id: '$deviceid-child_lock',
@@ -674,12 +658,6 @@ export default class Device extends AABBDevice {
         const errorCode = buf[recordOffset + ERROR_OFFSET]
         this.publishProperty('power', state === STATE_POWEROFF ? 'OFF' : 'ON')
         this.publishProperty('status', this.statusOf(buf, recordOffset))
-        // Only an EC frame carries the preceding state, and only when its
-        // record marker is present. An EB frame leaves the last value alone
-        // rather than publishing a wrong one.
-        if (recordOffset === DOUBLE_CURRENT_RECORD_OFFSET && buf[DOUBLE_PREVIOUS_RECORD_OFFSET] === RECORD_MARKER) {
-            this.publishProperty('previous_status', this.statusOf(buf, DOUBLE_PREVIOUS_RECORD_OFFSET))
-        }
         this.publishProperty(
             'child_lock',
             (buf[recordOffset + CHILD_LOCK_OFFSET] & CHILD_LOCK_FLAG) !== 0 ? 'ON' : 'OFF',

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -26,6 +26,11 @@ const SINGLE_RECORD_OFFSET = 3
 const DOUBLE_CURRENT_RECORD_OFFSET = 30
 const RECORD_MARKER = 0x19
 const STATE_OFFSET = 1
+// RH16 uses the same dryer record layout as the captured RV13 family and the
+// same relative error position as F24VDD: rec[7]. The owner's normal RH16
+// snapshots all report 0 here; non-zero labels come from this model's own
+// MonitoringValue.error table.
+const ERROR_OFFSET = 7
 // Owner-labelled ON→OFF transition isolated rec[15] bit 0x08:
 // ON current record ...00 08 08..., OFF ...00 00 08.... The adjacent
 // rec[16] bit remained set across the lock transition and power cycle.
@@ -36,7 +41,6 @@ const CHILD_LOCK_FLAG = 0x08
 const REMOTE_START_OFFSET = 16
 const REMOTE_START_FLAG = 0x01
 const STATE_POWEROFF = 0
-const STATE_ERROR = 5
 const STATE_DIAGNOSIS = 8
 const STATUS_REQUEST = 'F0ED1121010000001800'
 
@@ -49,6 +53,29 @@ const STATE = Enum.of({
     Error: 5,
     'Smart diagnosis': 8,
     Reserved: 100,
+})
+
+const ERROR_MESSAGE = Enum.of({
+    None: -1,
+    Normal: 0,
+    tE1: 1,
+    tE2: 2,
+    tE4: 4,
+    tE5: 5,
+    tE6: 6,
+    CE1: 7,
+    'OE Drain motor': 13,
+    'Empty water': 14,
+    'dE Door': 15,
+    'Filter clogging': 16,
+    'No filter': 17,
+    F1: 19,
+    LE2: 20,
+    AE: 21,
+    LE1: 30,
+    dE4: 37,
+    LE3: 39,
+    dE2: 42,
 })
 
 export default class Device extends AABBDevice {
@@ -103,6 +130,15 @@ export default class Device extends AABBDevice {
                         payload_on: 'ON',
                         payload_off: 'OFF',
                         device_class: 'problem',
+                        entity_category: 'diagnostic',
+                    },
+                    error_message: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-error_message',
+                        state_topic: '$this/error_message',
+                        name: 'Error message',
+                        device_class: 'enum',
+                        options: ERROR_MESSAGE.options,
                         icon: 'mdi:alert-circle-outline',
                         entity_category: 'diagnostic',
                     },
@@ -136,6 +172,7 @@ export default class Device extends AABBDevice {
 
         if (buf[recordOffset] !== RECORD_MARKER) return
         const state = buf[recordOffset + STATE_OFFSET]
+        const errorCode = buf[recordOffset + ERROR_OFFSET]
         this.publishProperty('power', state === STATE_POWEROFF ? 'OFF' : 'ON')
         this.publishProperty('status', STATE.map(state) ?? 'None')
         this.publishProperty(
@@ -146,7 +183,8 @@ export default class Device extends AABBDevice {
             'remote_start',
             (buf[recordOffset + REMOTE_START_OFFSET] & REMOTE_START_FLAG) !== 0 ? 'ON' : 'OFF',
         )
-        this.publishProperty('error', state === STATE_ERROR ? 'ON' : 'OFF')
+        this.publishProperty('error', errorCode === 0 ? 'OFF' : 'ON')
+        this.publishProperty('error_message', ERROR_MESSAGE.map(errorCode) ?? 'None')
         this.publishProperty('smart_diagnosis', state === STATE_DIAGNOSIS ? 'ON' : 'OFF')
     }
 }

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -1,7 +1,7 @@
 import { Device as Thinq2Device } from '../thinq2/device'
 import { type Connection } from '../homeassistant'
 import { type Metadata } from '../thinq'
-import { readFileSync, writeFileSync } from 'node:fs'
+import { readFileSync, openSync, writeSync, fsyncSync, closeSync, renameSync, unlinkSync } from 'node:fs'
 import { allowExtendedType } from '@/util/casting'
 import HADevice from './base'
 import AABBDevice from './aabb_device'
@@ -448,17 +448,36 @@ export default class Device extends AABBDevice {
         // window for a torn write. Skip the write when the serialized entry
         // is identical to what was last written.
         if (serialized === this.lastSavedMemory) return
+        // Crash-safety: writing straight onto the shared file can leave a
+        // torn (truncated) JSON if the process dies mid-write, and every
+        // later restart would then boot with amnesia. Write to a temp file,
+        // fsync it, and atomically rename over the target so readers only
+        // ever see the old-complete or the new-complete file, never half.
+        const file = courseMemoryFile()
+        const tmp = `${file}.${process.pid}.tmp`
         try {
             let all: Record<string, unknown> = {}
             try {
-                all = JSON.parse(readFileSync(courseMemoryFile(), 'utf8')) as Record<string, unknown>
+                all = JSON.parse(readFileSync(file, 'utf8')) as Record<string, unknown>
             } catch {
                 // no memory file yet — create it below
             }
             all[this.id] = entry
-            writeFileSync(courseMemoryFile(), JSON.stringify(all))
+            const fd = openSync(tmp, 'w')
+            try {
+                writeSync(fd, JSON.stringify(all))
+                fsyncSync(fd)
+            } finally {
+                closeSync(fd)
+            }
+            renameSync(tmp, file)
             this.lastSavedMemory = serialized
         } catch (err) {
+            try {
+                unlinkSync(tmp)
+            } catch {
+                // best effort cleanup of the temp file
+            }
             console.warn(`course memory save failed for ${this.id}: ${err}`)
         }
     }
@@ -822,6 +841,19 @@ export default class Device extends AABBDevice {
 
     start() {
         this.send(Buffer.from(STATUS_REQUEST, 'hex'))
+    }
+
+    // The shared AABBDevice base never checks the checksum it writes in
+    // send() — override here to verify it on receive too, so a corrupted or
+    // truncated frame on the wire cannot be decoded as a real status update.
+    // Scoped to this device only: the base class is shared with every other
+    // handler in the repo and some of those never captured a checksummed
+    // fixture, so changing it there would break unrelated devices.
+    processData(buf: Buffer) {
+        if (buf.length < 4 || buf[0] !== 0xaa || buf[buf.length - 1] !== 0xbb) return
+        const sum = buf.subarray(0, buf.length - 2).reduce((pv, cv) => pv + cv, 0)
+        if (buf[buf.length - 2] !== ((sum & 0xff) ^ 0x55)) return
+        this.processAABB(buf.subarray(2, buf.length - 2))
     }
 
     setProperty(prop: string, mqttValue: string) {

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -170,6 +170,16 @@ const DOWNLOAD_COURSE_TEMPLATE: Record<string, string> = {
 }
 const DOWNLOAD_COURSE_OPTIONS = Object.keys(DOWNLOAD_COURSE_TEMPLATE)
 const SMART_COURSE_SENSOR_OPTIONS = ['Unknown', ...DOWNLOAD_COURSE_OPTIONS]
+// Bridge mode tunnels the app's own F025 installs straight to the physical
+// appliance without going through setProperty, so an install made from the
+// ThinQ app while HA is bridged never touched our smart_course_select
+// state. Matching the exact install body we would have sent ourselves lets
+// the outgoing side of the tunnel update HA the same way the HA-initiated
+// path already does, instead of leaving Smart course stuck on its last
+// locally-known value.
+const DOWNLOAD_COURSE_BY_INSTALL_HEX = new Map(
+    Object.entries(DOWNLOAD_COURSE_TEMPLATE).map(([name, hex]) => [hex, name]),
+)
 // The downloaded program's execution id is byte 14 in each captured F025
 // install body, and its stable signature is byte 15. Live 3h reservations
 // for all ten courses reproduced those bytes at status rec[6] and rec[21].
@@ -397,8 +407,30 @@ export default class Device extends AABBDevice {
     private downloadedCourse: string | undefined = undefined
     private useDownloadedCourse = false
 
+    private observeOutgoing(buf: Buffer) {
+        if (buf.length < 4 || buf[0] !== 0xaa || buf[buf.length - 1] !== 0xbb) return
+        const inner = buf.subarray(2, buf.length - 2).toString('hex')
+        const name = DOWNLOAD_COURSE_BY_INSTALL_HEX.get(inner)
+        if (name === undefined) return
+        if (this.downloadedCourse === name && this.useDownloadedCourse) return
+        this.downloadedCourse = name
+        this.useDownloadedCourse = true
+        this.remember()
+        this.publishProperty('smart_course_select', name)
+        this.publishProperty('course_select', 'Downloaded Course')
+        this.publishProperty('smart_course', name)
+    }
+
     constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
         super(HA, thinq)
+        // Bridge mode replays app-issued commands straight to the physical
+        // appliance via send_packet(), which fires 'sendData' regardless of
+        // whether the frame originated from our own setProperty or from the
+        // tunnel. Only F025 installs matching one of our known download
+        // bodies are recognised here; anything else (native course starts,
+        // pause, power off, ...) already round-trips through the wire status
+        // frames the rest of this class already parses.
+        thinq.on('sendData', (buf: Buffer) => this.observeOutgoing(buf))
         this.setConfig(
             allowExtendedType({
                 ...HADevice.config(meta, { name: 'LG Dryer' }),

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -419,7 +419,7 @@ export default class Device extends AABBDevice {
                         command_topic: '$this/smart_course_select/set',
                         name: 'Smart course select',
                         options: DOWNLOAD_COURSE_OPTIONS,
-                        icon: 'mdi:cloud-download-outline',
+                        icon: 'mdi:playlist-edit',
                     },
                     reserve_hours: {
                         platform: 'number',

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -864,7 +864,6 @@ export default class Device extends AABBDevice {
         this.publishProperty('error_message', ERROR_MESSAGE.map(errorCode) ?? 'Unsupported')
         this.publishProperty('smart_diagnosis', state === STATE_DIAGNOSIS ? 'ON' : 'OFF')
         const smartCourse = smartCourseOf(buf, recordOffset)
-        this.publishProperty('smart_course', smartCourse ?? 'Unknown')
         const rawCourse = buf[recordOffset + COURSE_OFFSET]
         if (smartCourse !== undefined) {
             this.downloadedCourse = smartCourse
@@ -872,15 +871,28 @@ export default class Device extends AABBDevice {
             this.remember()
             this.publishProperty('smart_course_select', smartCourse)
             this.publishProperty('course_select', 'Downloaded Course')
+            this.publishProperty('smart_course', smartCourse)
         } else if (COURSE_TEMPLATE[rawCourse] !== undefined) {
             this.selectedCourse = rawCourse
             this.useDownloadedCourse = false
             this.remember()
             this.publishProperty('course_select', COURSE.map(rawCourse))
+            this.publishProperty('smart_course', 'Unknown')
+        } else if (!this.useDownloadedCourse) {
+            // Idle/native frame with nothing armed: no download is running.
+            this.publishProperty('smart_course', 'Unknown')
         }
+        // else: a download is armed (installed via HA or the bridge-tunnelled
+        // app path) but this particular frame carries no signature match —
+        // the signature only appears once the run is reserved or actually
+        // executing, not while merely installed and idle/powered off. Leave
+        // 'smart_course' at its last known value instead of flapping back to
+        // Unknown between the install and the run actually starting.
         this.publishProperty(
             'course',
-            smartCourse === undefined ? (COURSE.map(rawCourse) ?? 'Unsupported') : 'Downloaded Course',
+            smartCourse !== undefined || this.useDownloadedCourse
+                ? 'Downloaded Course'
+                : (COURSE.map(rawCourse) ?? 'Unsupported'),
         )
         this.publishProperty('dry_level', DRY_LEVEL.map(buf[recordOffset + DRY_LEVEL_OFFSET]) ?? 'Unsupported')
         this.publishProperty('eco_hybrid', ECO_HYBRID.map(buf[recordOffset + ECO_HYBRID_OFFSET]) ?? 'Unsupported')

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -141,6 +141,21 @@ const COURSE_DEFAULTS: Record<number, { dry: number; eco: number; ac: number }> 
     22: { dry: 0, eco: 3, ac: 0 },
     23: { dry: 0, eco: 2, ac: 0 },
 }
+// Download-course install blobs, replayed verbatim. Each was captured live
+// from the ThinQ app's own toDevice traffic while the owner downloaded that
+// course, same F025 family the washer installs with (f025 0315 header, then
+// sub-type 00 on the dryer versus 0e on the washer).
+// Only these two courses have captured blobs; anything else is refused
+// rather than derived by pattern. There is no confirmed monitor byte reading
+// the installed course back yet (the idle record showed rec[16]/rec[19] as
+// 00/08 with Power and 08/00 with Minimize Wrinkles, but both bytes also
+// drift during normal runs, so that swap grounds nothing), so the select
+// tracks the last install sent, exactly like course select already does.
+const DOWNLOAD_COURSE_TEMPLATE: Record<string, string> = {
+    'Powerful Dry': 'f0250315000264000000000000001177000000000000000000',
+    'Wrinkle Care Dry': 'f025031500025a000000000200000772000000030000000000',
+}
+const DOWNLOAD_COURSE_OPTIONS = Object.keys(DOWNLOAD_COURSE_TEMPLATE)
 
 function buildCourseFrame(
     courseId: number,
@@ -297,6 +312,10 @@ export default class Device extends AABBDevice {
     private dryCode = 3
     private ecoCode = 2
     private antiCreaseCode = 0
+    // Last download install sent from this select. No confirmed monitor byte
+    // reads the installed course back, so unlike course select this cannot be
+    // corrected from the wire and stays as sent until the next install.
+    private downloadedCourse: string | undefined = undefined
 
     constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
         super(HA, thinq)
@@ -377,6 +396,17 @@ export default class Device extends AABBDevice {
                         name: 'Course select',
                         options: COURSE_SELECT_OPTIONS,
                         icon: 'mdi:playlist-edit',
+                    },
+                    // Only download courses with a captured install blob are
+                    // offered. Installing replays the exact captured app bytes.
+                    smart_course_select: {
+                        platform: 'select',
+                        unique_id: '$deviceid-smart_course_select',
+                        state_topic: '$this/smart_course_select',
+                        command_topic: '$this/smart_course_select/set',
+                        name: 'Smart course select',
+                        options: DOWNLOAD_COURSE_OPTIONS,
+                        icon: 'mdi:cloud-download-outline',
                     },
                     reserve_hours: {
                         platform: 'number',
@@ -580,6 +610,14 @@ export default class Device extends AABBDevice {
             this.publishProperty('dry_level_select', DRY_LEVEL.map(def.dry) ?? 'Off')
             this.publishProperty('eco_hybrid_select', ECO_HYBRID.map(def.eco) ?? 'Auto')
             this.publishProperty('anti_crease_select', def.ac === 1 ? 'On' : 'Off')
+            return
+        }
+        if (prop === 'smart_course_select') {
+            const blob = DOWNLOAD_COURSE_TEMPLATE[mqttValue]
+            if (blob === undefined) return
+            this.downloadedCourse = mqttValue
+            this.send(Buffer.from(blob, 'hex'))
+            this.publishProperty('smart_course_select', mqttValue)
             return
         }
         if (prop === 'reserve_hours') {

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -188,6 +188,38 @@ function smartCourseOf(buf: Buffer, recordOffset: number): string | undefined {
     )
 }
 
+/*
+ * Powerful Dry and Wrinkle Care Dry immediate starts were captured as exact
+ * F026 frames. Their execution id, dry level, eco mode, initial time,
+ * anti-crease byte and signature line up with these positions in each
+ * course's captured F025 install body. The other eight courses use the same
+ * model-defined body layout, and their corresponding values were independently
+ * confirmed in live reserved status records.
+ */
+function buildDownloadCourseFrame(name: string, reserveHours: number): Buffer | undefined {
+    const installHex = DOWNLOAD_COURSE_TEMPLATE[name]
+    if (installHex === undefined) return undefined
+    const install = Buffer.from(installHex, 'hex')
+    return Buffer.from([
+        0xf0,
+        0x26,
+        install[14], // execution course id
+        install[19], // dry level
+        install[5], // Eco Hybrid
+        install[6], // initial time
+        install[7],
+        install[8],
+        reserveHours,
+        install[10],
+        install[12],
+        install[11], // anti-crease
+        0x03,
+        install[13],
+        install[15], // downloaded-course signature
+        0x00,
+    ])
+}
+
 function buildCourseFrame(
     courseId: number,
     reserveHours: number,
@@ -271,9 +303,10 @@ const ECO_HYBRID = Enum.of({
 // report a dry level or eco setting of Off on courses that do not expose it,
 // and an HA select's state has to be one of its own options.
 const selectable = (options: string[]) => options.filter((option) => option !== 'Unsupported')
-const COURSE_SELECT_OPTIONS = selectable(COURSE.options).filter(
-    (option) => COURSE_TEMPLATE[COURSE.unmap(option) ?? -1] !== undefined,
-)
+const COURSE_SELECT_OPTIONS = [
+    ...selectable(COURSE.options).filter((option) => COURSE_TEMPLATE[COURSE.unmap(option) ?? -1] !== undefined),
+    'Downloaded Course',
+]
 const DRY_LEVEL_SELECT_OPTIONS = selectable(DRY_LEVEL.options)
 const ECO_HYBRID_SELECT_OPTIONS = selectable(ECO_HYBRID.options)
 // Steam courses (Steam refresh, Steam sterilize, Condenser care, Steam tub
@@ -348,6 +381,7 @@ export default class Device extends AABBDevice {
     // reads the installed course back, so unlike course select this cannot be
     // corrected from the wire and stays as sent until the next install.
     private downloadedCourse: string | undefined = undefined
+    private useDownloadedCourse = false
 
     constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
         super(HA, thinq)
@@ -640,8 +674,14 @@ export default class Device extends AABBDevice {
         if (prop === 'pause') this.send(Buffer.from(PAUSE_COMMAND, 'hex'))
         if (prop === 'power_off') this.send(Buffer.from(POWER_OFF_COMMAND, 'hex'))
         if (prop === 'course_select') {
+            if (mqttValue === 'Downloaded Course') {
+                this.useDownloadedCourse = true
+                this.publishProperty('course_select', mqttValue)
+                return
+            }
             const id = COURSE.unmap(mqttValue)
             if (id === undefined || COURSE_TEMPLATE[id] === undefined) return
+            this.useDownloadedCourse = false
             this.selectedCourse = id
             const def = COURSE_DEFAULTS[id] ?? { dry: 0, eco: 2, ac: 0 }
             this.dryCode = def.dry
@@ -688,9 +728,16 @@ export default class Device extends AABBDevice {
             this.publishProperty('anti_crease_select', mqttValue)
             return
         }
-        // Resume replays the remembered full start frame: the captured
-        // ThinQ app resume is byte-identical in structure to a start with
-        // the same options, so both buttons build from the same templates.
+        if (prop === 'start_course' && this.useDownloadedCourse) {
+            if (this.downloadedCourse === undefined) return
+            const frame = buildDownloadCourseFrame(this.downloadedCourse, this.reserveHours)
+            if (frame !== undefined) this.send(frame)
+            return
+        }
+        // Resume replays the remembered native start frame. No downloaded-
+        // course resume command has been captured, so Resume does not transmit
+        // while Downloaded Course is selected.
+        if (prop === 'resume' && this.useDownloadedCourse) return
         if (prop === 'start_course' || prop === 'resume') {
             const frame = buildCourseFrame(
                 this.selectedCourse,
@@ -757,11 +804,20 @@ export default class Device extends AABBDevice {
         this.publishProperty('smart_diagnosis', state === STATE_DIAGNOSIS ? 'ON' : 'OFF')
         const smartCourse = smartCourseOf(buf, recordOffset)
         this.publishProperty('smart_course', smartCourse ?? 'Unknown')
+        const rawCourse = buf[recordOffset + COURSE_OFFSET]
+        if (smartCourse !== undefined) {
+            this.downloadedCourse = smartCourse
+            this.useDownloadedCourse = true
+            this.publishProperty('smart_course_select', smartCourse)
+            this.publishProperty('course_select', 'Downloaded Course')
+        } else if (COURSE_TEMPLATE[rawCourse] !== undefined) {
+            this.selectedCourse = rawCourse
+            this.useDownloadedCourse = false
+            this.publishProperty('course_select', COURSE.map(rawCourse))
+        }
         this.publishProperty(
             'course',
-            smartCourse === undefined
-                ? (COURSE.map(buf[recordOffset + COURSE_OFFSET]) ?? 'Unsupported')
-                : 'Downloaded Course',
+            smartCourse === undefined ? (COURSE.map(rawCourse) ?? 'Unsupported') : 'Downloaded Course',
         )
         this.publishProperty('dry_level', DRY_LEVEL.map(buf[recordOffset + DRY_LEVEL_OFFSET]) ?? 'Unsupported')
         this.publishProperty('eco_hybrid', ECO_HYBRID.map(buf[recordOffset + ECO_HYBRID_OFFSET]) ?? 'Unsupported')

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -771,10 +771,14 @@ export default class Device extends AABBDevice {
             if (disk.dryCode !== undefined) this.dryCode = disk.dryCode
             if (disk.ecoCode !== undefined) this.ecoCode = disk.ecoCode
         }
-        if (this.useDownloadedCourse && this.downloadedCourse !== undefined) {
-            this.publishProperty('course_select', 'Downloaded Course')
+        if (this.downloadedCourse !== undefined) {
+            // The installed download is shown whether it runs or not —
+            // the F24VDD washer re-reports it on every status frame.
             this.publishProperty('smart_course_select', this.downloadedCourse)
             this.publishProperty('smart_course', this.downloadedCourse)
+        }
+        if (this.useDownloadedCourse && this.downloadedCourse !== undefined) {
+            this.publishProperty('course_select', 'Downloaded Course')
         } else this.publishProperty('course_select', COURSE.map(this.selectedCourse))
         this.publishProperty('reserve_hours', this.reserveHours)
         this.publishProperty('dry_level_select', DRY_LEVEL.map(this.dryCode))
@@ -944,10 +948,14 @@ export default class Device extends AABBDevice {
             this.useDownloadedCourse = false
             this.remember()
             this.publishProperty('course_select', COURSE.map(rawCourse))
-            // smart_course is deliberately left alone: the installed download
-            // is still on the appliance (running a native course does not
-            // uninstall it), and the F24VDD washer keeps reporting it whether
-            // it runs or not. Never assert 'Unknown' here.
+            // smart_course keeps showing the installed download (running a
+            // native course does not uninstall it), and re-asserts it so a
+            // stale value converges — the F24VDD washer re-reports its
+            // download on every status frame. Never 'Unknown' here.
+            if (this.downloadedCourse !== undefined) {
+                this.publishProperty('smart_course_select', this.downloadedCourse)
+                this.publishProperty('smart_course', this.downloadedCourse)
+            }
         }
         // else: no positive evidence either way. An idle frame with nothing
         // we remember armed may still mean a download is installed on the

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -26,11 +26,14 @@ const SINGLE_RECORD_OFFSET = 3
 const DOUBLE_CURRENT_RECORD_OFFSET = 30
 const RECORD_MARKER = 0x19
 const STATE_OFFSET = 1
+const STATE_POWEROFF = 0
+const STATE_ERROR = 5
+const STATE_DIAGNOSIS = 8
 const STATUS_REQUEST = 'F0ED1121010000001800'
 
 const STATE = Enum.of({
     'Power off': 0,
-    Initial: 1,
+    Standby: 1,
     Drying: 2,
     Pause: 3,
     Complete: 4,
@@ -53,8 +56,7 @@ export default class Device extends AABBDevice {
                         name: 'Power',
                         payload_on: 'ON',
                         payload_off: 'OFF',
-                        device_class: 'running',
-                        icon: 'mdi:tumble-dryer',
+                        icon: 'mdi:power',
                     },
                     status: {
                         platform: 'sensor',
@@ -64,6 +66,28 @@ export default class Device extends AABBDevice {
                         device_class: 'enum',
                         options: STATE.options,
                         icon: 'mdi:tumble-dryer',
+                    },
+                    error: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-error',
+                        state_topic: '$this/error',
+                        name: 'Error',
+                        payload_on: 'ON',
+                        payload_off: 'OFF',
+                        device_class: 'problem',
+                        icon: 'mdi:alert-circle-outline',
+                        entity_category: 'diagnostic',
+                    },
+                    smart_diagnosis: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-smart_diagnosis',
+                        state_topic: '$this/smart_diagnosis',
+                        name: 'Smart diagnosis',
+                        payload_on: 'ON',
+                        payload_off: 'OFF',
+                        device_class: 'problem',
+                        icon: 'mdi:stethoscope',
+                        entity_category: 'diagnostic',
                     },
                 },
             }),
@@ -84,7 +108,9 @@ export default class Device extends AABBDevice {
 
         if (buf[recordOffset] !== RECORD_MARKER) return
         const state = buf[recordOffset + STATE_OFFSET]
-        this.publishProperty('power', state === 0 ? 'OFF' : 'ON')
+        this.publishProperty('power', state === STATE_POWEROFF ? 'OFF' : 'ON')
         this.publishProperty('status', STATE.map(state) ?? 'None')
+        this.publishProperty('error', state === STATE_ERROR ? 'ON' : 'OFF')
+        this.publishProperty('smart_diagnosis', state === STATE_DIAGNOSIS ? 'ON' : 'OFF')
     }
 }

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -58,6 +58,60 @@ const STATE_RUNNING = 2
 const STATE_DIAGNOSIS = 8
 const STATUS_REQUEST = 'F0ED1121010000001800'
 const PAUSE_COMMAND = 'F024040100'
+// Owner-labelled ThinQ app power-off, MCP toDevice seq 222.
+const POWER_OFF_COMMAND = 'F024010100'
+// Sixteen course codes isolated from owner-labelled ThinQ app starts with
+// matching state records: Standard 07, Sports Wear 08, Quick Dry 09,
+// Wool 0B, Bedding Brush 0F, Allergy Care 10, Condenser Care
+// 12, Tub Clean 13, Padding Refresh 14, Time Dry 15, Outdoor
+// Refresh 16, Baby Wear 17, Steam Refresh 01, Towel 02, Bulky Item 04,
+// Easy Care 05. The model's RACKDRY and COOLAIR entries have no captured code
+// yet and read back as 'None' through the safe fallback below.
+const COURSE_OFFSET = 6
+const COURSE = Enum.of({
+    'Steam Refresh': 1,
+    Towel: 2,
+    'Bulky Item': 4,
+    'Easy Care': 5,
+    Standard: 7,
+    'Sports Wear': 8,
+    'Quick Dry': 9,
+    Wool: 11,
+    'Bedding Brush': 15,
+    'Allergy Care': 16,
+    'Condenser Care': 18,
+    'Tub Clean': 19,
+    'Padding Refresh': 20,
+    'Time Dry': 21,
+    'Outdoor Refresh': 22,
+    'Baby Wear': 23,
+})
+// Rec[8] follows the model's own dryLevel index table (1 DAMP, 2 LESS,
+// 3 IRON, 4 CUPBOARD, 5 VERY); the owner-facing names are the ThinQ app
+// labels reported for those levels. 0 is the model default NO_DRYLEVEL.
+const DRY_LEVEL_OFFSET = 8
+const DRY_LEVEL = Enum.of({
+    Delicate: 1,
+    Light: 2,
+    Standard: 3,
+    'Standard+': 4,
+    Strong: 5,
+})
+// Rec[9] follows the model's own ecoHybrid index table (1 ECO, 2 NORMAL
+// labelled Auto in the app, 3 TURBO labelled Speed). Every captured run
+// reads back either the selected value or the course default from the
+// model's own Course function table.
+const ECO_HYBRID_OFFSET = 9
+const ECO_HYBRID = Enum.of({
+    Energy: 1,
+    Auto: 2,
+    Speed: 3,
+})
+// Steam courses (Steam refresh, Steam sterilize, Condenser care, Steam tub
+// sterilize) read rec[17] 0x08 while all 17 non-steam captures read 0x00,
+// and the same courses carry the 0x08 byte in the start payload tail.
+const STEAM_OFFSET = 17
+const STEAM_FLAG = 0x08
 
 const STATE = Enum.of({
     'Power off': 0,
@@ -126,6 +180,50 @@ export default class Device extends AABBDevice {
                         payload_on: 'ON',
                         payload_off: 'OFF',
                         icon: 'mdi:power',
+                    },
+                    power_off: {
+                        platform: 'button',
+                        unique_id: '$deviceid-power_off',
+                        command_topic: '$this/power_off/set',
+                        payload_press: '',
+                        name: 'Power off',
+                        icon: 'mdi:power-off',
+                    },
+                    course: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-course',
+                        state_topic: '$this/course',
+                        name: 'Course',
+                        device_class: 'enum',
+                        options: COURSE.options,
+                        icon: 'mdi:playlist-check',
+                    },
+                    dry_level: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-dry_level',
+                        state_topic: '$this/dry_level',
+                        name: 'Dry level',
+                        device_class: 'enum',
+                        options: DRY_LEVEL.options,
+                        icon: 'mdi:thermometer',
+                    },
+                    eco_hybrid: {
+                        platform: 'sensor',
+                        unique_id: '$deviceid-eco_hybrid',
+                        state_topic: '$this/eco_hybrid',
+                        name: 'Eco hybrid',
+                        device_class: 'enum',
+                        options: ECO_HYBRID.options,
+                        icon: 'mdi:leaf',
+                    },
+                    steam: {
+                        platform: 'binary_sensor',
+                        unique_id: '$deviceid-steam',
+                        state_topic: '$this/steam',
+                        name: 'Steam',
+                        payload_on: 'ON',
+                        payload_off: 'OFF',
+                        icon: 'mdi:cloud-outline',
                     },
                     status: {
                         platform: 'sensor',
@@ -206,6 +304,7 @@ export default class Device extends AABBDevice {
 
     setProperty(prop: string, _mqttValue: string) {
         if (prop === 'pause') this.send(Buffer.from(PAUSE_COMMAND, 'hex'))
+        if (prop === 'power_off') this.send(Buffer.from(POWER_OFF_COMMAND, 'hex'))
     }
 
     processAABB(buf: Buffer) {
@@ -246,5 +345,9 @@ export default class Device extends AABBDevice {
         this.publishProperty('error', errorCode === 0 ? 'OFF' : 'ON')
         this.publishProperty('error_message', ERROR_MESSAGE.map(errorCode) ?? 'None')
         this.publishProperty('smart_diagnosis', state === STATE_DIAGNOSIS ? 'ON' : 'OFF')
+        this.publishProperty('course', COURSE.map(buf[recordOffset + COURSE_OFFSET]) ?? 'None')
+        this.publishProperty('dry_level', DRY_LEVEL.map(buf[recordOffset + DRY_LEVEL_OFFSET]) ?? 'None')
+        this.publishProperty('eco_hybrid', ECO_HYBRID.map(buf[recordOffset + ECO_HYBRID_OFFSET]) ?? 'None')
+        this.publishProperty('steam', (buf[recordOffset + STEAM_OFFSET] & STEAM_FLAG) !== 0 ? 'ON' : 'OFF')
     }
 }

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -218,6 +218,14 @@ const COURSE = Enum.of({
     'Time Dry': 21,
     'Outdoor Refresh': 22,
     'Baby Wear': 23,
+    // Observed live once: while the downloaded Powerful Dry ran on a
+    // reservation, the course byte read 0x11, where native courses report
+    // their own id (Standard read 0x07 while running). The washer works the
+    // same way with one shared downloaded id, so this is the generic
+    // downloaded-course marker until a second download course proves
+    // otherwise. It is display only: course select and Start stay native
+    // until per-course smart start frames are captured.
+    'Downloaded Course': 17,
 })
 // Rec[8] follows the model's own dryLevel index table (1 DAMP, 2 LESS,
 // 3 IRON, 4 CUPBOARD, 5 VERY); the owner-facing names are the ThinQ app

--- a/cloud/devices/RH16_T_KR.ts
+++ b/cloud/devices/RH16_T_KR.ts
@@ -79,6 +79,10 @@ const RESERVE_REMAIN_HOUR_OFFSET = 11
 const RESERVE_REMAIN_MINUTE_OFFSET = 12
 const RESERVE_SET_HOUR_OFFSET = 13
 const RESERVE_SET_MINUTE_OFFSET = 14
+// This-cycle energy counter, 16-bit BE from the record start (single and
+// double records share the layout). Rises monotonically through a run and
+// freezes at completion; value is Wh x1 (see processAABB).
+const ENERGY_OFFSET = 18
 const STATE_POWEROFF = 0
 const STATE_RUNNING = 2
 const STATE_PAUSE = 3
@@ -784,12 +788,6 @@ export default class Device extends AABBDevice {
         this.publishProperty('dry_level_select', DRY_LEVEL.map(this.dryCode))
         this.publishProperty('eco_hybrid_select', ECO_HYBRID.map(this.ecoCode))
         this.publishProperty('anti_crease_select', 'Off')
-        // Energy offset not yet isolated for RH16 (tail bytes vary without a
-        // labelled transition) — expose as 0 until a running vs idle capture
-        // grounds it, same convention as F24VDD. The model's own
-        // EnergyMonitoring.powertable gives reference wattage per dry level
-        // (1400-2600W) but no cumulative Wh field has been captured on the wire.
-        this.publishProperty('energy', 0)
     }
 
     start() {
@@ -988,5 +986,10 @@ export default class Device extends AABBDevice {
             'reserve_time',
             buf[recordOffset + RESERVE_REMAIN_HOUR_OFFSET] * 60 + buf[recordOffset + RESERVE_REMAIN_MINUTE_OFFSET],
         )
+        // This-cycle energy, Wh x1. record+18 (16-bit BE) rises monotonically
+        // through a run on both single and double records (04:21 cycle:
+        // 14 -> 694, frozen at completion) and matches the ThinQ app's daily
+        // 694Wh exactly — the same x1 convention as the F24VDD washer.
+        this.publishProperty('energy', buf[recordOffset + ENERGY_OFFSET] * 256 + buf[recordOffset + ENERGY_OFFSET + 1])
     }
 }

--- a/cloud/ha_bridge.ts
+++ b/cloud/ha_bridge.ts
@@ -24,6 +24,7 @@ import RV13B6ES_D_US_WIFI from './devices/RV13B6ES_D_US_WIFI'
 import WTL_FXU_BDV_NA_01 from './devices/WTL_FXU_BDV_NA_01'
 import DHUM_056905_WW from './devices/DHUM_056905_WW'
 import ST_B_E4H01Y_APL from './devices/ST_B_E4H01Y_APL'
+import RH16_T_KR from './devices/RH16_T_KR'
 import { Device as T1Device } from './thinq1/device'
 import { Device as T2Device } from './thinq2/device'
 import { type Connection } from './homeassistant'
@@ -72,6 +73,7 @@ const t2deviceTypes: Record<string, T2Factory> = {
     WTL_FXU_BDV_NA_01, // LG WashTower
     DHUM_056905_WW,
     ST_B_E4H01Y_APL,
+    RH16_T_KR,
 }
 
 class Bridge {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -27,6 +27,15 @@ const REMOTE_START_ON = buf(
 const REMOTE_START_OFF = buf(
     'AA3C30EC00190100000000000000000000000000001900000000000000770000190100000000000000000000000000001800000000000000770000BB',
 )
+const STANDARD_DETECTING = buf(
+    'AA3C30EC00190100000000000000000000000000001900000000000000770000190201280128070003020000000000009B0000000100000077006DBB',
+)
+const STANDARD_DRYING = buf(
+    'AA3C30EC00190201280128070003020000000000009B000000010000007700001902010F010F070003020200000000001B0000000100000077003FBB',
+)
+const STANDARD_PAUSED = buf(
+    'AA3C30EC001902010F010F070003020200000000001B000000010000007700001903010F010F070003020200000000081B00000002000000770091BB',
+)
 const STATUS_REQUEST = 'aa0ef0ed1121010000001800b5bb'
 
 function makeDevice() {
@@ -70,6 +79,9 @@ describe('RH16_T_KR read-only status', () => {
             CHILD_LOCK_OFF,
             REMOTE_START_ON,
             REMOTE_START_OFF,
+            STANDARD_DETECTING,
+            STANDARD_DRYING,
+            STANDARD_PAUSED,
         ])
             assertIntact(frame)
     })
@@ -145,6 +157,16 @@ describe('RH16_T_KR read-only status', () => {
         thinq.emit('data', withError(3))
         assert.equal(ha.devices[DEVICE_ID].properties.error, 'ON')
         assert.equal(ha.devices[DEVICE_ID].properties.error_message, 'None')
+    })
+
+    test('uses the captured process sub-state for Detecting, Drying, then Pause', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STANDARD_DETECTING)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Detecting')
+        thinq.emit('data', STANDARD_DRYING)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Drying')
+        thinq.emit('data', STANDARD_PAUSED)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Pause')
     })
 
     test('decodes child lock from the isolated real ON and OFF transition', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -57,6 +57,9 @@ const STEAM_REFRESH_RESERVED_3H = buf(
 const STEAM_REFRESH_RESUMED_11H = buf(
     'AA3C30EC0019030020002001000002010B000B0001190800010200000077000019020020002001000002010B000B00011908000103000000770073BB',
 )
+const STEAM_REFRESH_RESERVED_14H_PARTWAY = buf(
+    'AA3C30EC0019030020002001000002010D380D3801130800010200000077000019030020002001000002010D380D38011B0800010200000077005FBB',
+)
 const CONDENSER_CARE_RUNNING = buf(
     'AA3C30EC00190301000100160000030103000300091900000002000000770000190201140114120000030100000000001908000003000000770084BB',
 )
@@ -119,6 +122,7 @@ describe('RH16_T_KR read-only status', () => {
             DUVET_RESERVED_4H,
             STEAM_REFRESH_RESERVED_3H,
             STEAM_REFRESH_RESUMED_11H,
+            STEAM_REFRESH_RESERVED_14H_PARTWAY,
             CONDENSER_CARE_RUNNING,
             SHIRTS_LOW_AC_ON_RESERVED_3H,
             TOWEL_RESERVED_3H,
@@ -406,6 +410,16 @@ describe('RH16_T_KR read-only status', () => {
         dev.setProperty('start_course', '')
         assert.equal(ha.devices[DEVICE_ID].properties.course_select, 'Standard')
         assert.equal(thinq.outbox[0].toString('hex'), 'aa14f0260703020000000000000001000000b4bb')
+    })
+
+    test('counts the reserve minute byte, not just whole hours', () => {
+        // A 14h reservation read 13h56m left: rec[11]=13, rec[12]=56. Reading
+        // the hour alone reported 780 minutes for a 836-minute countdown.
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STEAM_REFRESH_RESERVED_14H_PARTWAY)
+        assert.equal(ha.devices[DEVICE_ID].properties.reserve_time, 13 * 60 + 56)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Reserved')
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'Steam Refresh')
     })
 
     test('never publishes the literal None, which HA reads as unknown', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -127,22 +127,40 @@ describe('RH16_T_KR read-only status', () => {
         const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
         assert.deepEqual(Object.keys(components).sort(), [
             'anti_crease',
+            'anti_crease_select',
             'child_lock',
             'course',
+            'course_select',
             'dry_level',
+            'dry_level_select',
             'eco_hybrid',
+            'eco_hybrid_select',
             'error',
             'error_message',
             'pause',
             'power',
             'power_off',
             'remote_start',
+            'reserve_hours',
+            'resume',
             'smart_diagnosis',
+            'start_course',
             'status',
             'steam',
         ])
         for (const [id, component] of Object.entries(components)) {
-            if (id === 'pause' || id === 'power_off') assert.equal(component.command_topic, `$this/${id}/set`)
+            if (
+                id === 'pause' ||
+                id === 'power_off' ||
+                id === 'start_course' ||
+                id === 'resume' ||
+                id === 'course_select' ||
+                id === 'reserve_hours' ||
+                id === 'dry_level_select' ||
+                id === 'eco_hybrid_select' ||
+                id === 'anti_crease_select'
+            )
+                assert.equal(component.command_topic, `$this/${id}/set`)
             else assert.equal(component.command_topic, undefined)
         }
         assert.equal(components.pause.platform, 'button')
@@ -287,6 +305,88 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.course, 'Condenser Care')
         assert.equal(ha.devices[DEVICE_ID].properties.status, 'Steam')
         assert.equal(ha.devices[DEVICE_ID].properties.steam, 'ON')
+    })
+
+    test('Start course replays the captured template per course with reserve folded in', () => {
+        const cases: Array<[string, string, string]> = [
+            ['Steam Refresh', '0', 'aa14f0260100020000000000000003080000b7bb'],
+            ['Towel', '0', 'aa14f02602000200000000000000030000008ebb'],
+            ['Bulky Item', '0', 'aa14f0260400030000000000000203000000b5bb'],
+            ['Easy Care', '0', 'aa14f0260503020000000000000003000000b4bb'],
+            ['Standard', '0', 'aa14f0260703020000000000000001000000b4bb'],
+            ['Sports Wear', '0', 'aa14f0260800010000000000000003000000b5bb'],
+            ['Quick Dry', '0', 'aa14f0260900030000000000000203000000b0bb'],
+            ['Wool', '0', 'aa14f0260b00020000000000000003000000b1bb'],
+            ['Bedding Brush', '0', 'aa14f0260f00030000000000000003000000bcbb'],
+            ['Allergy Care', '0', 'aa14f0261000030000000000000003080000a7bb'],
+            ['Condenser Care', '0', 'aa14f0261200030000000000000003080000a1bb'],
+            ['Tub Clean', '0', 'aa14f0261300030000000000000003080000a0bb'],
+            ['Padding Refresh', '0', 'aa14f0261400030000000000000003000000bbbb'],
+            ['Time Dry', '0', 'aa14f0261500021e0000000000000300000059bb'],
+            ['Outdoor Refresh', '0', 'aa14f0261600033c0000000000000300000079bb'],
+            ['Baby Wear', '0', 'aa14f0261700020000000000000003000000a5bb'],
+            ['Standard', '3', 'aa14f0260703020000000300000001000000b1bb'],
+        ]
+        for (const [course, reserve, expected] of cases) {
+            const { thinq, dev } = makeDevice()
+            dev.setProperty('course_select', course)
+            dev.setProperty('reserve_hours', reserve)
+            dev.setProperty('start_course', '')
+            assert.equal(thinq.outbox.length, 1, course)
+            assert.equal(thinq.outbox[0].toString('hex'), expected, course)
+        }
+    })
+
+    test('Start course folds dry, eco and anti-crease in only where the model allows', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('course_select', 'Standard')
+        dev.setProperty('dry_level_select', 'Strong')
+        dev.setProperty('eco_hybrid_select', 'Speed')
+        dev.setProperty('anti_crease_select', 'On')
+        dev.setProperty('reserve_hours', '3')
+        dev.setProperty('start_course', '')
+        assert.equal(thinq.outbox[0].toString('hex'), 'aa14f0260705030000000300000201000000bcbb')
+        // Easy Care allows Light/Standard only: Strong leaves the template byte.
+        const easy = makeDevice()
+        easy.dev.setProperty('course_select', 'Easy Care')
+        easy.dev.setProperty('dry_level_select', 'Strong')
+        easy.dev.setProperty('eco_hybrid_select', 'Speed')
+        easy.dev.setProperty('start_course', '')
+        assert.equal(easy.thinq.outbox[0].toString('hex'), 'aa14f0260503020000000000000003000000b4bb')
+        // Condenser Care declares no anti-crease: On leaves the template byte.
+        const cond = makeDevice()
+        cond.dev.setProperty('course_select', 'Condenser Care')
+        cond.dev.setProperty('anti_crease_select', 'On')
+        cond.dev.setProperty('start_course', '')
+        assert.equal(cond.thinq.outbox[0].toString('hex'), 'aa14f0261200030000000000000003080000a1bb')
+    })
+
+    test('Resume replays the remembered full start frame', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('resume', '')
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(thinq.outbox[0].toString('hex'), 'aa14f0260703020000000000000001000000b4bb')
+    })
+
+    test('selecting a course resets options to the model defaults', () => {
+        const { ha, dev } = makeDevice()
+        dev.setProperty('course_select', 'Bulky Item')
+        assert.equal(ha.devices[DEVICE_ID].properties.course_select, 'Bulky Item')
+        assert.equal(ha.devices[DEVICE_ID].properties.anti_crease_select, 'On')
+        assert.equal(ha.devices[DEVICE_ID].properties.eco_hybrid_select, 'Speed')
+        dev.setProperty('course_select', 'Sports Wear')
+        assert.equal(ha.devices[DEVICE_ID].properties.anti_crease_select, 'Off')
+        assert.equal(ha.devices[DEVICE_ID].properties.eco_hybrid_select, 'Energy')
+    })
+
+    test('invalid select values fall back to the remembered defaults', () => {
+        const { ha, thinq, dev } = makeDevice()
+        dev.setProperty('course_select', 'Rack Dry')
+        dev.setProperty('reserve_hours', '20')
+        dev.setProperty('dry_level_select', 'Damp')
+        dev.setProperty('start_course', '')
+        assert.equal(ha.devices[DEVICE_ID].properties.course_select, 'Standard')
+        assert.equal(thinq.outbox[0].toString('hex'), 'aa14f0260703020000000000000001000000b4bb')
     })
 
     test('Power off reproduces the exact ThinQ app command captured by MCP', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -15,6 +15,12 @@ const INITIAL = buf('AA2130EB001901000000000000000000000000000804000000000000007
 const DOUBLE_INITIAL = buf(
     'AA3C30EC00190100000000000000000000000000080400000000000000770000190100000000000000000000000000000400000000000000770061BB',
 )
+const CHILD_LOCK_ON = buf(
+    'AA3C30EC00190000000000000000000000000000000000000001000000770000190100000000000000000000000000080800000000000000770061BB',
+)
+const CHILD_LOCK_OFF = buf(
+    'AA3C30EC00190100000000000000000000000000080800000000000000770000190100000000000000000000000000000800000000000000770069BB',
+)
 const STATUS_REQUEST = 'aa0ef0ed1121010000001800b5bb'
 
 function makeDevice() {
@@ -41,16 +47,17 @@ function withState(state: number) {
 
 describe('RH16_T_KR read-only status', () => {
     test('real capture fixtures have intact AA/BB envelopes', () => {
-        for (const frame of [OFF, INITIAL, DOUBLE_INITIAL]) assertIntact(frame)
+        for (const frame of [OFF, INITIAL, DOUBLE_INITIAL, CHILD_LOCK_ON, CHILD_LOCK_OFF]) assertIntact(frame)
     })
 
     test('exposes the common read-only status sensors', () => {
         const { ha } = makeDevice()
         const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
-        assert.deepEqual(Object.keys(components).sort(), ['error', 'power', 'smart_diagnosis', 'status'])
+        assert.deepEqual(Object.keys(components).sort(), ['child_lock', 'error', 'power', 'smart_diagnosis', 'status'])
         for (const component of Object.values(components)) assert.equal(component.command_topic, undefined)
         assert.equal(components.power.icon, 'mdi:power')
         assert.equal(components.status.icon, 'mdi:tumble-dryer')
+        assert.equal(components.child_lock.device_class, 'lock')
         assert.equal(components.error.device_class, 'problem')
         assert.equal(components.smart_diagnosis.device_class, 'problem')
     })
@@ -89,6 +96,14 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.status, 'Smart diagnosis')
         assert.equal(ha.devices[DEVICE_ID].properties.error, 'OFF')
         assert.equal(ha.devices[DEVICE_ID].properties.smart_diagnosis, 'ON')
+    })
+
+    test('decodes child lock from the isolated real ON and OFF transition', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', CHILD_LOCK_ON)
+        assert.equal(ha.devices[DEVICE_ID].properties.child_lock, 'ON')
+        thinq.emit('data', CHILD_LOCK_OFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.child_lock, 'OFF')
     })
 
     test('asks only for the family-wide read-only status snapshot on connect', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -54,6 +54,9 @@ const DUVET_RESERVED_4H = buf(
 const STEAM_REFRESH_RESERVED_3H = buf(
     'AA3C30EC001903010A010A0500020202023B023B0B1900000002000000770000190200200020010000020103000300011908000003000000770002BB',
 )
+const STEAM_REFRESH_RESUMED_11H = buf(
+    'AA3C30EC0019030020002001000002010B000B0001190800010200000077000019020020002001000002010B000B00011908000103000000770073BB',
+)
 const CONDENSER_CARE_RUNNING = buf(
     'AA3C30EC00190301000100160000030103000300091900000002000000770000190201140114120000030100000000001908000003000000770084BB',
 )
@@ -115,6 +118,7 @@ describe('RH16_T_KR read-only status', () => {
             ANTI_CREASE_OFF,
             DUVET_RESERVED_4H,
             STEAM_REFRESH_RESERVED_3H,
+            STEAM_REFRESH_RESUMED_11H,
             CONDENSER_CARE_RUNNING,
             SHIRTS_LOW_AC_ON_RESERVED_3H,
             TOWEL_RESERVED_3H,
@@ -310,6 +314,12 @@ describe('RH16_T_KR read-only status', () => {
         thinq.emit('data', STEAM_REFRESH_RESERVED_3H)
         assert.equal(ha.devices[DEVICE_ID].properties.course, 'Steam Refresh')
         assert.equal(ha.devices[DEVICE_ID].properties.steam, 'ON')
+        thinq.emit('data', STEAM_REFRESH_RESUMED_11H)
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'Steam Refresh')
+        assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'None')
+        assert.equal(ha.devices[DEVICE_ID].properties.eco_hybrid, 'Auto')
+        assert.equal(ha.devices[DEVICE_ID].properties.steam, 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Reserved')
         thinq.emit('data', CONDENSER_CARE_RUNNING)
         assert.equal(ha.devices[DEVICE_ID].properties.course, 'Condenser Care')
         assert.equal(ha.devices[DEVICE_ID].properties.status, 'Steam')

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -48,6 +48,14 @@ const STANDARD_DETECTING = buf(
 const STANDARD_DRYING = buf(
     'AA3C30EC00190201280128070003020000000000009B000000010000007700001902010F010F070003020200000000001B0000000100000077003FBB',
 )
+// Real captures from the 04:21 drying cycle (app daily total: 694Wh).
+// record+18 (16-bit BE) is the this-cycle Wh counter, x1.
+const ENERGY_MID_CYCLE = buf(
+    'aa3c30ec00190201080114120000030300000000201b0800ad01000000770000190201070114120000030300000000201b0800b001000000770023bb',
+)
+const ENERGY_AT_COMPLETION = buf(
+    'aa3c30ec00190200010114120000030500000000001b0802b301000000770000190400010114120000030700000000081a0802b602000000770012bb',
+)
 const STANDARD_PAUSED = buf(
     'AA3C30EC001902010F010F070003020200000000001B000000010000007700001903010F010F070003020200000000081B00000002000000770091BB',
 )
@@ -237,6 +245,17 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.eco_hybrid, 'Off')
         assert.equal(ha.devices[DEVICE_ID].properties.steam, 'OFF')
         assert.equal(ha.devices[DEVICE_ID].properties.energy, 0)
+    })
+
+    test('publishes this-cycle energy from the record+18 Wh counter', () => {
+        // Real 04:21 cycle captures: the counter rises 176 -> 694 and the
+        // ThinQ app reported 694Wh for the day, so the value is Wh x1 —
+        // the same convention as the F24VDD washer.
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', ENERGY_MID_CYCLE)
+        assert.equal(ha.devices[DEVICE_ID].properties.energy, 176)
+        thinq.emit('data', ENERGY_AT_COMPLETION)
+        assert.equal(ha.devices[DEVICE_ID].properties.energy, 694)
     })
 
     test('decodes the real Initial EB snapshot', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -158,6 +158,7 @@ describe('RH16_T_KR read-only status', () => {
             'reserve_hours',
             'reserve_time',
             'resume',
+            'smart_course_select',
             'smart_diagnosis',
             'start_course',
             'status',
@@ -170,6 +171,7 @@ describe('RH16_T_KR read-only status', () => {
                 id === 'start_course' ||
                 id === 'resume' ||
                 id === 'course_select' ||
+                id === 'smart_course_select' ||
                 id === 'reserve_hours' ||
                 id === 'dry_level_select' ||
                 id === 'eco_hybrid_select' ||
@@ -504,6 +506,8 @@ describe('RH16_T_KR read-only status', () => {
         assert.ok(components.dry_level.options.includes('Off'))
         assert.ok(components.eco_hybrid.options.includes('Off'))
         assert.ok(!components.status.options.includes('Unsupported'))
+        // Only download courses with a captured install blob are offered.
+        assert.deepEqual(components.smart_course_select.options, ['Powerful Dry', 'Wrinkle Care Dry'])
     })
 
     test('Power off reproduces the exact ThinQ app command captured by MCP', () => {
@@ -518,6 +522,28 @@ describe('RH16_T_KR read-only status', () => {
         dev.setProperty('pause', '')
         assert.equal(thinq.outbox.length, 1)
         assert.equal(thinq.outbox[0].toString('hex'), 'aa09f02404010099bb')
+    })
+
+    test('installing a download course replays the exact captured app bytes', () => {
+        // Both install frames were captured live from the ThinQ app's own
+        // toDevice traffic while the owner downloaded each course.
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('smart_course_select', 'Powerful Dry')
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(thinq.outbox[0].toString('hex'), 'aa1df0250315000264000000000000001177000000000000000000b7bb')
+    })
+
+    test('installing the second download course replays its captured bytes', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('smart_course_select', 'Wrinkle Care Dry')
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(thinq.outbox[0].toString('hex'), 'aa1df025031500025a0000000002000007720000000300000000009bbb')
+    })
+
+    test('refuses a download course with no captured install blob', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('smart_course_select', 'Gym Clothes')
+        assert.equal(thinq.outbox.length, 0)
     })
 
     test('asks only for the family-wide read-only status snapshot on connect', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -231,6 +231,9 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(components.error_message.device_class, 'enum')
         assert.equal(components.error_message.entity_category, 'diagnostic')
         assert.equal(components.smart_diagnosis.device_class, 'problem')
+        // Energy is a first-class reading like the washer's, not a
+        // diagnostic: no entity_category, so it stays on the device card.
+        assert.equal(components.energy.entity_category, undefined)
     })
 
     test('decodes the current real powered-off EB snapshot', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -30,18 +30,29 @@ function assertIntact(packet: Buffer) {
     assert.equal(packet[packet.length - 2], (sum & 0xff) ^ 0x55)
 }
 
+/** Model-declared state probe derived from a real frame; not capture evidence. */
+function withState(state: number) {
+    const packet = Buffer.from(OFF)
+    packet[6] = state
+    const sum = packet.subarray(0, packet.length - 2).reduce((a, b) => a + b, 0)
+    packet[packet.length - 2] = (sum & 0xff) ^ 0x55
+    return packet
+}
+
 describe('RH16_T_KR read-only status', () => {
     test('real capture fixtures have intact AA/BB envelopes', () => {
         for (const frame of [OFF, INITIAL, DOUBLE_INITIAL]) assertIntact(frame)
     })
 
-    test('exposes only read-only Power and Status sensors', () => {
+    test('exposes the common read-only status sensors', () => {
         const { ha } = makeDevice()
         const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
-        assert.deepEqual(Object.keys(components).sort(), ['power', 'status'])
+        assert.deepEqual(Object.keys(components).sort(), ['error', 'power', 'smart_diagnosis', 'status'])
         for (const component of Object.values(components)) assert.equal(component.command_topic, undefined)
-        assert.equal(components.power.icon, 'mdi:tumble-dryer')
+        assert.equal(components.power.icon, 'mdi:power')
         assert.equal(components.status.icon, 'mdi:tumble-dryer')
+        assert.equal(components.error.device_class, 'problem')
+        assert.equal(components.smart_diagnosis.device_class, 'problem')
     })
 
     test('decodes the current real powered-off EB snapshot', () => {
@@ -49,13 +60,15 @@ describe('RH16_T_KR read-only status', () => {
         thinq.emit('data', OFF)
         assert.equal(ha.devices[DEVICE_ID].properties.power, 'OFF')
         assert.equal(ha.devices[DEVICE_ID].properties.status, 'Power off')
+        assert.equal(ha.devices[DEVICE_ID].properties.error, 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties.smart_diagnosis, 'OFF')
     })
 
     test('decodes the real Initial EB snapshot', () => {
         const { ha, thinq } = makeDevice()
         thinq.emit('data', INITIAL)
         assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
-        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Initial')
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Standby')
     })
 
     test('uses the current record in a real EC frame', () => {
@@ -63,7 +76,19 @@ describe('RH16_T_KR read-only status', () => {
         thinq.emit('data', OFF)
         thinq.emit('data', DOUBLE_INITIAL)
         assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
-        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Initial')
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Standby')
+    })
+
+    test('publishes separate Error and Smart diagnosis problem sensors', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', withState(5))
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Error')
+        assert.equal(ha.devices[DEVICE_ID].properties.error, 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.smart_diagnosis, 'OFF')
+        thinq.emit('data', withState(8))
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Smart diagnosis')
+        assert.equal(ha.devices[DEVICE_ID].properties.error, 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties.smart_diagnosis, 'ON')
     })
 
     test('asks only for the family-wide read-only status snapshot on connect', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -72,12 +72,6 @@ const SHIRTS_LOW_AC_ON_RESERVED_3H = buf(
 const TOWEL_RESERVED_3H = buf(
     'AA3C30EC00190301000100170000020204000400091B0000000200000077000019020128012802000002000300030001990000000300000077003EBB',
 )
-// Powerful Dry (downloaded) running on a 3h reservation. Captured live the
-// evening the owner started it from the app: the course byte reads 0x11
-// while native courses report their own id.
-const DOWNLOADED_POWERFUL_RUNNING_RESERVED_3H = buf(
-    'AA3C30EC00190201280128110000020003000300019B00000001770000770000190201190119110000020203000300011B000000017700007700DDBB',
-)
 const STATUS_REQUEST = 'aa0ef0ed1121010000001800b5bb'
 
 function makeDevice() {
@@ -135,7 +129,6 @@ describe('RH16_T_KR read-only status', () => {
             CONDENSER_CARE_RUNNING,
             SHIRTS_LOW_AC_ON_RESERVED_3H,
             TOWEL_RESERVED_3H,
-            DOWNLOADED_POWERFUL_RUNNING_RESERVED_3H,
         ])
             assertIntact(frame)
     })
@@ -618,19 +611,6 @@ describe('RH16_T_KR read-only status', () => {
         const { thinq, dev } = makeDevice()
         dev.setProperty('smart_course_select', '')
         assert.equal(thinq.outbox.length, 0)
-    })
-
-    test('reads a running downloaded course as Downloaded Course', () => {
-        const { ha, thinq, dev } = makeDevice()
-        dev.start()
-        thinq.emit('data', DOWNLOADED_POWERFUL_RUNNING_RESERVED_3H)
-        assert.equal(ha.devices[DEVICE_ID].properties.course, 'Downloaded Course')
-        // The 3h reservation is still counting down, so Status reads Reserved.
-        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Reserved')
-        // Display only: no start template exists for it, so course select
-        // must not offer it.
-        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
-        assert.ok(!(components.course_select.options as string[]).includes('Downloaded Course'))
     })
 
     test('asks only for the family-wide read-only status snapshot on connect', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -93,12 +93,18 @@ describe('RH16_T_KR read-only status', () => {
             'child_lock',
             'error',
             'error_message',
+            'pause',
             'power',
             'remote_start',
             'smart_diagnosis',
             'status',
         ])
-        for (const component of Object.values(components)) assert.equal(component.command_topic, undefined)
+        for (const [id, component] of Object.entries(components)) {
+            if (id === 'pause') assert.equal(component.command_topic, '$this/pause/set')
+            else assert.equal(component.command_topic, undefined)
+        }
+        assert.equal(components.pause.platform, 'button')
+        assert.equal(components.pause.payload_press, '')
         assert.equal(components.power.icon, 'mdi:power')
         assert.equal(components.status.icon, 'mdi:tumble-dryer')
         assert.equal(components.child_lock.device_class, 'lock')
@@ -183,6 +189,13 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.remote_start, 'ON')
         thinq.emit('data', REMOTE_START_OFF)
         assert.equal(ha.devices[DEVICE_ID].properties.remote_start, 'OFF')
+    })
+
+    test('Pause reproduces the exact ThinQ app command captured by MCP', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('pause', '')
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(thinq.outbox[0].toString('hex'), 'aa09f02404010099bb')
     })
 
     test('asks only for the family-wide read-only status snapshot on connect', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -72,6 +72,11 @@ const SHIRTS_LOW_AC_ON_RESERVED_3H = buf(
 const TOWEL_RESERVED_3H = buf(
     'AA3C30EC00190301000100170000020204000400091B0000000200000077000019020128012802000002000300030001990000000300000077003EBB',
 )
+// Owner-confirmed Big Size Item 3h reservation. All ten live download-course
+// reservations matched the execution-id/signature pair encoded in F025.
+const BIG_SIZE_ITEM_RESERVED_3H = buf(
+    'AA3C30EC00190202370237040000030203000300011B000000017100007100001902023702370400000302023B023B011B000000017100007100F9BB',
+)
 const STATUS_REQUEST = 'aa0ef0ed1121010000001800b5bb'
 
 function makeDevice() {
@@ -129,6 +134,7 @@ describe('RH16_T_KR read-only status', () => {
             CONDENSER_CARE_RUNNING,
             SHIRTS_LOW_AC_ON_RESERVED_3H,
             TOWEL_RESERVED_3H,
+            BIG_SIZE_ITEM_RESERVED_3H,
         ])
             assertIntact(frame)
     })
@@ -158,6 +164,7 @@ describe('RH16_T_KR read-only status', () => {
             'reserve_hours',
             'reserve_time',
             'resume',
+            'smart_course',
             'smart_course_select',
             'smart_diagnosis',
             'start_course',
@@ -611,6 +618,20 @@ describe('RH16_T_KR read-only status', () => {
         const { thinq, dev } = makeDevice()
         dev.setProperty('smart_course_select', '')
         assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('identifies a running download and reports Downloaded Course', () => {
+        const { ha, thinq, dev } = makeDevice()
+        dev.start()
+        thinq.emit('data', BIG_SIZE_ITEM_RESERVED_3H)
+        assert.equal(ha.devices[DEVICE_ID].properties.smart_course, 'Big Size Item')
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'Downloaded Course')
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Reserved')
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        assert.ok((components.course.options as string[]).includes('Downloaded Course'))
+        // Prepared in the sensor enum but not offered for control until a
+        // downloaded-course F026 start frame is captured.
+        assert.ok(!(components.course_select.options as string[]).includes('Downloaded Course'))
     })
 
     test('asks only for the family-wide read-only status snapshot on connect', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -689,6 +689,37 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(thinq.outbox[0].toString('hex'), 'aa14f026110002640000000000000300770090bb')
     })
 
+    // The armed course's signature only shows up on the wire once a run is
+    // reserved or executing (see smartCourseOf). An idle/powered-off status
+    // frame that follows an install carries no signature at all, and must
+    // not be read as "nothing armed" and flapped back to Unknown.
+    test('an armed download survives an idle status frame with no signature', () => {
+        const { ha, thinq, dev } = makeDevice()
+        dev.setProperty('smart_course_select', 'Powerful Dry')
+        thinq.emit('data', OFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.smart_course, 'Powerful Dry')
+        assert.equal(ha.devices[DEVICE_ID].properties.smart_course_select, 'Powerful Dry')
+        assert.equal(ha.devices[DEVICE_ID].properties.course_select, 'Downloaded Course')
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'Downloaded Course')
+    })
+
+    test('a bridge-tunnelled install survives a follow-up idle status frame', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('sendData', buf('aa1df0250315000264000000000000001177000000000000000000b7bb'))
+        thinq.emit('data', OFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.smart_course, 'Powerful Dry')
+        assert.equal(ha.devices[DEVICE_ID].properties.smart_course_select, 'Powerful Dry')
+        assert.equal(ha.devices[DEVICE_ID].properties.course_select, 'Downloaded Course')
+    })
+
+    test('a real native-course status frame still clears a stale download', () => {
+        const { ha, thinq, dev } = makeDevice()
+        dev.setProperty('smart_course_select', 'Powerful Dry')
+        thinq.emit('data', STANDARD_DETECTING)
+        assert.equal(ha.devices[DEVICE_ID].properties.smart_course, 'Unknown')
+        assert.equal(ha.devices[DEVICE_ID].properties.course_select, 'Standard')
+    })
+
     test('starts Powerful Dry through Downloaded Course with the captured F026 frame', () => {
         const { thinq, dev } = makeDevice()
         dev.setProperty('smart_course_select', 'Powerful Dry')

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -51,6 +51,15 @@ function withState(state: number) {
     return packet
 }
 
+/** Model-declared error probe derived from a real frame; not capture evidence. */
+function withError(error: number) {
+    const packet = Buffer.from(OFF)
+    packet[12] = error
+    const sum = packet.subarray(0, packet.length - 2).reduce((a, b) => a + b, 0)
+    packet[packet.length - 2] = (sum & 0xff) ^ 0x55
+    return packet
+}
+
 describe('RH16_T_KR read-only status', () => {
     test('real capture fixtures have intact AA/BB envelopes', () => {
         for (const frame of [
@@ -71,6 +80,7 @@ describe('RH16_T_KR read-only status', () => {
         assert.deepEqual(Object.keys(components).sort(), [
             'child_lock',
             'error',
+            'error_message',
             'power',
             'remote_start',
             'smart_diagnosis',
@@ -81,6 +91,8 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(components.status.icon, 'mdi:tumble-dryer')
         assert.equal(components.child_lock.device_class, 'lock')
         assert.equal(components.error.device_class, 'problem')
+        assert.equal(components.error_message.device_class, 'enum')
+        assert.equal(components.error_message.entity_category, 'diagnostic')
         assert.equal(components.smart_diagnosis.device_class, 'problem')
     })
 
@@ -90,6 +102,7 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.power, 'OFF')
         assert.equal(ha.devices[DEVICE_ID].properties.status, 'Power off')
         assert.equal(ha.devices[DEVICE_ID].properties.error, 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties.error_message, 'Normal')
         assert.equal(ha.devices[DEVICE_ID].properties.smart_diagnosis, 'OFF')
     })
 
@@ -108,16 +121,30 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.status, 'Standby')
     })
 
-    test('publishes separate Error and Smart diagnosis problem sensors', () => {
+    test('keeps Error separate from the state enum and derives it from the error code', () => {
         const { ha, thinq } = makeDevice()
         thinq.emit('data', withState(5))
         assert.equal(ha.devices[DEVICE_ID].properties.status, 'Error')
-        assert.equal(ha.devices[DEVICE_ID].properties.error, 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.error, 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties.error_message, 'Normal')
         assert.equal(ha.devices[DEVICE_ID].properties.smart_diagnosis, 'OFF')
         thinq.emit('data', withState(8))
         assert.equal(ha.devices[DEVICE_ID].properties.status, 'Smart diagnosis')
         assert.equal(ha.devices[DEVICE_ID].properties.error, 'OFF')
         assert.equal(ha.devices[DEVICE_ID].properties.smart_diagnosis, 'ON')
+    })
+
+    test('maps the model-declared error byte and safely handles an undefined code', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', withError(1))
+        assert.equal(ha.devices[DEVICE_ID].properties.error, 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.error_message, 'tE1')
+        thinq.emit('data', withError(0))
+        assert.equal(ha.devices[DEVICE_ID].properties.error, 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties.error_message, 'Normal')
+        thinq.emit('data', withError(3))
+        assert.equal(ha.devices[DEVICE_ID].properties.error, 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.error_message, 'None')
     })
 
     test('decodes child lock from the isolated real ON and OFF transition', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -153,7 +153,6 @@ describe('RH16_T_KR read-only status', () => {
             'pause',
             'power',
             'power_off',
-            'previous_status',
             'remaining_time',
             'remote_start',
             'reserve_hours',
@@ -447,24 +446,6 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.course, 'Steam Refresh')
     })
 
-    test('publishes the previous state from the leading record of an EC frame', () => {
-        // An EC frame stacks the prior state at offset 3 and the current one
-        // at 30. The child lock toggle frames are a clean pair: the record
-        // only differs by the lock bit, so the phase reads the same on both.
-        const { ha, thinq } = makeDevice()
-        thinq.emit('data', STEAM_REFRESH_RESERVED_14H_PARTWAY)
-        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Reserved')
-        assert.equal(ha.devices[DEVICE_ID].properties.previous_status, 'Reserved')
-    })
-
-    test('leaves the previous state alone for a single-record EB frame', () => {
-        const { ha, thinq } = makeDevice()
-        thinq.emit('data', STEAM_REFRESH_RESERVED_14H_PARTWAY)
-        const seen = ha.devices[DEVICE_ID].properties.previous_status
-        thinq.emit('data', INITIAL)
-        assert.equal(ha.devices[DEVICE_ID].properties.previous_status, seen)
-    })
-
     test('every Status value it can publish is a declared option', () => {
         // device_class enum forces any value outside options to unknown, so a
         // fallback like `Code 12` would blank the entity instead of informing.
@@ -483,14 +464,8 @@ describe('RH16_T_KR read-only status', () => {
         ]
         for (const frame of frames) {
             thinq.emit('data', frame)
-            const { status, previous_status } = ha.devices[DEVICE_ID].properties
+            const { status } = ha.devices[DEVICE_ID].properties
             assert.ok(components.status.options.includes(status as string), `status ${status}`)
-            if (previous_status !== undefined) {
-                assert.ok(
-                    components.previous_status.options.includes(previous_status as string),
-                    `previous_status ${previous_status}`,
-                )
-            }
         }
     })
 

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -72,6 +72,12 @@ const SHIRTS_LOW_AC_ON_RESERVED_3H = buf(
 const TOWEL_RESERVED_3H = buf(
     'AA3C30EC00190301000100170000020204000400091B0000000200000077000019020128012802000002000300030001990000000300000077003EBB',
 )
+// Powerful Dry (downloaded) running on a 3h reservation. Captured live the
+// evening the owner started it from the app: the course byte reads 0x11
+// while native courses report their own id.
+const DOWNLOADED_POWERFUL_RUNNING_RESERVED_3H = buf(
+    'AA3C30EC00190201280128110000020003000300019B00000001770000770000190201190119110000020203000300011B000000017700007700DDBB',
+)
 const STATUS_REQUEST = 'aa0ef0ed1121010000001800b5bb'
 
 function makeDevice() {
@@ -129,6 +135,7 @@ describe('RH16_T_KR read-only status', () => {
             CONDENSER_CARE_RUNNING,
             SHIRTS_LOW_AC_ON_RESERVED_3H,
             TOWEL_RESERVED_3H,
+            DOWNLOADED_POWERFUL_RUNNING_RESERVED_3H,
         ])
             assertIntact(frame)
     })
@@ -611,6 +618,19 @@ describe('RH16_T_KR read-only status', () => {
         const { thinq, dev } = makeDevice()
         dev.setProperty('smart_course_select', '')
         assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('reads a running downloaded course as Downloaded Course', () => {
+        const { ha, thinq, dev } = makeDevice()
+        dev.start()
+        thinq.emit('data', DOWNLOADED_POWERFUL_RUNNING_RESERVED_3H)
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'Downloaded Course')
+        // The 3h reservation is still counting down, so Status reads Reserved.
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Reserved')
+        // Display only: no start template exists for it, so course select
+        // must not offer it.
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        assert.ok(!(components.course_select.options as string[]).includes('Downloaded Course'))
     })
 
     test('asks only for the family-wide read-only status snapshot on connect', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -205,7 +205,7 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.smart_diagnosis, 'OFF')
         assert.equal(ha.devices[DEVICE_ID].properties.course, 'Off')
         assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'Off')
-        assert.equal(ha.devices[DEVICE_ID].properties.eco_hybrid, 'Unsupported')
+        assert.equal(ha.devices[DEVICE_ID].properties.eco_hybrid, 'Off')
         assert.equal(ha.devices[DEVICE_ID].properties.steam, 'OFF')
         assert.equal(ha.devices[DEVICE_ID].properties.energy, 0)
     })
@@ -502,6 +502,8 @@ describe('RH16_T_KR read-only status', () => {
         // The sensors keep the fallback so an unmapped code still reads back.
         assert.ok(components.course.options.includes('Unsupported'))
         assert.ok(components.dry_level.options.includes('Off'))
+        assert.ok(components.eco_hybrid.options.includes('Off'))
+        assert.ok(!components.status.options.includes('Unsupported'))
     })
 
     test('Power off reproduces the exact ThinQ app command captured by MCP', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -135,13 +135,17 @@ describe('RH16_T_KR read-only status', () => {
             'dry_level_select',
             'eco_hybrid',
             'eco_hybrid_select',
+            'energy',
             'error',
             'error_message',
+            'initial_time',
             'pause',
             'power',
             'power_off',
+            'remaining_time',
             'remote_start',
             'reserve_hours',
+            'reserve_time',
             'resume',
             'smart_diagnosis',
             'start_course',
@@ -172,7 +176,8 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(components.eco_hybrid.device_class, 'enum')
         assert.equal(components.power.icon, 'mdi:power')
         assert.equal(components.status.icon, 'mdi:tumble-dryer')
-        assert.equal(components.child_lock.device_class, 'lock')
+        assert.equal(components.child_lock.device_class, undefined)
+        assert.equal(components.child_lock.entity_category, 'diagnostic')
         assert.equal(components.error.device_class, 'problem')
         assert.equal(components.error_message.device_class, 'enum')
         assert.equal(components.error_message.entity_category, 'diagnostic')
@@ -191,6 +196,7 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'None')
         assert.equal(ha.devices[DEVICE_ID].properties.eco_hybrid, 'None')
         assert.equal(ha.devices[DEVICE_ID].properties.steam, 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties.energy, 0)
     })
 
     test('decodes the real Initial EB snapshot', () => {
@@ -283,6 +289,9 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'Delicate')
         assert.equal(ha.devices[DEVICE_ID].properties.eco_hybrid, 'Energy')
         assert.equal(ha.devices[DEVICE_ID].properties.steam, 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties.remaining_time, 30)
+        assert.equal(ha.devices[DEVICE_ID].properties.initial_time, 30)
+        assert.equal(ha.devices[DEVICE_ID].properties.reserve_time, 19 * 60)
         thinq.emit('data', SHIRTS_LOW_AC_ON_RESERVED_3H)
         assert.equal(ha.devices[DEVICE_ID].properties.course, 'Easy Care')
         assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'Light')

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -720,6 +720,17 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.course_select, 'Standard')
     })
 
+    test('a fresh idle frame after restart leaves smart_course untouched', () => {
+        // Post-restart the arming memory is gone while the appliance may
+        // still have a download installed. With no positive evidence either
+        // way, smart_course must keep HA's last displayed value instead of
+        // being asserted to Unknown (the F24VDD washer convention).
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', OFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.smart_course, undefined)
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'OFF')
+    })
+
     test('starts Powerful Dry through Downloaded Course with the captured F026 frame', () => {
         const { thinq, dev } = makeDevice()
         dev.setProperty('smart_course_select', 'Powerful Dry')

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -21,6 +21,12 @@ const CHILD_LOCK_ON = buf(
 const CHILD_LOCK_OFF = buf(
     'AA3C30EC00190100000000000000000000000000080800000000000000770000190100000000000000000000000000000800000000000000770069BB',
 )
+const REMOTE_START_ON = buf(
+    'AA3C30EC00190100000000000000000000000000000900000000000000770000190100000000000000000000000000001900000000000000770013BB',
+)
+const REMOTE_START_OFF = buf(
+    'AA3C30EC00190100000000000000000000000000001900000000000000770000190100000000000000000000000000001800000000000000770000BB',
+)
 const STATUS_REQUEST = 'aa0ef0ed1121010000001800b5bb'
 
 function makeDevice() {
@@ -47,13 +53,29 @@ function withState(state: number) {
 
 describe('RH16_T_KR read-only status', () => {
     test('real capture fixtures have intact AA/BB envelopes', () => {
-        for (const frame of [OFF, INITIAL, DOUBLE_INITIAL, CHILD_LOCK_ON, CHILD_LOCK_OFF]) assertIntact(frame)
+        for (const frame of [
+            OFF,
+            INITIAL,
+            DOUBLE_INITIAL,
+            CHILD_LOCK_ON,
+            CHILD_LOCK_OFF,
+            REMOTE_START_ON,
+            REMOTE_START_OFF,
+        ])
+            assertIntact(frame)
     })
 
     test('exposes the common read-only status sensors', () => {
         const { ha } = makeDevice()
         const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
-        assert.deepEqual(Object.keys(components).sort(), ['child_lock', 'error', 'power', 'smart_diagnosis', 'status'])
+        assert.deepEqual(Object.keys(components).sort(), [
+            'child_lock',
+            'error',
+            'power',
+            'remote_start',
+            'smart_diagnosis',
+            'status',
+        ])
         for (const component of Object.values(components)) assert.equal(component.command_topic, undefined)
         assert.equal(components.power.icon, 'mdi:power')
         assert.equal(components.status.icon, 'mdi:tumble-dryer')
@@ -104,6 +126,14 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.child_lock, 'ON')
         thinq.emit('data', CHILD_LOCK_OFF)
         assert.equal(ha.devices[DEVICE_ID].properties.child_lock, 'OFF')
+    })
+
+    test('decodes remote start from the isolated real ON and OFF transition', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', REMOTE_START_ON)
+        assert.equal(ha.devices[DEVICE_ID].properties.remote_start, 'ON')
+        thinq.emit('data', REMOTE_START_OFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.remote_start, 'OFF')
     })
 
     test('asks only for the family-wide read-only status snapshot on connect', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -2,7 +2,7 @@ import { describe, test } from 'node:test'
 import assert from 'node:assert/strict'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { unlinkSync } from 'node:fs'
+import { unlinkSync, writeFileSync } from 'node:fs'
 import DUT from '@/cloud/devices/RH16_T_KR'
 import type { Metadata } from '@/cloud/thinq'
 import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
@@ -757,6 +757,30 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(p.smart_course, 'Powerful Dry')
         assert.equal(p.smart_course_select, 'Powerful Dry')
         assert.equal(p.course_select, 'Downloaded Course')
+    })
+
+    test('a restart shows an installed-but-idle download without arming it', () => {
+        // Installed on the appliance, nothing armed (e.g. a native course
+        // was running when rethink restarted): smart_course still shows the
+        // download while course_select follows the restored native course.
+        writeFileSync(
+            process.env.RETHINK_MEMORY_FILE as string,
+            JSON.stringify({
+                [DEVICE_ID]: {
+                    downloadedCourse: 'Powerful Dry',
+                    useDownloadedCourse: false,
+                    selectedCourse: 7,
+                },
+            }),
+        )
+        const ha2 = new MockHAConnection()
+        const thinq2 = new MockThinq2Device(DEVICE_ID, META)
+        const second = new DUT(ha2.asConnection(), thinq2, META)
+        assert.ok(second)
+        const p = ha2.devices[DEVICE_ID].properties
+        assert.equal(p.smart_course, 'Powerful Dry')
+        assert.equal(p.smart_course_select, 'Powerful Dry')
+        assert.equal(p.course_select, 'Standard')
     })
 
     test('a fresh idle frame after restart leaves smart_course untouched', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -1,8 +1,20 @@
 import { describe, test } from 'node:test'
 import assert from 'node:assert/strict'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { unlinkSync } from 'node:fs'
 import DUT from '@/cloud/devices/RH16_T_KR'
 import type { Metadata } from '@/cloud/thinq'
 import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+
+// Disk-backed course memory under test: each run starts with no memory
+// file, and the driver under test reads the path at call time.
+process.env.RETHINK_MEMORY_FILE = join(tmpdir(), 'rethink-course-memory-dryer-test.json')
+try {
+    unlinkSync(process.env.RETHINK_MEMORY_FILE)
+} catch {
+    // no memory file from a previous run — start clean
+}
 
 const DEVICE_ID = 'test-id'
 const META: Metadata = { modelId: 'RH16_T_KR', modelName: 'RH16_T_KR', swVersion: '2.10.122' }
@@ -80,6 +92,14 @@ const BIG_SIZE_ITEM_RESERVED_3H = buf(
 const STATUS_REQUEST = 'aa0ef0ed1121010000001800b5bb'
 
 function makeDevice() {
+    // Each test starts with no disk memory (what a fresh install sees);
+    // the restart test below bypasses this by building its second handler
+    // by hand on the armed file.
+    try {
+        unlinkSync(process.env.RETHINK_MEMORY_FILE as string)
+    } catch {
+        // nothing persisted yet — start clean
+    }
     const ha = new MockHAConnection()
     const thinq = new MockThinq2Device(DEVICE_ID, META)
     const dev = new DUT(ha.asConnection(), thinq, META)
@@ -712,12 +732,31 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.course_select, 'Downloaded Course')
     })
 
-    test('a real native-course status frame still clears a stale download', () => {
+    test('a real native-course status frame keeps the installed download visible', () => {
+        // F24VDD washer convention: running a native course does not
+        // uninstall the download, and smart_course keeps showing it whether
+        // it runs or not. Only the native evidence itself is published.
         const { ha, thinq, dev } = makeDevice()
         dev.setProperty('smart_course_select', 'Powerful Dry')
         thinq.emit('data', STANDARD_DETECTING)
-        assert.equal(ha.devices[DEVICE_ID].properties.smart_course, 'Unknown')
+        assert.equal(ha.devices[DEVICE_ID].properties.smart_course, 'Powerful Dry')
         assert.equal(ha.devices[DEVICE_ID].properties.course_select, 'Standard')
+    })
+
+    test('a restart restores the installed download from disk memory', () => {
+        // Arm a download, then build a fresh handler on a fresh HA
+        // connection (what a real restart builds: the static remembered map
+        // misses, so the driver falls back to the disk memory file).
+        const first = makeDevice()
+        first.dev.setProperty('smart_course_select', 'Powerful Dry')
+        const ha2 = new MockHAConnection()
+        const thinq2 = new MockThinq2Device(DEVICE_ID, META)
+        const second = new DUT(ha2.asConnection(), thinq2, META)
+        assert.ok(second)
+        const p = ha2.devices[DEVICE_ID].properties
+        assert.equal(p.smart_course, 'Powerful Dry')
+        assert.equal(p.smart_course_select, 'Powerful Dry')
+        assert.equal(p.course_select, 'Downloaded Course')
     })
 
     test('a fresh idle frame after restart leaves smart_course untouched', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -543,6 +543,34 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(thinq.outbox[0].toString('hex'), 'aa09f02404010099bb')
     })
 
+    test('Smart course select installs and stays visible while powered off', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('data', OFF)
+        dev.setProperty('smart_course_select', 'Powerful Dry')
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'OFF')
+        assert.equal(
+            thinq.outbox[thinq.outbox.length - 1]?.toString('hex'),
+            'aa1df0250315000264000000000000001177000000000000000000b7bb',
+        )
+        assert.equal(ha.devices[DEVICE_ID].properties.smart_course, 'Powerful Dry')
+        assert.equal(ha.devices[DEVICE_ID].properties.smart_course_select, 'Powerful Dry')
+        assert.equal(ha.devices[DEVICE_ID].properties.course_select, 'Downloaded Course')
+    })
+
+    test('restores an armed Smart course when the handler reconnects', () => {
+        const ha = new MockHAConnection()
+        const firstThinq = new MockThinq2Device(DEVICE_ID, META)
+        const first = new DUT(ha.asConnection(), firstThinq, META)
+        first.setProperty('smart_course_select', 'Wrinkle Care Dry')
+
+        const secondThinq = new MockThinq2Device(DEVICE_ID, META)
+        new DUT(ha.asConnection(), secondThinq, META)
+        assert.equal(ha.devices[DEVICE_ID].properties.smart_course, 'Wrinkle Care Dry')
+        assert.equal(ha.devices[DEVICE_ID].properties.smart_course_select, 'Wrinkle Care Dry')
+        assert.equal(ha.devices[DEVICE_ID].properties.course_select, 'Downloaded Course')
+        assert.equal(secondThinq.outbox.length, 0)
+    })
+
     test('installing a download course replays the exact captured app bytes', () => {
         // Both install frames were captured live from the ThinQ app's own
         // toDevice traffic while the owner downloaded each course.

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -15,11 +15,14 @@ const INITIAL = buf('AA2130EB001901000000000000000000000000000804000000000000007
 const DOUBLE_INITIAL = buf(
     'AA3C30EC00190100000000000000000000000000080400000000000000770000190100000000000000000000000000000400000000000000770061BB',
 )
+// Owner toggled child lock ON then OFF on the appliance while a reserved
+// Steam Refresh run waited. rec[15] went 0x01 -> 0x11 -> 0x01, and in both
+// frames that byte was the only one in the record to change.
 const CHILD_LOCK_ON = buf(
-    'AA3C30EC00190000000000000000000000000000000000000001000000770000190100000000000000000000000000080800000000000000770061BB',
+    'AA3C30EC0019030020002001000002010D380D38010A0800050200000077000019030020002001000002010D380D38110A0800050200000077005DBB',
 )
 const CHILD_LOCK_OFF = buf(
-    'AA3C30EC00190100000000000000000000000000080800000000000000770000190100000000000000000000000000000800000000000000770069BB',
+    'AA3C30EC0019030020002001000002010D380D38110A0800050200000077000019030020002001000002010D380D38010A0800050200000077005DBB',
 )
 const REMOTE_START_ON = buf(
     'AA3C30EC00190100000000000000000000000000000900000000000000770000190100000000000000000000000000001900000000000000770013BB',
@@ -272,6 +275,27 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.child_lock, 'ON')
         thinq.emit('data', CHILD_LOCK_OFF)
         assert.equal(ha.devices[DEVICE_ID].properties.child_lock, 'OFF')
+    })
+
+    test('does not mistake the unrelated 0x08 bit for child lock', () => {
+        // The first mapping used rec[15] bit 0x08, which is also set in plain
+        // idle and paused captures the owner never locked. Those have to read
+        // OFF or the lock is reported on for a dryer nobody locked.
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', INITIAL)
+        assert.equal(ha.devices[DEVICE_ID].properties.child_lock, 'OFF')
+        thinq.emit('data', STANDARD_PAUSED)
+        assert.equal(ha.devices[DEVICE_ID].properties.child_lock, 'OFF')
+    })
+
+    test('keeps child lock and anti-crease on separate bits of the same byte', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', ANTI_CREASE_ON)
+        assert.equal(ha.devices[DEVICE_ID].properties.anti_crease, 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.child_lock, 'OFF')
+        thinq.emit('data', CHILD_LOCK_ON)
+        assert.equal(ha.devices[DEVICE_ID].properties.child_lock, 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.anti_crease, 'OFF')
     })
 
     test('decodes anti-crease from the single-toggle ON and OFF pair', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -36,6 +36,12 @@ const STANDARD_DRYING = buf(
 const STANDARD_PAUSED = buf(
     'AA3C30EC001902010F010F070003020200000000001B000000010000007700001903010F010F070003020200000000081B00000002000000770091BB',
 )
+const STANDARD_ENERGY_DELICATE_RESERVED_19H = buf(
+    'AA3C30EC001903010C010F0700030202000000000819000005020000007700001902001E001E070001010013001300019B000000030000007700D1BB',
+)
+const STANDARD_SPEED_LOW_RESERVED_3H = buf(
+    'AA3C30EC001903013701370700010102123A123A091B000000020000007700001902001E001E07000203000300030001990000000300000077001EBB',
+)
 const STATUS_REQUEST = 'aa0ef0ed1121010000001800b5bb'
 
 function makeDevice() {
@@ -82,6 +88,8 @@ describe('RH16_T_KR read-only status', () => {
             STANDARD_DETECTING,
             STANDARD_DRYING,
             STANDARD_PAUSED,
+            STANDARD_ENERGY_DELICATE_RESERVED_19H,
+            STANDARD_SPEED_LOW_RESERVED_3H,
         ])
             assertIntact(frame)
     })
@@ -173,6 +181,14 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.status, 'Drying')
         thinq.emit('data', STANDARD_PAUSED)
         assert.equal(ha.devices[DEVICE_ID].properties.status, 'Pause')
+    })
+
+    test('reports Reserved while a real 19h or 3h reservation is pending', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STANDARD_ENERGY_DELICATE_RESERVED_19H)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Reserved')
+        thinq.emit('data', STANDARD_SPEED_LOW_RESERVED_3H)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Reserved')
     })
 
     test('decodes child lock from the isolated real ON and OFF transition', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -507,7 +507,18 @@ describe('RH16_T_KR read-only status', () => {
         assert.ok(components.eco_hybrid.options.includes('Off'))
         assert.ok(!components.status.options.includes('Unsupported'))
         // Only download courses with a captured install blob are offered.
-        assert.deepEqual(components.smart_course_select.options, ['Powerful Dry', 'Wrinkle Care Dry'])
+        assert.deepEqual(components.smart_course_select.options, [
+            'Powerful Dry',
+            'Wrinkle Care Dry',
+            'Full Size Load',
+            'Refresh',
+            'Small Load',
+            'Gym Clothes',
+            'Rainy Season',
+            'Economic Dry',
+            'Easy Iron',
+            'Big Size Item',
+        ])
     })
 
     test('Power off reproduces the exact ThinQ app command captured by MCP', () => {
@@ -540,9 +551,65 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(thinq.outbox[0].toString('hex'), 'aa1df025031500025a0000000002000007720000000300000000009bbb')
     })
 
-    test('refuses a download course with no captured install blob', () => {
+    test('installing Full Size Load replays its captured bytes', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('smart_course_select', 'Full Size Load')
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(thinq.outbox[0].toString('hex'), 'aa1df02503150003640000000000000007740000000500000000008ebb')
+    })
+
+    test('installing Refresh replays its captured bytes', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('smart_course_select', 'Refresh')
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(thinq.outbox[0].toString('hex'), 'aa1df0250315000314000000000000000f6b000000000000000000d0bb')
+    })
+
+    test('installing Small Load replays its captured bytes', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('smart_course_select', 'Small Load')
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(thinq.outbox[0].toString('hex'), 'aa1df025031500031e000000000000000e6c000000000000000000dabb')
+    })
+
+    test('installing Gym Clothes replays its captured bytes', () => {
         const { thinq, dev } = makeDevice()
         dev.setProperty('smart_course_select', 'Gym Clothes')
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(thinq.outbox[0].toString('hex'), 'aa1df025031500013d000000000000000866000000000000000000f5bb')
+    })
+
+    test('installing Rainy Season replays its captured bytes', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('smart_course_select', 'Rainy Season')
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(thinq.outbox[0].toString('hex'), 'aa1df0250315000328000000000000000e69000000000000000000c3bb')
+    })
+
+    test('installing Economic Dry replays its captured bytes', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('smart_course_select', 'Economic Dry')
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(thinq.outbox[0].toString('hex'), 'aa1df025031500017d000000000000000770000000030000000000b9bb')
+    })
+
+    test('installing Easy Iron replays its captured bytes', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('smart_course_select', 'Easy Iron')
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(thinq.outbox[0].toString('hex'), 'aa1df025031500034100000000000000076e000000010000000000fbbb')
+    })
+
+    test('installing Big Size Item replays its captured bytes', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('smart_course_select', 'Big Size Item')
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(thinq.outbox[0].toString('hex'), 'aa1df02503150003af0000000000000004710000000000000000004ebb')
+    })
+
+    test('refuses a download course with no captured install blob', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('smart_course_select', '')
         assert.equal(thinq.outbox.length, 0)
     })
 

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -196,9 +196,9 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.error, 'OFF')
         assert.equal(ha.devices[DEVICE_ID].properties.error_message, 'Normal')
         assert.equal(ha.devices[DEVICE_ID].properties.smart_diagnosis, 'OFF')
-        assert.equal(ha.devices[DEVICE_ID].properties.course, 'None')
-        assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'None')
-        assert.equal(ha.devices[DEVICE_ID].properties.eco_hybrid, 'None')
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'Off')
+        assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'Off')
+        assert.equal(ha.devices[DEVICE_ID].properties.eco_hybrid, 'Unsupported')
         assert.equal(ha.devices[DEVICE_ID].properties.steam, 'OFF')
         assert.equal(ha.devices[DEVICE_ID].properties.energy, 0)
     })
@@ -241,7 +241,7 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.error_message, 'Normal')
         thinq.emit('data', withError(3))
         assert.equal(ha.devices[DEVICE_ID].properties.error, 'ON')
-        assert.equal(ha.devices[DEVICE_ID].properties.error_message, 'None')
+        assert.equal(ha.devices[DEVICE_ID].properties.error_message, 'Unsupported')
     })
 
     test('uses the captured process sub-state for Detecting, Drying, then Pause', () => {
@@ -303,12 +303,12 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.steam, 'OFF')
         thinq.emit('data', DUVET_RESERVED_4H)
         assert.equal(ha.devices[DEVICE_ID].properties.course, 'Bulky Item')
-        assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'None')
+        assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'Off')
         assert.equal(ha.devices[DEVICE_ID].properties.eco_hybrid, 'Speed')
         assert.equal(ha.devices[DEVICE_ID].properties.steam, 'OFF')
         thinq.emit('data', TOWEL_RESERVED_3H)
         assert.equal(ha.devices[DEVICE_ID].properties.course, 'Towel')
-        assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'None')
+        assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'Off')
         assert.equal(ha.devices[DEVICE_ID].properties.eco_hybrid, 'Auto')
         assert.equal(ha.devices[DEVICE_ID].properties.steam, 'OFF')
         thinq.emit('data', STEAM_REFRESH_RESERVED_3H)
@@ -316,7 +316,7 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.steam, 'ON')
         thinq.emit('data', STEAM_REFRESH_RESUMED_11H)
         assert.equal(ha.devices[DEVICE_ID].properties.course, 'Steam Refresh')
-        assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'None')
+        assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'Off')
         assert.equal(ha.devices[DEVICE_ID].properties.eco_hybrid, 'Auto')
         assert.equal(ha.devices[DEVICE_ID].properties.steam, 'ON')
         assert.equal(ha.devices[DEVICE_ID].properties.status, 'Reserved')
@@ -406,6 +406,41 @@ describe('RH16_T_KR read-only status', () => {
         dev.setProperty('start_course', '')
         assert.equal(ha.devices[DEVICE_ID].properties.course_select, 'Standard')
         assert.equal(thinq.outbox[0].toString('hex'), 'aa14f0260703020000000000000001000000b4bb')
+    })
+
+    test('never publishes the literal None, which HA reads as unknown', () => {
+        // HA's MQTT sensor maps the payload 'None' to PAYLOAD_NONE and forces
+        // the state to unknown, so no enum reading may ever be that string.
+        const { ha, thinq } = makeDevice()
+        const frames = [
+            INITIAL,
+            OFF,
+            STANDARD_ENERGY_DELICATE_RESERVED_19H,
+            STEAM_REFRESH_RESERVED_3H,
+            STEAM_REFRESH_RESUMED_11H,
+            CONDENSER_CARE_RUNNING,
+            SHIRTS_LOW_AC_ON_RESERVED_3H,
+        ]
+        for (const frame of frames) {
+            thinq.emit('data', frame)
+            for (const [key, value] of Object.entries(ha.devices[DEVICE_ID].properties)) {
+                assert.notEqual(value, 'None', `${key} published the literal None`)
+            }
+        }
+    })
+
+    test('offers only startable courses and no read-only labels in the selects', () => {
+        const { ha } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as unknown as Record<string, { options: string[] }>
+        assert.ok(!components.course_select.options.includes('Unsupported'))
+        assert.ok(!components.dry_level_select.options.includes('Unsupported'))
+        assert.ok(!components.eco_hybrid_select.options.includes('Unsupported'))
+        assert.ok(!components.course_select.options.includes('Off'))
+        // Every offered course must have a captured start template behind it.
+        assert.equal(components.course_select.options.length, 16)
+        // The sensors keep the fallback so an unmapped code still reads back.
+        assert.ok(components.course.options.includes('Unsupported'))
+        assert.ok(components.dry_level.options.includes('Off'))
     })
 
     test('Power off reproduces the exact ThinQ app command captured by MCP', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -334,6 +334,23 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.child_lock, 'OFF')
     })
 
+    test('a frame with a corrupted checksum is dropped, not decoded', () => {
+        // The shared AABBDevice base never verified the checksum it writes
+        // in send(); this device overrides processData to check it on
+        // receive too. Flip a byte in a real captured frame without
+        // recomputing the checksum, and the whole update must be ignored.
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', OFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties.child_lock, 'OFF')
+
+        const corrupted = Buffer.from(CHILD_LOCK_ON)
+        corrupted[10] ^= 0xff // flip a mid-frame byte, checksum left untouched
+        thinq.emit('data', corrupted)
+        assert.equal(ha.devices[DEVICE_ID].properties.child_lock, 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'OFF')
+    })
+
     test('does not mistake the unrelated 0x08 bit for child lock', () => {
         // The first mapping used rec[15] bit 0x08, which is also set in plain
         // idle and paused captures the owner never locked. Those have to read
@@ -874,6 +891,21 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(p.smart_course, 'Powerful Dry')
         assert.equal(p.smart_course_select, 'Powerful Dry')
         assert.equal(p.course_select, 'Standard')
+    })
+
+    test('a torn memory file boots with defaults instead of throwing', () => {
+        // What a crash mid-write used to leave behind: truncated JSON.
+        // Atomic saves make this impossible going forward, but files torn
+        // by older versions must still boot cleanly with defaults.
+        // (A fresh HA connection misses the static remembered map, so this
+        // genuinely exercises the disk path.)
+        writeFileSync(process.env.RETHINK_MEMORY_FILE as string, `{"${DEVICE_ID}": {"downloadedCourse": "Power`)
+        const ha2 = new MockHAConnection()
+        const thinq2 = new MockThinq2Device(DEVICE_ID, META)
+        assert.ok(new DUT(ha2.asConnection(), thinq2, META))
+        const p = ha2.devices[DEVICE_ID].properties
+        assert.equal(p.course_select, 'Standard')
+        assert.equal(p.smart_course, undefined)
     })
 
     test('a fresh idle frame after restart leaves smart_course untouched', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -189,6 +189,7 @@ describe('RH16_T_KR read-only status', () => {
             'power_off',
             'remaining_time',
             'remote_start',
+            'reservation',
             'reserve_hours',
             'reserve_time',
             'resume',
@@ -315,6 +316,14 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.status, 'Reserved')
         thinq.emit('data', STANDARD_SPEED_LOW_RESERVED_3H)
         assert.equal(ha.devices[DEVICE_ID].properties.status, 'Reserved')
+    })
+
+    test('reservation flag follows the same rec[15] byte as anti_crease, bit 0x01', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STANDARD_ENERGY_DELICATE_RESERVED_19H)
+        assert.equal(ha.devices[DEVICE_ID].properties.reservation, 'ON')
+        thinq.emit('data', OFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.reservation, 'OFF')
     })
 
     test('decodes child lock from the isolated real ON and OFF transition', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -1,8 +1,8 @@
-import { describe, test } from 'node:test'
+import { describe, test, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { unlinkSync, writeFileSync } from 'node:fs'
+import { unlinkSync, writeFileSync, chmodSync } from 'node:fs'
 import DUT from '@/cloud/devices/RH16_T_KR'
 import type { Metadata } from '@/cloud/thinq'
 import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
@@ -771,6 +771,37 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.course_select, 'Standard')
     })
 
+    test('repeated identical status frames do not rewrite the memory file', () => {
+        // Give this test its own memory file so it doesn't interfere with
+        // other tests sharing the default one.
+        const memFile = join(tmpdir(), 'rethink-course-memory-dryer-nowrite-test.json')
+        try {
+            unlinkSync(memFile)
+        } catch {
+            // no memory file from a previous run — start clean
+        }
+        const previousMemFile = process.env.RETHINK_MEMORY_FILE
+        process.env.RETHINK_MEMORY_FILE = memFile
+        const warnSpy = mock.method(console, 'warn')
+        try {
+            const { thinq } = makeDevice()
+            thinq.emit('data', STANDARD_DETECTING)
+            // Make the file un-writable: if the driver's cached-entry skip
+            // logic works, later identical frames never call writeFileSync
+            // again and this never gets hit. If it regresses to writing on
+            // every frame, the write fails and is caught internally as a
+            // console.warn (saveMemory never throws).
+            chmodSync(memFile, 0o444)
+            thinq.emit('data', STANDARD_DETECTING)
+            thinq.emit('data', STANDARD_DETECTING)
+            assert.equal(warnSpy.mock.callCount(), 0)
+        } finally {
+            chmodSync(memFile, 0o644)
+            warnSpy.mock.restore()
+            process.env.RETHINK_MEMORY_FILE = previousMemFile
+        }
+    })
+
     test('a restart restores the installed download from disk memory', () => {
         // Arm a download, then build a fresh handler on a fresh HA
         // connection (what a real restart builds: the static remembered map
@@ -785,6 +816,25 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(p.smart_course, 'Powerful Dry')
         assert.equal(p.smart_course_select, 'Powerful Dry')
         assert.equal(p.course_select, 'Downloaded Course')
+    })
+
+    test('a restart restores a native course selection and its options from disk', () => {
+        const first = makeDevice()
+        first.dev.setProperty('course_select', 'Bulky Item')
+        first.dev.setProperty('dry_level_select', 'Standard+')
+        first.dev.setProperty('eco_hybrid_select', 'Energy')
+        first.dev.setProperty('anti_crease_select', 'On')
+        first.dev.setProperty('reserve_hours', '5')
+        const ha2 = new MockHAConnection()
+        const thinq2 = new MockThinq2Device(DEVICE_ID, META)
+        const second = new DUT(ha2.asConnection(), thinq2, META)
+        assert.ok(second)
+        const p = ha2.devices[DEVICE_ID].properties
+        assert.equal(p.course_select, 'Bulky Item')
+        assert.equal(p.dry_level_select, 'Standard+')
+        assert.equal(p.eco_hybrid_select, 'Energy')
+        assert.equal(p.anti_crease_select, 'On')
+        assert.equal(p.reserve_hours, 5)
     })
 
     test('a restart shows an installed-but-idle download without arming it', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -48,6 +48,21 @@ const ANTI_CREASE_ON = buf(
 const ANTI_CREASE_OFF = buf(
     'AA3C30EC001902001E001E070005030003000300019B000000030000007700001902001E001E070005030003000300019900000003000000770051BB',
 )
+const DUVET_RESERVED_4H = buf(
+    'AA3C30EC00190202370237040000030204000400031B00000003000000770000190202370237040000030204000400031900000003000000770039BB',
+)
+const STEAM_REFRESH_RESERVED_3H = buf(
+    'AA3C30EC001903010A010A0500020202023B023B0B1900000002000000770000190200200020010000020103000300011908000003000000770002BB',
+)
+const CONDENSER_CARE_RUNNING = buf(
+    'AA3C30EC00190301000100160000030103000300091900000002000000770000190201140114120000030100000000001908000003000000770084BB',
+)
+const SHIRTS_LOW_AC_ON_RESERVED_3H = buf(
+    'AA3C30EC001902010A010A050002020203000300031B000000030000007700001902010A010A0500020202023B023B031B0000000300000077007FBB',
+)
+const TOWEL_RESERVED_3H = buf(
+    'AA3C30EC00190301000100170000020204000400091B0000000200000077000019020128012802000002000300030001990000000300000077003EBB',
+)
 const STATUS_REQUEST = 'aa0ef0ed1121010000001800b5bb'
 
 function makeDevice() {
@@ -98,6 +113,11 @@ describe('RH16_T_KR read-only status', () => {
             STANDARD_SPEED_LOW_RESERVED_3H,
             ANTI_CREASE_ON,
             ANTI_CREASE_OFF,
+            DUVET_RESERVED_4H,
+            STEAM_REFRESH_RESERVED_3H,
+            CONDENSER_CARE_RUNNING,
+            SHIRTS_LOW_AC_ON_RESERVED_3H,
+            TOWEL_RESERVED_3H,
         ])
             assertIntact(frame)
     })
@@ -108,20 +128,30 @@ describe('RH16_T_KR read-only status', () => {
         assert.deepEqual(Object.keys(components).sort(), [
             'anti_crease',
             'child_lock',
+            'course',
+            'dry_level',
+            'eco_hybrid',
             'error',
             'error_message',
             'pause',
             'power',
+            'power_off',
             'remote_start',
             'smart_diagnosis',
             'status',
+            'steam',
         ])
         for (const [id, component] of Object.entries(components)) {
-            if (id === 'pause') assert.equal(component.command_topic, '$this/pause/set')
+            if (id === 'pause' || id === 'power_off') assert.equal(component.command_topic, `$this/${id}/set`)
             else assert.equal(component.command_topic, undefined)
         }
         assert.equal(components.pause.platform, 'button')
         assert.equal(components.pause.payload_press, '')
+        assert.equal(components.power_off.platform, 'button')
+        assert.equal(components.power_off.payload_press, '')
+        assert.equal(components.course.device_class, 'enum')
+        assert.equal(components.dry_level.device_class, 'enum')
+        assert.equal(components.eco_hybrid.device_class, 'enum')
         assert.equal(components.power.icon, 'mdi:power')
         assert.equal(components.status.icon, 'mdi:tumble-dryer')
         assert.equal(components.child_lock.device_class, 'lock')
@@ -139,6 +169,10 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.error, 'OFF')
         assert.equal(ha.devices[DEVICE_ID].properties.error_message, 'Normal')
         assert.equal(ha.devices[DEVICE_ID].properties.smart_diagnosis, 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'None')
+        assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'None')
+        assert.equal(ha.devices[DEVICE_ID].properties.eco_hybrid, 'None')
+        assert.equal(ha.devices[DEVICE_ID].properties.steam, 'OFF')
     })
 
     test('decodes the real Initial EB snapshot', () => {
@@ -222,6 +256,44 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.remote_start, 'ON')
         thinq.emit('data', REMOTE_START_OFF)
         assert.equal(ha.devices[DEVICE_ID].properties.remote_start, 'OFF')
+    })
+
+    test('decodes course, dry level, eco and steam from real reservation frames', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STANDARD_ENERGY_DELICATE_RESERVED_19H)
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'Standard')
+        assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'Delicate')
+        assert.equal(ha.devices[DEVICE_ID].properties.eco_hybrid, 'Energy')
+        assert.equal(ha.devices[DEVICE_ID].properties.steam, 'OFF')
+        thinq.emit('data', SHIRTS_LOW_AC_ON_RESERVED_3H)
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'Easy Care')
+        assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'Light')
+        assert.equal(ha.devices[DEVICE_ID].properties.eco_hybrid, 'Auto')
+        assert.equal(ha.devices[DEVICE_ID].properties.steam, 'OFF')
+        thinq.emit('data', DUVET_RESERVED_4H)
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'Bulky Item')
+        assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'None')
+        assert.equal(ha.devices[DEVICE_ID].properties.eco_hybrid, 'Speed')
+        assert.equal(ha.devices[DEVICE_ID].properties.steam, 'OFF')
+        thinq.emit('data', TOWEL_RESERVED_3H)
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'Towel')
+        assert.equal(ha.devices[DEVICE_ID].properties.dry_level, 'None')
+        assert.equal(ha.devices[DEVICE_ID].properties.eco_hybrid, 'Auto')
+        assert.equal(ha.devices[DEVICE_ID].properties.steam, 'OFF')
+        thinq.emit('data', STEAM_REFRESH_RESERVED_3H)
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'Steam Refresh')
+        assert.equal(ha.devices[DEVICE_ID].properties.steam, 'ON')
+        thinq.emit('data', CONDENSER_CARE_RUNNING)
+        assert.equal(ha.devices[DEVICE_ID].properties.course, 'Condenser Care')
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Steam')
+        assert.equal(ha.devices[DEVICE_ID].properties.steam, 'ON')
+    })
+
+    test('Power off reproduces the exact ThinQ app command captured by MCP', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('power_off', '')
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(thinq.outbox[0].toString('hex'), 'aa09f0240101009cbb')
     })
 
     test('Pause reproduces the exact ThinQ app command captured by MCP', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -661,6 +661,34 @@ describe('RH16_T_KR read-only status', () => {
         assert.ok((components.course_select.options as string[]).includes('Downloaded Course'))
     })
 
+    // Bridge mode tunnels an app-issued F025 straight to the physical
+    // appliance through send_packet(), bypassing setProperty entirely. HA
+    // must still learn about the change, the same way it would if the
+    // install had been requested from smart_course_select.
+    test('bridge-tunnelled app install updates HA the same as a local select', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('sendData', buf('aa1df0250315000264000000000000001177000000000000000000b7bb'))
+        assert.equal(ha.devices[DEVICE_ID].properties.smart_course_select, 'Powerful Dry')
+        assert.equal(ha.devices[DEVICE_ID].properties.course_select, 'Downloaded Course')
+        assert.equal(ha.devices[DEVICE_ID].properties.smart_course, 'Powerful Dry')
+    })
+
+    test('bridge-tunnelled installs are ignored when the body matches no known course', () => {
+        const { ha, thinq, dev } = makeDevice()
+        thinq.emit('sendData', buf('aa09f0240101009cbb')) // power off, not an install
+        assert.equal(ha.devices[DEVICE_ID].properties.smart_course_select, undefined)
+        assert.equal(ha.devices[DEVICE_ID].properties.course_select, 'Standard')
+    })
+
+    test('bridge-tunnelled install still lets HA start the tunnelled course', () => {
+        const { thinq, dev } = makeDevice()
+        thinq.emit('sendData', buf('aa1df0250315000264000000000000001177000000000000000000b7bb'))
+        thinq.resetRecorder()
+        dev.setProperty('start_course', '')
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(thinq.outbox[0].toString('hex'), 'aa14f026110002640000000000000300770090bb')
+    })
+
     test('starts Powerful Dry through Downloaded Course with the captured F026 frame', () => {
         const { thinq, dev } = makeDevice()
         dev.setProperty('smart_course_select', 'Powerful Dry')

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -42,6 +42,12 @@ const STANDARD_ENERGY_DELICATE_RESERVED_19H = buf(
 const STANDARD_SPEED_LOW_RESERVED_3H = buf(
     'AA3C30EC001903013701370700010102123A123A091B000000020000007700001902001E001E07000203000300030001990000000300000077001EBB',
 )
+const ANTI_CREASE_ON = buf(
+    'AA3C30EC001903011401140700040202033B033B0919000000020000007700001902001E001E0700050300030003000399000000030000007700A5BB',
+)
+const ANTI_CREASE_OFF = buf(
+    'AA3C30EC001902001E001E070005030003000300019B000000030000007700001902001E001E070005030003000300019900000003000000770051BB',
+)
 const STATUS_REQUEST = 'aa0ef0ed1121010000001800b5bb'
 
 function makeDevice() {
@@ -90,6 +96,8 @@ describe('RH16_T_KR read-only status', () => {
             STANDARD_PAUSED,
             STANDARD_ENERGY_DELICATE_RESERVED_19H,
             STANDARD_SPEED_LOW_RESERVED_3H,
+            ANTI_CREASE_ON,
+            ANTI_CREASE_OFF,
         ])
             assertIntact(frame)
     })
@@ -98,6 +106,7 @@ describe('RH16_T_KR read-only status', () => {
         const { ha } = makeDevice()
         const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
         assert.deepEqual(Object.keys(components).sort(), [
+            'anti_crease',
             'child_lock',
             'error',
             'error_message',
@@ -197,6 +206,14 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.child_lock, 'ON')
         thinq.emit('data', CHILD_LOCK_OFF)
         assert.equal(ha.devices[DEVICE_ID].properties.child_lock, 'OFF')
+    })
+
+    test('decodes anti-crease from the single-toggle ON and OFF pair', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', ANTI_CREASE_ON)
+        assert.equal(ha.devices[DEVICE_ID].properties.anti_crease, 'ON')
+        thinq.emit('data', ANTI_CREASE_OFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.anti_crease, 'OFF')
     })
 
     test('decodes remote start from the isolated real ON and OFF transition', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -1,0 +1,83 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import DUT from '@/cloud/devices/RH16_T_KR'
+import type { Metadata } from '@/cloud/thinq'
+import { MockHAConnection, MockThinq2Device, buf } from '@/tests/helpers/mocks'
+
+const DEVICE_ID = 'test-id'
+const META: Metadata = { modelId: 'RH16_T_KR', modelName: 'RH16_T_KR', swVersion: '2.10.122' }
+
+// Real frames captured from the owner's RH16_T_KR. OFF is the current state
+// after a live reconnect; INITIAL and the EC transition are historical traffic
+// from the same appliance.
+const OFF = buf('AA2130EB00190000000000000000000000000000000000000000000000770023BB')
+const INITIAL = buf('AA2130EB001901000000000000000000000000000804000000000000007700D6BB')
+const DOUBLE_INITIAL = buf(
+    'AA3C30EC00190100000000000000000000000000080400000000000000770000190100000000000000000000000000000400000000000000770061BB',
+)
+const STATUS_REQUEST = 'aa0ef0ed1121010000001800b5bb'
+
+function makeDevice() {
+    const ha = new MockHAConnection()
+    const thinq = new MockThinq2Device(DEVICE_ID, META)
+    const dev = new DUT(ha.asConnection(), thinq, META)
+    return { ha, thinq, dev }
+}
+
+function assertIntact(packet: Buffer) {
+    assert.equal(packet[1], packet.length)
+    const sum = packet.subarray(0, packet.length - 2).reduce((a, b) => a + b, 0)
+    assert.equal(packet[packet.length - 2], (sum & 0xff) ^ 0x55)
+}
+
+describe('RH16_T_KR read-only status', () => {
+    test('real capture fixtures have intact AA/BB envelopes', () => {
+        for (const frame of [OFF, INITIAL, DOUBLE_INITIAL]) assertIntact(frame)
+    })
+
+    test('exposes only read-only Power and Status sensors', () => {
+        const { ha } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
+        assert.deepEqual(Object.keys(components).sort(), ['power', 'status'])
+        for (const component of Object.values(components)) assert.equal(component.command_topic, undefined)
+        assert.equal(components.power.icon, 'mdi:tumble-dryer')
+        assert.equal(components.status.icon, 'mdi:tumble-dryer')
+    })
+
+    test('decodes the current real powered-off EB snapshot', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', OFF)
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'OFF')
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Power off')
+    })
+
+    test('decodes the real Initial EB snapshot', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', INITIAL)
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Initial')
+    })
+
+    test('uses the current record in a real EC frame', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', OFF)
+        thinq.emit('data', DOUBLE_INITIAL)
+        assert.equal(ha.devices[DEVICE_ID].properties.power, 'ON')
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Initial')
+    })
+
+    test('asks only for the family-wide read-only status snapshot on connect', () => {
+        const { thinq, dev } = makeDevice()
+        dev.start()
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(thinq.outbox[0].toString('hex'), STATUS_REQUEST)
+    })
+
+    test('ignores other device types and malformed RH16 status shapes', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', buf('AA2120EB00190000000000000000000000000000000000000000000000770033BB'))
+        thinq.emit('data', buf('AA0730EB00A8BB'))
+        assert.equal(ha.devices[DEVICE_ID].properties.power, undefined)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, undefined)
+    })
+})

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -153,6 +153,7 @@ describe('RH16_T_KR read-only status', () => {
             'pause',
             'power',
             'power_off',
+            'previous_status',
             'remaining_time',
             'remote_start',
             'reserve_hours',
@@ -444,6 +445,53 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.reserve_time, 13 * 60 + 56)
         assert.equal(ha.devices[DEVICE_ID].properties.status, 'Reserved')
         assert.equal(ha.devices[DEVICE_ID].properties.course, 'Steam Refresh')
+    })
+
+    test('publishes the previous state from the leading record of an EC frame', () => {
+        // An EC frame stacks the prior state at offset 3 and the current one
+        // at 30. The child lock toggle frames are a clean pair: the record
+        // only differs by the lock bit, so the phase reads the same on both.
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STEAM_REFRESH_RESERVED_14H_PARTWAY)
+        assert.equal(ha.devices[DEVICE_ID].properties.status, 'Reserved')
+        assert.equal(ha.devices[DEVICE_ID].properties.previous_status, 'Reserved')
+    })
+
+    test('leaves the previous state alone for a single-record EB frame', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', STEAM_REFRESH_RESERVED_14H_PARTWAY)
+        const seen = ha.devices[DEVICE_ID].properties.previous_status
+        thinq.emit('data', INITIAL)
+        assert.equal(ha.devices[DEVICE_ID].properties.previous_status, seen)
+    })
+
+    test('every Status value it can publish is a declared option', () => {
+        // device_class enum forces any value outside options to unknown, so a
+        // fallback like `Code 12` would blank the entity instead of informing.
+        const { ha, thinq } = makeDevice()
+        const components = ha.devices[DEVICE_ID].config!.components as unknown as Record<string, { options: string[] }>
+        const frames = [
+            INITIAL,
+            OFF,
+            STANDARD_ENERGY_DELICATE_RESERVED_19H,
+            STANDARD_DETECTING,
+            STANDARD_DRYING,
+            STANDARD_PAUSED,
+            STEAM_REFRESH_RESERVED_14H_PARTWAY,
+            CONDENSER_CARE_RUNNING,
+            CHILD_LOCK_ON,
+        ]
+        for (const frame of frames) {
+            thinq.emit('data', frame)
+            const { status, previous_status } = ha.devices[DEVICE_ID].properties
+            assert.ok(components.status.options.includes(status as string), `status ${status}`)
+            if (previous_status !== undefined) {
+                assert.ok(
+                    components.previous_status.options.includes(previous_status as string),
+                    `previous_status ${previous_status}`,
+                )
+            }
+        }
     })
 
     test('never publishes the literal None, which HA reads as unknown', () => {

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -472,6 +472,21 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(thinq.outbox[0].toString('hex'), 'aa14f0260703020000000000000001000000b4bb')
     })
 
+    test('reserve_hours=1 or 2 is refused: LG declares 0 or 3..19, not 1 or 2', () => {
+        const { ha, dev } = makeDevice()
+        dev.setProperty('reserve_hours', '1')
+        assert.equal(ha.devices[DEVICE_ID].properties.reserve_hours, 0)
+        dev.setProperty('reserve_hours', '2')
+        assert.equal(ha.devices[DEVICE_ID].properties.reserve_hours, 0)
+        // 0 and the declared 3..19 bounds remain accepted.
+        dev.setProperty('reserve_hours', '3')
+        assert.equal(ha.devices[DEVICE_ID].properties.reserve_hours, 3)
+        dev.setProperty('reserve_hours', '19')
+        assert.equal(ha.devices[DEVICE_ID].properties.reserve_hours, 19)
+        dev.setProperty('reserve_hours', '20')
+        assert.equal(ha.devices[DEVICE_ID].properties.reserve_hours, 19)
+    })
+
     test('selecting a course resets options to the model defaults', () => {
         const { ha, dev } = makeDevice()
         dev.setProperty('course_select', 'Bulky Item')

--- a/tests/cloud/devices/RH16_T_KR.test.ts
+++ b/tests/cloud/devices/RH16_T_KR.test.ts
@@ -506,8 +506,9 @@ describe('RH16_T_KR read-only status', () => {
         assert.ok(!components.dry_level_select.options.includes('Unsupported'))
         assert.ok(!components.eco_hybrid_select.options.includes('Unsupported'))
         assert.ok(!components.course_select.options.includes('Off'))
-        // Every offered course must have a captured start template behind it.
-        assert.equal(components.course_select.options.length, 16)
+        // Every offered native course and Downloaded Course has a start path.
+        assert.equal(components.course_select.options.length, 17)
+        assert.ok(components.course_select.options.includes('Downloaded Course'))
         // The sensors keep the fallback so an unmapped code still reads back.
         assert.ok(components.course.options.includes('Unsupported'))
         assert.ok(components.dry_level.options.includes('Off'))
@@ -629,9 +630,57 @@ describe('RH16_T_KR read-only status', () => {
         assert.equal(ha.devices[DEVICE_ID].properties.status, 'Reserved')
         const components = ha.devices[DEVICE_ID].config!.components as Record<string, Record<string, unknown>>
         assert.ok((components.course.options as string[]).includes('Downloaded Course'))
-        // Prepared in the sensor enum but not offered for control until a
-        // downloaded-course F026 start frame is captured.
-        assert.ok(!(components.course_select.options as string[]).includes('Downloaded Course'))
+        assert.ok((components.course_select.options as string[]).includes('Downloaded Course'))
+    })
+
+    test('starts Powerful Dry through Downloaded Course with the captured F026 frame', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('smart_course_select', 'Powerful Dry')
+        dev.setProperty('course_select', 'Downloaded Course')
+        dev.setProperty('start_course', '')
+        assert.equal(thinq.outbox.length, 2)
+        assert.equal(thinq.outbox[0].toString('hex'), 'aa1df0250315000264000000000000001177000000000000000000b7bb')
+        assert.equal(thinq.outbox[1].toString('hex'), 'aa14f026110002640000000000000300770090bb')
+    })
+
+    test('starts Wrinkle Care Dry through Downloaded Course with the captured F026 frame', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('smart_course_select', 'Wrinkle Care Dry')
+        dev.setProperty('course_select', 'Downloaded Course')
+        dev.setProperty('start_course', '')
+        assert.equal(thinq.outbox.length, 2)
+        assert.equal(thinq.outbox[1].toString('hex'), 'aa14f0260703025a00000000000203007200e4bb')
+    })
+
+    test('builds a checksummed start frame for every captured download definition', () => {
+        const expected: Record<string, string> = {
+            'Powerful Dry': 'aa14f026110002640000000000000300770090bb',
+            'Wrinkle Care Dry': 'aa14f0260703025a00000000000203007200e4bb',
+            'Full Size Load': 'aa14f0260705036400000000000003007400ebbb',
+            Refresh: 'aa14f0260f00031400000000000003006b003dbb',
+            'Small Load': 'aa14f0260e00031e00000000000003006c0027bb',
+            'Gym Clothes': 'aa14f0260800013d00000000000003006600d6bb',
+            'Rainy Season': 'aa14f0260e000328000000000000030069002cbb',
+            'Economic Dry': 'aa14f0260703017d000000000000030070009abb',
+            'Easy Iron': 'aa14f0260701034100000000000003006e00c4bb',
+            'Big Size Item': 'aa14f026040003af00000000000003007100abbb',
+        }
+        for (const [course, frame] of Object.entries(expected)) {
+            const { thinq, dev } = makeDevice()
+            dev.setProperty('smart_course_select', course)
+            dev.setProperty('course_select', 'Downloaded Course')
+            dev.setProperty('start_course', '')
+            assert.equal(thinq.outbox[1].toString('hex'), frame, course)
+            assertIntact(thinq.outbox[1])
+        }
+    })
+
+    test('does not guess a downloaded start or resume without captured state', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('course_select', 'Downloaded Course')
+        dev.setProperty('start_course', '')
+        dev.setProperty('resume', '')
+        assert.equal(thinq.outbox.length, 0)
     })
 
     test('asks only for the family-wide read-only status snapshot on connect', () => {


### PR DESCRIPTION
## Summary

Adds first-class support for the **LG RH16VT 16 kg heat-pump dryer** (ThinQ model `RH16_T_KR`, `deviceType: 202`). This is a dedicated AA/BB handler built from captures from the physical dryer.

It supports detailed state reporting, 16 confirmed native courses, all 10 downloadable courses, course and option controls, reservation, pause/resume, remote power off, restart-safe smart-course tracking, and this-cycle energy.

## What is supported

- 16 native courses with captured `F026` start templates
- All 10 downloadable courses with exact captured `F025` install frames
- Downloadable start generation from two structurally different exact `F026` captures plus each course's own captured definition and signature
- Course, dry-level, Eco Hybrid, Anti crease, and reservation controls (0 or 3 to 19 hours; 1-2h rejected per LG's declared range)
- Start, pause, native resume, and remote power off
- Power, status, course, smart course, dry level, Eco Hybrid, steam, Anti crease, remote start, child lock, duration, errors, diagnosis, and energy sensors

Downloaded-course resume remains intentionally disabled because no matching resume frame has been captured.

## State protocol

The dryer reports either one current 26-byte record (`EB`) or a previous/current pair (`EC`). For `EC`, only the trailing current record is published.

Confirmed fields include:

- `record[1]`: top-level state
- `record[2..5]`: remaining and initial time
- `record[6]`: native/download execution course
- `record[7]`: error
- `record[8]`: dry level
- `record[9]`: Eco Hybrid
- `record[10]`: process phase
- `record[11..14]`: reservation times
- `record[15]` bits: Anti crease and child lock
- `record[16]` bit: remote-start availability
- `record[17]` bit: steam
- `record[18..19]`: this-cycle energy, 16-bit big-endian Wh
- `record[21]`: downloadable-course signature

## Downloadable courses

All ten captured downloads can be installed through `smart_course_select`:

- Powerful Dry
- Wrinkle Care Dry
- Full Size Load
- Refresh
- Small Load
- Gym Clothes
- Rainy Season
- Economic Dry
- Easy Iron
- Big Size Item

Several downloads reuse the same execution-course byte. The handler therefore identifies them using the captured `(record[6], record[21])` pair. Every pair was verified in a live reserved run.

## Energy

`record[18..19]` is cumulative energy for the current cycle in Wh, multiplier 1. During a complete dryer cycle it rose from 14 to 694 across the regular status frames and froze at completion. The ThinQ app showed exactly 694Wh for the same day. The old placeholder zero has been removed.

## Smart-course behavior and restarts

Idle/native frames do not prove that the installed download disappeared. `smart_course` therefore keeps showing the installed course whether it runs or not and is never asserted to Unknown merely because the dryer is idle or running a native course.

The installed course and selects are kept in process and in `/app/data/rethink-course-memory.json`. A real rethink restart restores and republishes them. Known status frames re-assert the installed course so stale Home Assistant state converges. This matches the F24VDD washer convention.

App-issued download frames observed through the bridge update the same state as a Home Assistant selection.

## Safety boundaries

- No remote power-on command because none was captured.
- Child lock is read-only because only its physical-panel state transition was captured.
- Downloadable resume sends nothing because no such frame was captured.
- Rack Dry and Cool Air are not exposed because no labelled start/state capture was available.
- Writes outside the selected native course's captured option ranges are refused rather than guessed.

## Recent updates

- Energy sensor renamed from Power to Energy (`device_class: energy`, Wh, `total_increasing`).
- Reservation flag exposed as its own entity.
- Option persistence ordering fixed; memory file is no longer rewritten when nothing changed.
- `reserve_hours` 1-2h rejected, matching LG's declared 0-or-3..19 range.
- Incoming AABB checksum is now verified on receive; corrupted frames are dropped instead of decoded.
- Course memory is saved atomically (temp file, fsync, rename) so a crash mid-write can no longer leave a torn file; torn files from older versions still boot with defaults.
- Energy is a plain sensor again (no `entity_category`), matching the washer and the other Wh handlers in the repo.

## Verification

- `npm run check`: pass
- RH16_T_KR tests: **62/62 pass**
- Full branch suite: **660/660 pass**
- Prettier: pass
- Local all-device deployment suite: **893/893 pass**
- Deployed as `rethink-local:latest`; all eight configured devices reconnected

## Files

- `cloud/devices/RH16_T_KR.ts`
- `tests/cloud/devices/RH16_T_KR.test.ts`
- `cloud/ha_bridge.ts`
- `README.md`