### PR TITLE
Add clock and beeper controls for the MVEM1825 microwave and LREL6323S range

### DIFF
--- a/cloud/devices/WLREL6323S.ts
+++ b/cloud/devices/WLREL6323S.ts
@@ -12,7 +12,9 @@ import { Enum } from '@/util/enum'
 // Captures from the physical panel establish the single-cavity oven fields, door-open bit,
 // and aggregate cooktop state. Normal elements and the warming zone use different bytes, but
 // individual normal elements report the same transition, so no individual entities are exposed.
-// Writes remain disabled until their complete command shapes and appliance interlocks are captured.
+// The only writes are the Preferences frame shared with the WFV474PGV oven (clock, clock format and
+// beeper), verified on a live range. Cooking writes remain disabled until their complete command
+// shapes and appliance interlocks are captured.
 
 const CLASS_BYTE = 0x40
 const SINGLE_STATUS_FRAME_TYPE = 0xeb
@@ -50,7 +52,39 @@ const OVEN_MODES = Enum.of({
 // Observed from LG's cloud and confirmed against the WLREL6323S: the reply is a 40 EB status frame.
 const STATUS_QUERY = 'f0ed114101000000181a0207080c14191a1e262b30353a00000000000000000000000000'
 
+// Preference write: the same F0 43 21 frame and 13-byte payload as the WFV474PGV oven's, where every
+// field the write does not set goes out as the 0x80 "no change" sentinel and index 11 as 0xFF.
+// Verified on a live WLREL6323S on 2026-09-10, each write acknowledged 40 00 43 00:
+//   0, 1   clock hour and minute
+//   2      clock format. 0x00 with a 0-23 hour switched the display to 24-hour; 0x01 with a 1-12
+//          hour put it back to 12-hour. The format travels with every clock write, so the time cannot
+//          be set without also choosing the format.
+//   11     beeper. 0x00 silenced the panel keys, 0x02 brought them back. The double oven keeps a
+//          0xFF sentinel here; on this range it lines up with the cooktop beeper the LSIS6338FE
+//          reports, which offers only Mute and High.
+// Index 8 is the double oven's beeper volume. Writing 0x00 there was acknowledged but left the keys
+// beeping, so it is not exposed.
+const PREFERENCE_COMMAND_PREFIX = [0xf0, 0x43, 0x21, 0x0e]
+const PREFERENCE_PAYLOAD_LENGTH = 13
+const PREFERENCE_NO_CHANGE = 0x80
+const PREFERENCE_FF_INDEX = 11
+const PREFERENCE_FF_NO_CHANGE = 0xff
+const CLOCK_HOURS_INDEX = 0
+const CLOCK_MINUTES_INDEX = 1
+const CLOCK_FORMAT_INDEX = 2
+const CLOCK_FORMATS = Enum.of({ '12-hour': 0x01, '24-hour': 0x00 })
+const BEEPER_VOLUME_INDEX = 11
+const BEEPER_VOLUMES = Enum.of({ High: 0x02, Mute: 0x00 })
+
+// Write acknowledgement: 40 00 <command family> <result>, result 0x00 on success.
+const ACK_FRAME_TYPE = 0x00
+const PREFERENCE_COMMAND_FAMILY = 0x43
+
 export default class Device extends AABBDevice {
+    // The range cannot be asked for its format. Assume 12-hour (the US default and the tested unit's
+    // setting) until HA selects otherwise.
+    clockFormat = 0x01
+
     constructor(HA: Connection, thinq: Thinq2Device, meta: Metadata) {
         super(HA, thinq)
         this.setConfig(
@@ -102,6 +136,37 @@ export default class Device extends AABBDevice {
                         payload_on: 'ON',
                         payload_off: 'OFF',
                     },
+                    // No status record carries the clock, so this is write-only, like the oven's.
+                    clock_sync: {
+                        platform: 'button',
+                        icon: 'mdi:clock-check-outline',
+                        unique_id: '$deviceid-clock_sync',
+                        command_topic: '$this/clock_sync/set',
+                        payload_press: 'PRESS',
+                        name: 'Sync Clock',
+                    },
+                    // The range never reports its clock format, so HA tracks the selection itself.
+                    // Choosing one re-sends the current time in that format, since the two always
+                    // travel together.
+                    clock_format: {
+                        platform: 'select',
+                        icon: 'mdi:clock-outline',
+                        unique_id: '$deviceid-clock_format',
+                        command_topic: '$this/clock_format/set',
+                        options: CLOCK_FORMATS.options,
+                        optimistic: true,
+                        name: 'Clock Format',
+                    },
+                    // Write-only for the same reason as the clock format.
+                    beeper_volume: {
+                        platform: 'select',
+                        icon: 'mdi:volume-high',
+                        unique_id: '$deviceid-beeper_volume',
+                        command_topic: '$this/beeper_volume/set',
+                        options: BEEPER_VOLUMES.options,
+                        optimistic: true,
+                        name: 'Beeper Volume',
+                    },
                 },
             }),
         )
@@ -113,6 +178,11 @@ export default class Device extends AABBDevice {
 
     processAABB(buf: Buffer) {
         if (buf.length >= 2 && buf[0] === CLASS_BYTE) {
+            if (buf.length === 4 && buf[1] === ACK_FRAME_TYPE && buf[2] === PREFERENCE_COMMAND_FAMILY) {
+                if (buf[3] !== 0x00) log('WLREL6323S', 'command rejected by the range', buf.toString('hex'))
+                return
+            }
+
             if (buf[1] === SINGLE_STATUS_FRAME_TYPE && buf.length === 2 + STATUS_RECORD_LENGTH) {
                 this.publishStatus(buf.subarray(2))
                 return
@@ -142,6 +212,60 @@ export default class Device extends AABBDevice {
 
         const cooktopOn = COOKTOP_STATE_OFFSETS.some((offset) => current[offset] !== 0)
         this.publishProperty('cooktop_status', cooktopOn ? 'ON' : 'OFF')
+    }
+
+    setProperty(prop: string, mqttValue: string) {
+        if (prop === 'clock_sync') {
+            if (mqttValue === 'PRESS') this.syncClock()
+            return
+        }
+
+        if (prop === 'clock_format') {
+            const format = CLOCK_FORMATS.unmap(mqttValue)
+            if (format === undefined) return
+            this.clockFormat = format
+            this.syncClock()
+            return
+        }
+
+        if (prop === 'beeper_volume') {
+            const volume = BEEPER_VOLUMES.unmap(mqttValue)
+            if (volume !== undefined) this.sendBeeperVolume(volume)
+            return
+        }
+
+        super.setProperty(prop, mqttValue)
+    }
+
+    // Starts from an all-sentinel payload so anything the write does not set goes out as "no change".
+    static preferencePayload() {
+        const payload = Buffer.alloc(PREFERENCE_PAYLOAD_LENGTH, PREFERENCE_NO_CHANGE)
+        payload[PREFERENCE_FF_INDEX] = PREFERENCE_FF_NO_CHANGE
+        return payload
+    }
+
+    sendPreference(payload: Buffer) {
+        this.send(Buffer.concat([Buffer.from(PREFERENCE_COMMAND_PREFIX), payload]))
+    }
+
+    syncClock() {
+        const now = new Date()
+        this.sendClock(now.getHours(), now.getMinutes(), this.clockFormat)
+    }
+
+    // hours is always 0-23; the 12-hour format carries it as 1-12.
+    sendClock(hours: number, minutes: number, format: number) {
+        const payload = Device.preferencePayload()
+        payload[CLOCK_HOURS_INDEX] = format === CLOCK_FORMATS.unmap('12-hour') ? hours % 12 || 12 : hours
+        payload[CLOCK_MINUTES_INDEX] = minutes
+        payload[CLOCK_FORMAT_INDEX] = format
+        this.sendPreference(payload)
+    }
+
+    sendBeeperVolume(volume: number) {
+        const payload = Device.preferencePayload()
+        payload[BEEPER_VOLUME_INDEX] = volume
+        this.sendPreference(payload)
     }
 
     // HA rejects any value outside the declared options, so an undecoded byte is published as

--- a/cloud/devices/WLREL6323S.ts
+++ b/cloud/devices/WLREL6323S.ts
@@ -135,7 +135,6 @@ export default class Device extends AABBDevice {
                         payload_on: 'ON',
                         payload_off: 'OFF',
                     },
-                    // No status record carries the clock, so this is write-only, like the oven's.
                     clock_sync: {
                         platform: 'button',
                         icon: 'mdi:clock-check-outline',
@@ -236,7 +235,6 @@ export default class Device extends AABBDevice {
         super.setProperty(prop, mqttValue)
     }
 
-    // Starts from an all-sentinel payload so anything the write does not set goes out as "no change".
     static preferencePayload() {
         const payload = Buffer.alloc(PREFERENCE_PAYLOAD_LENGTH, PREFERENCE_NO_CHANGE)
         payload[PREFERENCE_FF_INDEX] = PREFERENCE_FF_NO_CHANGE

--- a/cloud/devices/WLREL6323S.ts
+++ b/cloud/devices/WLREL6323S.ts
@@ -13,8 +13,7 @@ import { Enum } from '@/util/enum'
 // and aggregate cooktop state. Normal elements and the warming zone use different bytes, but
 // individual normal elements report the same transition, so no individual entities are exposed.
 // The only writes are the Preferences frame shared with the WFV474PGV oven (clock, clock format and
-// beeper), verified on a live range. Cooking writes remain disabled until their complete command
-// shapes and appliance interlocks are captured.
+// beeper), verified on a live range.
 
 const CLASS_BYTE = 0x40
 const SINGLE_STATUS_FRAME_TYPE = 0xeb

--- a/cloud/devices/WMVEM1825.ts
+++ b/cloud/devices/WMVEM1825.ts
@@ -103,7 +103,6 @@ export default class Device extends AABBDevice {
                         name: 'Cooktop light',
                         icon: 'mdi:lightbulb',
                     },
-                    // No status record carries the clock, so this is write-only, like the oven's.
                     clock_sync: {
                         platform: 'button',
                         icon: 'mdi:clock-check-outline',
@@ -197,7 +196,6 @@ export default class Device extends AABBDevice {
         )
     }
 
-    // Starts from an all-sentinel payload so anything the write does not set goes out as "no change".
     static preferencePayload() {
         const payload = Buffer.alloc(PREFERENCE_PAYLOAD_LENGTH, PREFERENCE_NO_CHANGE)
         payload[PREFERENCE_FF_INDEX] = PREFERENCE_FF_NO_CHANGE

--- a/cloud/devices/WMVEM1825.ts
+++ b/cloud/devices/WMVEM1825.ts
@@ -14,6 +14,29 @@ const STATUS = Enum.of({
     'Ready to start': 0x07,
 })
 
+// Preference write: the same F0 43 21 frame and payload layout as the WFV474PGV oven's, where every
+// field the write does not set goes out as the 0x80 "no change" sentinel and index 11 as 0xFF.
+// Verified on a live MVEM1825: indices 0-2 set the displayed clock, and index 3 is the beeper, which
+// the oven keeps at index 8 (writing index 8 here is acknowledged but changes nothing).
+const PREFERENCE_COMMAND_PREFIX = [0xf0, 0x43, 0x21, 0x0e]
+const PREFERENCE_PAYLOAD_LENGTH = 13
+const PREFERENCE_NO_CHANGE = 0x80
+const PREFERENCE_FF_INDEX = 11
+const PREFERENCE_FF_NO_CHANGE = 0xff
+const CLOCK_HOURS_INDEX = 0
+const CLOCK_MINUTES_INDEX = 1
+const CLOCK_HOUR_FORMAT_INDEX = 2
+// 0x00 carries a 0-23 hour. It is the form the oven handler writes, and the one verified here.
+const CLOCK_HOUR_FORMAT_24H = 0x00
+const BEEPER_INDEX = 3
+// Writing 1, 2 or 3 all read back as the same status, so the appliance offers only on and off.
+const BEEPER_ON = 0x01
+const BEEPER_OFF = 0x00
+// Unlike the oven, the microwave reports the setting: rec[35]'s low two bits read 3 while the keys
+// beep and 0 once muted.
+const BEEPER_STATUS_OFFSET = 35
+const BEEPER_STATUS_MASK = 0x03
+
 export default class Device extends AABBDevice {
     fanSpeed = 0
     lightLevel = 0
@@ -80,6 +103,25 @@ export default class Device extends AABBDevice {
                         name: 'Cooktop light',
                         icon: 'mdi:lightbulb',
                     },
+                    // No status record carries the clock, so this is write-only, like the oven's.
+                    clock_sync: {
+                        platform: 'button',
+                        icon: 'mdi:clock-check-outline',
+                        unique_id: '$deviceid-clock_sync',
+                        command_topic: '$this/clock_sync/set',
+                        payload_press: 'PRESS',
+                        name: 'Sync clock',
+                    },
+                    beeper: {
+                        platform: 'switch',
+                        icon: 'mdi:volume-high',
+                        unique_id: '$deviceid-beeper',
+                        state_topic: '$this/beeper',
+                        command_topic: '$this/beeper/set',
+                        payload_on: 'ON',
+                        payload_off: 'OFF',
+                        name: 'Beeper',
+                    },
                 },
             }),
         )
@@ -111,6 +153,7 @@ export default class Device extends AABBDevice {
             this.publishProperty('light_power', lightLevel > 0 ? 'ON' : 'OFF')
             this.publishProperty('light_level', lightLevel)
         }
+        this.publishProperty('beeper', (rec[BEEPER_STATUS_OFFSET] & BEEPER_STATUS_MASK) !== 0 ? 'ON' : 'OFF')
     }
 
     processAABB(buf: Buffer) {
@@ -154,6 +197,31 @@ export default class Device extends AABBDevice {
         )
     }
 
+    // Starts from an all-sentinel payload so anything the write does not set goes out as "no change".
+    static preferencePayload() {
+        const payload = Buffer.alloc(PREFERENCE_PAYLOAD_LENGTH, PREFERENCE_NO_CHANGE)
+        payload[PREFERENCE_FF_INDEX] = PREFERENCE_FF_NO_CHANGE
+        return payload
+    }
+
+    sendPreference(payload: Buffer) {
+        this.send(Buffer.concat([Buffer.from(PREFERENCE_COMMAND_PREFIX), payload]))
+    }
+
+    sendClock(hours: number, minutes: number) {
+        const payload = Device.preferencePayload()
+        payload[CLOCK_HOURS_INDEX] = hours
+        payload[CLOCK_MINUTES_INDEX] = minutes
+        payload[CLOCK_HOUR_FORMAT_INDEX] = CLOCK_HOUR_FORMAT_24H
+        this.sendPreference(payload)
+    }
+
+    sendBeeper(on: boolean) {
+        const payload = Device.preferencePayload()
+        payload[BEEPER_INDEX] = on ? BEEPER_ON : BEEPER_OFF
+        this.sendPreference(payload)
+    }
+
     setProperty(prop: string, mqttValue: string) {
         if (prop === 'fan_power') {
             this.fanSpeed = mqttValue === 'ON' ? this.fanSpeed || 1 : 0
@@ -171,6 +239,12 @@ export default class Device extends AABBDevice {
             if (!Number.isFinite(value)) return
             this.lightLevel = Math.min(2, Math.max(0, Math.round(value)))
             this.sendHoodCommand()
+        } else if (prop === 'clock_sync') {
+            if (mqttValue !== 'PRESS') return
+            const now = new Date()
+            this.sendClock(now.getHours(), now.getMinutes())
+        } else if (prop === 'beeper') {
+            if (mqttValue === 'ON' || mqttValue === 'OFF') this.sendBeeper(mqttValue === 'ON')
         } else {
             console.warn(`Unknown property ${prop}`)
         }

--- a/tests/cloud/devices/WLREL6323S.test.ts
+++ b/tests/cloud/devices/WLREL6323S.test.ts
@@ -228,7 +228,6 @@ describe(MODEL_ID, () => {
         assert.ok(payload(thinq.outbox[0])[0] >= 1 && payload(thinq.outbox[0])[0] <= 12)
         assert.deepEqual([...payload(thinq.outbox[0]).subarray(3)], [...Array(8).fill(0x80), 0xff, 0x80])
 
-        // Selecting a format re-sends the time in it, and later syncs follow the selection.
         dev.setProperty('clock_format', '24-hour')
         dev.setProperty('clock_sync', 'PRESS')
         assert.equal(thinq.outbox.length, 3)

--- a/tests/cloud/devices/WLREL6323S.test.ts
+++ b/tests/cloud/devices/WLREL6323S.test.ts
@@ -101,6 +101,14 @@ describe(MODEL_ID, () => {
         assert.equal(components.oven_door.device_class, 'door')
         assert.equal(components.oven_door.icon, undefined)
         assert.equal(components.oven_status.command_topic, undefined)
+        assert.equal(components.clock_sync.platform, 'button')
+        assert.equal(components.clock_sync.command_topic, '$this/clock_sync/set')
+        assert.equal(components.clock_format.platform, 'select')
+        assert.deepEqual(components.clock_format.options, ['12-hour', '24-hour'])
+        assert.equal(components.clock_format.optimistic, true)
+        assert.equal(components.beeper_volume.platform, 'select')
+        assert.deepEqual(components.beeper_volume.options, ['High', 'Mute'])
+        assert.equal(components.beeper_volume.optimistic, true)
     })
 
     test('start sends the captured status query', () => {
@@ -185,6 +193,74 @@ describe(MODEL_ID, () => {
 
     test('does not mask unknown oven-mode bits into a known mode', () => {
         assert.equal(DUT.formatOvenMode(0x81), undefined)
+    })
+
+    // Sent to a live WLREL6323S on 2026-09-10, both acknowledged 40 00 43 00. The first (13:11,
+    // byte 2 = 0x00) switched the display to 24-hour; the second (1:13 with byte 2 = 0x01) restored
+    // 12-hour, confirmed at the panel.
+    test('clock writes reproduce both frames verified on the appliance', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.sendClock(13, 11, 0x00)
+        dev.sendClock(13, 13, 0x01)
+
+        assert.equal(thinq.outbox.length, 2)
+        assert.equal(hex(thinq.outbox[0]), 'AA15F043210E0D0B008080808080808080FF80EDBB')
+        assert.equal(hex(thinq.outbox[1]), 'AA15F043210E010D018080808080808080FF80FABB')
+    })
+
+    test('12-hour clock writes carry midnight and noon as 12', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.sendClock(0, 5, 0x01)
+        dev.sendClock(12, 5, 0x01)
+
+        assert.equal(thinq.outbox[0][6], 12)
+        assert.equal(thinq.outbox[1][6], 12)
+    })
+
+    test('clock sync keeps the 12-hour format until another is selected', () => {
+        const { thinq, dev } = makeDevice()
+        const payload = (frame: Buffer) => frame.subarray(6, frame.length - 2)
+
+        dev.setProperty('clock_sync', 'PRESS')
+        assert.equal(payload(thinq.outbox[0])[2], 0x01)
+        assert.ok(payload(thinq.outbox[0])[0] >= 1 && payload(thinq.outbox[0])[0] <= 12)
+        assert.deepEqual([...payload(thinq.outbox[0]).subarray(3)], [...Array(8).fill(0x80), 0xff, 0x80])
+
+        // Selecting a format re-sends the time in it, and later syncs follow the selection.
+        dev.setProperty('clock_format', '24-hour')
+        dev.setProperty('clock_sync', 'PRESS')
+        assert.equal(thinq.outbox.length, 3)
+        assert.equal(payload(thinq.outbox[1])[2], 0x00)
+        assert.equal(payload(thinq.outbox[2])[2], 0x00)
+        assert.ok(payload(thinq.outbox[2])[0] < 24)
+    })
+
+    // Mute was sent live and silenced the panel keys; High (0x02) brought them back.
+    test('beeper volume writes only payload index 11', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.setProperty('beeper_volume', 'Mute')
+        dev.setProperty('beeper_volume', 'High')
+
+        assert.equal(hex(thinq.outbox[0]), 'AA15F043210E8080808080808080808080008074BB')
+        const high = thinq.outbox[1].subarray(6, thinq.outbox[1].length - 2)
+        high.forEach((value, index) => assert.equal(value, index === 11 ? 0x02 : 0x80, `payload index ${index}`))
+    })
+
+    test('invalid preference values send nothing', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('clock_sync', 'not-a-press')
+        dev.setProperty('clock_format', '36-hour')
+        dev.setProperty('beeper_volume', 'Deafening')
+        assert.equal(thinq.outbox.length, 0)
+    })
+
+    test('write acknowledgements are consumed without publishing', () => {
+        const { ha, thinq } = makeDevice()
+        thinq.emit('data', buf('AA084000430060BB'))
+        assert.deepEqual(ha.devices[DEVICE_ID].properties, {})
     })
 
     test('ignores frames outside the AA..BB envelope and unexpected status lengths', () => {

--- a/tests/cloud/devices/WMVEM1825.test.ts
+++ b/tests/cloud/devices/WMVEM1825.test.ts
@@ -37,6 +37,15 @@ const SAMPLE_FAN_HIGH_LIGHT_LOW = buf(
     'AA6241EC003000015500000000000000FF030D000000000000000000000000000000C3000000004010008080808001000000003000015500000000000000FF030D000000000000000000000000000000C3000000004012008080808001000000D8BB',
 )
 
+// Status replies to the 2026-09-10 beeper writes: current record rec[35] = 0x43 (keys beep), then
+// 0x40 (muted). The hood byte rec[36] stays 0x20 (light high) in both.
+const SAMPLE_BEEPER_ON = buf(
+    'AA6241EC003000015500000000000000FF030C000000000000000000000000000000C3000000004320008080808001000000003000015500000000000000FF030D000000000000000000000000000000C3000000004320008080808001000000E5BB',
+)
+const SAMPLE_BEEPER_MUTED = buf(
+    'AA6241EC003000015500000000000000FF030D000000000000000000000000000000C3000000004320008080808001000000003000015500000000000000FF030D000000000000000000000000000000C3000000004020008080808001000000FBBB',
+)
+
 function makeDevice() {
     const ha = new MockHAConnection()
     const thinq = new MockThinq2Device(DEVICE_ID, META)
@@ -73,6 +82,8 @@ describe(MODEL_ID, () => {
             'door',
             'fan_power',
             'light_power',
+            'clock_sync',
+            'beeper',
         ])
         assert.equal(components.status.device_class, 'enum')
         assert.deepEqual(components.status.options, ['Idle', 'Cooking', 'Paused', 'Done', 'Ready to start'])
@@ -83,6 +94,12 @@ describe(MODEL_ID, () => {
         assert.equal(components.fan_power.speed_range_max, 2)
         assert.equal(components.light_power.platform, 'light')
         assert.equal(components.light_power.brightness_scale, 2)
+        assert.equal(components.clock_sync.platform, 'button')
+        assert.equal(components.clock_sync.command_topic, '$this/clock_sync/set')
+        assert.equal(components.clock_sync.state_topic, undefined)
+        assert.equal(components.beeper.platform, 'switch')
+        assert.equal(components.beeper.state_topic, '$this/beeper')
+        assert.equal(components.beeper.command_topic, '$this/beeper/set')
     })
 
     test('initial status reports idle with both hood controls off', () => {
@@ -202,6 +219,64 @@ describe(MODEL_ID, () => {
         unknown[4] = 0xff
         thinq.emit('data', unknown)
         assert.equal(ha.devices[DEVICE_ID].properties.status, 'None')
+    })
+
+    // Both frames were sent to a live MVEM1825 on 2026-09-10 and acknowledged (41 00 43 00). The
+    // first set the displayed clock to 13:05, confirmed at the panel.
+    test('clock sync reproduces the frame verified on the appliance', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.sendClock(13, 5)
+
+        assert.equal(thinq.outbox.length, 1)
+        assert.equal(hex(thinq.outbox[0]), 'AA15F043210E0D05008080808080808080FF80E7BB')
+    })
+
+    test('clock sync sends the host time and leaves every other preference unchanged', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.setProperty('clock_sync', 'PRESS')
+
+        assert.equal(thinq.outbox.length, 1)
+        const frame = thinq.outbox[0]
+        const payload = frame.subarray(6, frame.length - 2)
+        assert.equal(hex(frame.subarray(0, 6)), 'AA15F043210E')
+        assert.ok(payload[0] < 24)
+        assert.ok(payload[1] < 60)
+        assert.equal(payload[2], 0x00)
+        assert.deepEqual([...payload.subarray(3)], [...Array(8).fill(0x80), 0xff, 0x80])
+    })
+
+    // Captured 2026-09-10. Payload index 3 = 0 silenced the keys (confirmed at the panel); 1 brought
+    // them back. Nothing else in the status record moved.
+    test('beeper commands reproduce the frames verified on the appliance', () => {
+        const { thinq, dev } = makeDevice()
+
+        dev.setProperty('beeper', 'OFF')
+        dev.setProperty('beeper', 'ON')
+
+        assert.equal(thinq.outbox.length, 2)
+        assert.equal(hex(thinq.outbox[0]), 'AA15F043210E8080800080808080808080FF80F5BB')
+        assert.equal(hex(thinq.outbox[1]), 'AA15F043210E8080800180808080808080FF80F4BB')
+    })
+
+    // Live replies to the two writes above: rec[35] went 0x43 -> 0x40 on mute and back to 0x43 on
+    // un-mute. Writing 2 or 3 also read back as 0x43, so the appliance treats the setting as on/off.
+    test('beeper state decodes from the low bits of rec[35]', () => {
+        const { ha, thinq } = makeDevice()
+
+        thinq.emit('data', SAMPLE_BEEPER_ON)
+        assert.equal(ha.devices[DEVICE_ID].properties.beeper, 'ON')
+
+        thinq.emit('data', SAMPLE_BEEPER_MUTED)
+        assert.equal(ha.devices[DEVICE_ID].properties.beeper, 'OFF')
+    })
+
+    test('invalid beeper and clock payloads send nothing', () => {
+        const { thinq, dev } = makeDevice()
+        dev.setProperty('beeper', 'LOUD')
+        dev.setProperty('clock_sync', 'not-a-press')
+        assert.equal(thinq.outbox.length, 0)
     })
 
     test('unrecognised frame shapes are ignored', () => {


### PR DESCRIPTION
## Summary

Both appliances accept the same `F0 43 21` Preferences write that the WFV474PGV oven handler already uses (`0x80` = no change, index 11 = `0xFF`), with a different payload layout. This adds the controls that were verified on real hardware.

**MVEM1825 microwave (`WMVEM1825`)**
- `Sync clock` button: payload 0–2 = hour (0–23), minute, `0x00`.
- `Beeper` switch: payload **3**, not the oven's 8. `0x00` mutes and `0x01` restores. Unlike the oven, the setting **is reported back** in the low two bits of status `rec[35]` (3 while beeping, 0 once muted), so the switch has real state rather than being optimistic.

**LREL6323S range (`WLREL6323S`)**
- `Sync Clock` button and `Clock Format` select. Payload 2 is the format: `0x00` with a 0–23 hour switches the display to 24-hour, and `0x01` with a 1–12 hour switches it to 12-hour. The format travels with every clock write, and the range doesn't report it, so the select is optimistic (default 12-hour). Clock sync always re-sends the selected format, so it never flips the display by accident.
- `Beeper Volume` select (Mute / High): payload **11**, which the double oven leaves at `0xFF`. It lines up with the cooktop beeper that the LSIS6338FE reports in #165 (Mute/High only). Optimistic, because the range reports no settings (its status record was byte-identical before and after every write).
- Write acknowledgements (`40 00 43 xx`) are consumed, with a log line if a write is rejected, instead of being logged as undecoded frames.

## Hardware validation (2026-09-10)

Every write below was sent to the live appliance, acknowledged `4x 00 43 00`, and checked at the panel:

| Appliance | Frame | Observed |
| --- | --- | --- |
| Microwave | clock 13:05, byte 2 `00` | correct time shown; display stays 12-hour (the microwave has no 24-hour mode) |
| Microwave | beeper `00` / `01` | keys silent / beeping; `rec[35]` `0x43` → `0x40` → `0x43`. Writing `02` or `03` read back the same as `01` |
| Microwave | index 8 = `00` (the oven's beeper byte) | acknowledged, no effect |
| Range | clock 13:11, byte 2 `00` | display switched to 24-hour |
| Range | clock 1:13, byte 2 `01` | back to 12-hour, correct time |
| Range | index 11 = `00` | panel keys silent |
| Range | index 11 = `02` | beeps back |
| Range | index 8 = `00` | acknowledged, keys still beep, so not exposed |

The range's index 8 is probably its oven/alert beeper, as on the WFV474PGV, but I couldn't confirm that by ear, so it is left out.

## Tests

- New handler tests pin every frame above to the exact bytes sent to the appliances, plus the status replies that drive the microwave beeper state.
- `npm run check`, Prettier and all `tests/cloud` suites pass (518 → 529 tests). On my machine `tests/management/device-monitor.test.ts` hangs; this PR doesn't touch it.
